### PR TITLE
Change include name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,8 @@ message(STATUS "Version: ${PROJECT_VERSION}")
 ###############################################################################
 # Load external projects.
 ###############################################################################
-find_package(fastrtps REQUIRED)
 find_package(fastcdr REQUIRED)
+find_package(fastrtps REQUIRED)
 
 ###############################################################################
 # Test system configuration

--- a/fastdds_statistics_backend.repos
+++ b/fastdds_statistics_backend.repos
@@ -14,7 +14,7 @@ repositories:
     fastdds-statistics-backend:
         type: git
         url: https://github.com/eProsima/Fast-DDS-statistics-backend.git
-        version: main
+        version: feature/statistics/impl
     fastrtpsgen:
         type: git
         url: https://github.com/eProsima/Fast-DDS-Gen.git

--- a/fastdds_statistics_backend.repos
+++ b/fastdds_statistics_backend.repos
@@ -10,7 +10,7 @@ repositories:
     fastdds:
         type: git
         url: https://github.com/eProsima/Fast-DDS.git
-        version: feature/statistics/api
+        version: master
     fastdds-statistics-backend:
         type: git
         url: https://github.com/eProsima/Fast-DDS-statistics-backend.git

--- a/include/fastdds-statistics-backend/types/types.hpp
+++ b/include/fastdds-statistics-backend/types/types.hpp
@@ -20,7 +20,7 @@
 #ifndef _EPROSIMA_FASTDDS_STATISTICS_BACKEND_TYPES_TYPES_HPP_
 #define _EPROSIMA_FASTDDS_STATISTICS_BACKEND_TYPES_TYPES_HPP_
 
-#include <nlohmann-json/json.hpp>
+#include <fastdds-statistics-backend/nlohmann-json/json.hpp>
 #include <fastdds-statistics-backend/types/Bitmask.hpp>
 #include <fastdds-statistics-backend/types/EntityId.hpp>
 

--- a/src/cpp/database/data.hpp
+++ b/src/cpp/database/data.hpp
@@ -22,8 +22,8 @@
 
 #include "samples.hpp"
 
-#include <fastdds-statistics-backend/types/EntityId.hpp>
 #include <fastdds-statistics-backend/nlohmann-json/json.hpp>
+#include <fastdds-statistics-backend/types/EntityId.hpp>
 
 #include <chrono>
 #include <vector>

--- a/src/cpp/database/data.hpp
+++ b/src/cpp/database/data.hpp
@@ -23,7 +23,7 @@
 #include "samples.hpp"
 
 #include <fastdds-statistics-backend/types/EntityId.hpp>
-#include <nlohmann-json/json.hpp>
+#include <fastdds-statistics-backend/nlohmann-json/json.hpp>
 
 #include <chrono>
 #include <vector>


### PR DESCRIPTION
Signed-off-by: jparisu <javierparis@eprosima.com>

Compiling as external library, the json include needs to be called with `fastdds-statistics-backend` before the directory name.