### PR TITLE
[11433] Use `system_clock` instead of `steady_clock`

### DIFF
--- a/src/cpp/database/data.hpp
+++ b/src/cpp/database/data.hpp
@@ -122,7 +122,7 @@ struct DomainParticipantData : RTPSData
      * represents whether the timepoint corresponds to a discovery/update (represented as ALIVE
      * with value 1), or to a un-discovery (represented as DISPOSED with value 0).
      */
-    std::map<EntityId, std::vector<std::pair<std::chrono::steady_clock::time_point, bool>>> discovered_entity;
+    std::map<EntityId, std::vector<std::pair<std::chrono::system_clock::time_point, bool>>> discovered_entity;
 
     /*
      * Data reported by topic: eprosima::fastdds::statistics::PDP_PACKETS_TOPIC

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -606,7 +606,7 @@ void Database::insert(
             if (participant)
             {
                 const DiscoveryTimeSample& discovery_time = dynamic_cast<const DiscoveryTimeSample&>(sample);
-                participant->data.discovered_entity[discovery_time.remote_entity].push_back(std::pair<std::chrono::steady_clock::time_point,
+                participant->data.discovered_entity[discovery_time.remote_entity].push_back(std::pair<std::chrono::system_clock::time_point,
                         bool>(discovery_time.time, discovery_time.discovered));
                 break;
             }

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -184,7 +184,7 @@ void DatabaseDataQueue::process_sample_type(
         DiscoveryTimeSample& sample,
         const StatisticsDiscoveryTime& item) const
 {
-    sample.time = std::chrono::steady_clock::time_point (std::chrono::nanoseconds(item.time()));
+    sample.time = std::chrono::system_clock::time_point (std::chrono::nanoseconds(item.time()));
     std::string remote_entity_guid = deserialize_guid(item.remote_entity_guid());
     auto found_remote_entities = database_->get_entities_by_guid(entity_kind, remote_entity_guid);
     if (found_remote_entities.empty())

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -69,7 +69,7 @@ public:
     using StatisticsSampleIdentity = eprosima::fastdds::statistics::detail::SampleIdentity_s;
     using StatisticsLocator = eprosima::fastdds::statistics::detail::Locator_s;
 
-    using queue_item_type = std::pair<std::chrono::steady_clock::time_point, T>;
+    using queue_item_type = std::pair<std::chrono::system_clock::time_point, T>;
 
     DatabaseQueue()
         : foreground_queue_(&queue_alpha_)
@@ -90,7 +90,7 @@ public:
      * @param item Item to push into the queue
      */
     void push(
-            std::chrono::steady_clock::time_point ts,
+            std::chrono::system_clock::time_point ts,
             const T& item)
     {
         std::unique_lock<std::mutex> guard(background_mutex_);

--- a/src/cpp/database/samples.hpp
+++ b/src/cpp/database/samples.hpp
@@ -56,7 +56,7 @@ struct StatisticsSample
     }
 
     DataKind kind;
-    std::chrono::steady_clock::time_point src_ts;
+    std::chrono::system_clock::time_point src_ts;
 };
 
 /*
@@ -180,7 +180,7 @@ struct TimepointSample : StatisticsSample
         return !(*this == other);
     }
 
-    std::chrono::steady_clock::time_point time;
+    std::chrono::system_clock::time_point time;
 };
 
 /*

--- a/test/unittest/Database/DataTests.cpp
+++ b/test/unittest/Database/DataTests.cpp
@@ -45,8 +45,8 @@ TEST(database, domainparticipant_data_clear)
 
     // DomainParticipantData
     data.discovered_entity[EntityId(1)].push_back(
-        std::pair<std::chrono::steady_clock::time_point, bool>(
-            std::chrono::steady_clock::now(), true));
+        std::pair<std::chrono::system_clock::time_point, bool>(
+            std::chrono::system_clock::now(), true));
     data.pdp_packets.push_back(count_sample);
     data.last_reported_pdp_packets = count_sample;
     data.edp_packets.push_back(count_sample);

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -1661,7 +1661,7 @@ TEST_F(database_tests, insert_sample_history_latency)
     HistoryLatencySample sample;
     sample.reader = reader_id;
     sample.data = 12;
-    sample.src_ts = std::chrono::steady_clock::now();
+    sample.src_ts = std::chrono::system_clock::now();
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
 
     ASSERT_EQ(writer->data.history2history_latency[reader_id].size(), 1);
@@ -1950,7 +1950,7 @@ TEST_F(database_tests, insert_sample_discovery_time)
 {
     DiscoveryTimeSample sample;
     sample.remote_entity = writer_id;
-    sample.time = std::chrono::steady_clock::now();
+    sample.time = std::chrono::system_clock::now();
     sample.discovered = true;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample));
 
@@ -1963,7 +1963,7 @@ TEST_F(database_tests, insert_sample_discovery_time_wrong_entity)
 {
     DiscoveryTimeSample sample;
     sample.remote_entity = db.generate_entity_id();
-    sample.time = std::chrono::steady_clock::now();
+    sample.time = std::chrono::system_clock::now();
     sample.discovered = true;
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
 }

--- a/test/unittest/Database/SampleTests.cpp
+++ b/test/unittest/Database/SampleTests.cpp
@@ -24,43 +24,43 @@ using namespace eprosima::statistics_backend::database;
 TEST(database, statistics_sample_clear)
 {
     StatisticsSample sample(DataKind::NACKFRAG_COUNT);
-    sample.src_ts = std::chrono::steady_clock::now();
+    sample.src_ts = std::chrono::system_clock::now();
     sample.clear();
     ASSERT_EQ(sample.kind, DataKind::INVALID);
-    ASSERT_EQ(sample.src_ts, std::chrono::steady_clock::time_point());
+    ASSERT_EQ(sample.src_ts, std::chrono::system_clock::time_point());
 }
 
 TEST(database, entitydata_sample_clear)
 {
     EntityDataSample sample(DataKind::NACKFRAG_COUNT);
-    sample.src_ts = std::chrono::steady_clock::now();
+    sample.src_ts = std::chrono::system_clock::now();
     sample.data = 12.0;
     sample.clear();
     ASSERT_EQ(sample.kind, DataKind::INVALID);
-    ASSERT_EQ(sample.src_ts, std::chrono::steady_clock::time_point());
+    ASSERT_EQ(sample.src_ts, std::chrono::system_clock::time_point());
     ASSERT_EQ(sample.data, 0);
 }
 
 TEST(database, entitycount_sample_clear)
 {
     EntityCountSample sample(DataKind::NACKFRAG_COUNT);
-    sample.src_ts = std::chrono::steady_clock::now();
+    sample.src_ts = std::chrono::system_clock::now();
     sample.count = 12;
     sample.clear();
     ASSERT_EQ(sample.kind, DataKind::INVALID);
-    ASSERT_EQ(sample.src_ts, std::chrono::steady_clock::time_point());
+    ASSERT_EQ(sample.src_ts, std::chrono::system_clock::time_point());
     ASSERT_EQ(sample.count, 0);
 }
 
 TEST(database, bytecount_sample_clear)
 {
     ByteCountSample sample(DataKind::NACKFRAG_COUNT);
-    sample.src_ts = std::chrono::steady_clock::now();
+    sample.src_ts = std::chrono::system_clock::now();
     sample.count = 12;
     sample.magnitude_order = 2;
     sample.clear();
     ASSERT_EQ(sample.kind, DataKind::INVALID);
-    ASSERT_EQ(sample.src_ts, std::chrono::steady_clock::time_point());
+    ASSERT_EQ(sample.src_ts, std::chrono::system_clock::time_point());
     ASSERT_EQ(sample.count, 0);
     ASSERT_EQ(sample.magnitude_order, 0);
 }
@@ -71,7 +71,7 @@ TEST(database, statisticssample_operator_comparison)
     StatisticsSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = StatisticsSample();
@@ -85,7 +85,7 @@ TEST(database, entitydatasample_operator_comparison)
     EntityDataSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = EntityDataSample();
@@ -99,7 +99,7 @@ TEST(database, entitycountsample_operator_comparison)
     EntityCountSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = EntityCountSample();
@@ -113,7 +113,7 @@ TEST(database, bytecountsample_operator_comparison)
     ByteCountSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = ByteCountSample();
@@ -136,11 +136,11 @@ TEST(database, timepointsample_operator_comparison)
     TimepointSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = TimepointSample();
-    sample_2.time = std::chrono::steady_clock::now();
+    sample_2.time = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 }
 
@@ -150,7 +150,7 @@ TEST(database, entitytolocatorcountsample_operator_comparison)
     EntityToLocatorCountSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = EntityToLocatorCountSample();
@@ -164,7 +164,7 @@ TEST(database, bytetolocatorcountsample_operator_comparison)
     ByteToLocatorCountSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = ByteToLocatorCountSample();
@@ -178,7 +178,7 @@ TEST(database, historylatencysample_operator_comparison)
     HistoryLatencySample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = HistoryLatencySample();
@@ -192,7 +192,7 @@ TEST(database, networklatencysample_operator_comparison)
     NetworkLatencySample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = NetworkLatencySample();
@@ -206,7 +206,7 @@ TEST(database, publicationthroughputsample_operator_comparison)
     PublicationThroughputSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = PublicationThroughputSample();
@@ -220,7 +220,7 @@ TEST(database, subscriptionthroughputsample_operator_comparison)
     SubscriptionThroughputSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = SubscriptionThroughputSample();
@@ -234,7 +234,7 @@ TEST(database, rtpspacketssentsample_operator_comparison)
     RtpsPacketsSentSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = RtpsPacketsSentSample();
@@ -248,7 +248,7 @@ TEST(database, rtpsbytessentsample_operator_comparison)
     RtpsBytesSentSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = RtpsBytesSentSample();
@@ -271,7 +271,7 @@ TEST(database, rtpspacketslostsample_operator_comparison)
     RtpsPacketsLostSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = RtpsPacketsLostSample();
@@ -289,7 +289,7 @@ TEST(database, rtpsbyteslostsample_operator_comparison)
     RtpsBytesLostSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = RtpsBytesLostSample();
@@ -312,7 +312,7 @@ TEST(database, resentdatasample_operator_comparison)
     ResentDataSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = ResentDataSample();
@@ -326,7 +326,7 @@ TEST(database, heartbeatcountsample_operator_comparison)
     HeartbeatCountSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = HeartbeatCountSample();
@@ -340,7 +340,7 @@ TEST(database, acknackcountsample_operator_comparison)
     AcknackCountSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = AcknackCountSample();
@@ -354,7 +354,7 @@ TEST(database, nackfragcountsample_operator_comparison)
     NackfragCountSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = NackfragCountSample();
@@ -368,7 +368,7 @@ TEST(database, gapcountsample_operator_comparison)
     GapCountSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = GapCountSample();
@@ -382,7 +382,7 @@ TEST(database, datacountsample_operator_comparison)
     DataCountSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = DataCountSample();
@@ -396,7 +396,7 @@ TEST(database, pdpcountsample_operator_comparison)
     PdpCountSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = PdpCountSample();
@@ -410,7 +410,7 @@ TEST(database, edpcountsample_operator_comparison)
     EdpCountSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = EdpCountSample();
@@ -424,7 +424,7 @@ TEST(database, discoverytimesample_operator_comparison)
     DiscoveryTimeSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = DiscoveryTimeSample();
@@ -447,7 +447,7 @@ TEST(database, sampledatascountsample_operator_comparison)
     SampleDatasCountSample sample_2;
     ASSERT_EQ(sample_1, sample_2);
 
-    sample_2.src_ts = std::chrono::steady_clock::now();
+    sample_2.src_ts = std::chrono::system_clock::now();
     ASSERT_NE(sample_1, sample_2);
 
     sample_2 = SampleDatasCountSample();

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -210,7 +210,7 @@ public:
 TEST_F(database_queue_tests, start_stop_flush)
 {
     // Generate some data
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::shared_ptr<Host> host = std::make_shared<Host>("hostname");
     std::shared_ptr<User> user = std::make_shared<User>("username", host);
     std::shared_ptr<Process> process = std::make_shared<Process>("processname", "1", user);
@@ -272,7 +272,7 @@ TEST_F(database_queue_tests, start_stop_flush)
 
 TEST_F(database_queue_tests, push_host)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string hostname = "hostname";
 
     // Create the entity hierarchy
@@ -298,7 +298,7 @@ TEST_F(database_queue_tests, push_host)
 
 TEST_F(database_queue_tests, push_user)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string hostname = "hostname";
     std::string username = "username";
 
@@ -327,7 +327,7 @@ TEST_F(database_queue_tests, push_user)
 
 TEST_F(database_queue_tests, push_process)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string hostname = "hostname";
     std::string username = "username";
     std::string command = "command";
@@ -360,7 +360,7 @@ TEST_F(database_queue_tests, push_process)
 
 TEST_F(database_queue_tests, push_domain)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string domain_name = "domain name";
 
     // Create the domain hierarchy
@@ -387,7 +387,7 @@ TEST_F(database_queue_tests, push_domain)
 TEST_F(database_queue_tests, push_participant_process_exists)
 {
     // Create the process
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string command = "command";
     std::string pid = "1234";
 
@@ -427,7 +427,7 @@ TEST_F(database_queue_tests, push_participant_process_exists)
 TEST_F(database_queue_tests, push_participant_no_process_exists)
 {
     // Create the domain hierarchy
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string participant_name = "participant name";
     Qos participant_qos;
     std::string participant_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.0";
@@ -462,7 +462,7 @@ TEST_F(database_queue_tests, push_participant_no_process_exists)
 TEST_F(database_queue_tests, push_topic)
 {
     // Create the domain hierarchy
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string topic_name = "topic";
     std::string type_name = "type";
 
@@ -493,7 +493,7 @@ TEST_F(database_queue_tests, push_topic)
 TEST_F(database_queue_tests, push_datawriter)
 {
     // Create the domain hierarchy
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string datawriter_name = "datawriter";
     Qos datawriter_qos;
     std::string datawriter_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.1";
@@ -528,7 +528,7 @@ TEST_F(database_queue_tests, push_datawriter)
 TEST_F(database_queue_tests, push_datareader)
 {
     // Create the domain hierarchy
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string datareader_name = "datareader";
     Qos datareader_qos;
     std::string datareader_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.2";
@@ -563,7 +563,7 @@ TEST_F(database_queue_tests, push_datareader)
 TEST_F(database_queue_tests, push_locator)
 {
     // Create the domain hierarchy
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string locator_name = "locator";
 
     std::shared_ptr<Locator> locator =
@@ -588,7 +588,7 @@ TEST_F(database_queue_tests, push_locator)
 
 TEST_F(database_queue_tests, push_history_latency)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> reader_id = {0, 0, 0, 1};
@@ -656,7 +656,7 @@ TEST_F(database_queue_tests, push_history_latency)
 
 TEST_F(database_queue_tests, push_history_latency_no_reader)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> reader_id = {0, 0, 0, 1};
@@ -710,7 +710,7 @@ TEST_F(database_queue_tests, push_history_latency_no_reader)
 
 TEST_F(database_queue_tests, push_history_latency_no_writer)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> reader_id = {0, 0, 0, 1};
@@ -764,7 +764,7 @@ TEST_F(database_queue_tests, push_history_latency_no_writer)
 
 TEST_F(database_queue_tests, push_network_latency)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 16> src_locator_address = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
     uint32_t src_locator_port = 1024;
@@ -826,7 +826,7 @@ TEST_F(database_queue_tests, push_network_latency)
 
 TEST_F(database_queue_tests, push_network_latency_no_source_locator)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 16> src_locator_address = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
     uint32_t src_locator_port = 1024;
@@ -875,7 +875,7 @@ TEST_F(database_queue_tests, push_network_latency_no_source_locator)
 
 TEST_F(database_queue_tests, push_network_latency_no_destination_locator)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 16> src_locator_address = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
     uint32_t src_locator_port = 1024;
@@ -924,7 +924,7 @@ TEST_F(database_queue_tests, push_network_latency_no_destination_locator)
 
 TEST_F(database_queue_tests, push_publication_throughput)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -975,7 +975,7 @@ TEST_F(database_queue_tests, push_publication_throughput)
 
 TEST_F(database_queue_tests, push_publication_throughput_no_writer)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -1013,7 +1013,7 @@ TEST_F(database_queue_tests, push_publication_throughput_no_writer)
 
 TEST_F(database_queue_tests, push_subscription_throughput)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> reader_id = {0, 0, 0, 1};
@@ -1064,7 +1064,7 @@ TEST_F(database_queue_tests, push_subscription_throughput)
 
 TEST_F(database_queue_tests, push_subscription_throughput_no_reder)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> reader_id = {0, 0, 0, 1};
@@ -1102,7 +1102,7 @@ TEST_F(database_queue_tests, push_subscription_throughput_no_reder)
 
 TEST_F(database_queue_tests, push_rtps_sent)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -1187,7 +1187,7 @@ TEST_F(database_queue_tests, push_rtps_sent)
 
 TEST_F(database_queue_tests, push_rtps_sent_no_writer)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -1242,7 +1242,7 @@ TEST_F(database_queue_tests, push_rtps_sent_no_writer)
 
 TEST_F(database_queue_tests, push_rtps_sent_no_locator)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -1297,7 +1297,7 @@ TEST_F(database_queue_tests, push_rtps_sent_no_locator)
 
 TEST_F(database_queue_tests, push_rtps_lost)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -1382,7 +1382,7 @@ TEST_F(database_queue_tests, push_rtps_lost)
 
 TEST_F(database_queue_tests, push_rtps_lost_no_writer)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -1437,7 +1437,7 @@ TEST_F(database_queue_tests, push_rtps_lost_no_writer)
 
 TEST_F(database_queue_tests, push_rtps_lost_no_locator)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -1590,7 +1590,7 @@ TEST_F(database_queue_tests, push_rtps_bytes_no_locator)
 
 TEST_F(database_queue_tests, push_resent_datas)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -1641,7 +1641,7 @@ TEST_F(database_queue_tests, push_resent_datas)
 
 TEST_F(database_queue_tests, push_resent_datas_no_writer)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -1679,7 +1679,7 @@ TEST_F(database_queue_tests, push_resent_datas_no_writer)
 
 TEST_F(database_queue_tests, push_heartbeat_count)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -1730,7 +1730,7 @@ TEST_F(database_queue_tests, push_heartbeat_count)
 
 TEST_F(database_queue_tests, push_heartbeat_count_no_writer)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -1768,7 +1768,7 @@ TEST_F(database_queue_tests, push_heartbeat_count_no_writer)
 
 TEST_F(database_queue_tests, push_acknack_count)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> reader_id = {0, 0, 0, 1};
@@ -1819,7 +1819,7 @@ TEST_F(database_queue_tests, push_acknack_count)
 
 TEST_F(database_queue_tests, push_acknack_count_no_reader)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> reader_id = {0, 0, 0, 1};
@@ -1857,7 +1857,7 @@ TEST_F(database_queue_tests, push_acknack_count_no_reader)
 
 TEST_F(database_queue_tests, push_nackfrag_count)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> reader_id = {0, 0, 0, 1};
@@ -1908,7 +1908,7 @@ TEST_F(database_queue_tests, push_nackfrag_count)
 
 TEST_F(database_queue_tests, push_nackfrag_count_no_reader)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> reader_id = {0, 0, 0, 1};
@@ -1946,7 +1946,7 @@ TEST_F(database_queue_tests, push_nackfrag_count_no_reader)
 
 TEST_F(database_queue_tests, push_gap_count)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -1997,7 +1997,7 @@ TEST_F(database_queue_tests, push_gap_count)
 
 TEST_F(database_queue_tests, push_gap_count_no_writer)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -2035,7 +2035,7 @@ TEST_F(database_queue_tests, push_gap_count_no_writer)
 
 TEST_F(database_queue_tests, push_data_count)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -2086,7 +2086,7 @@ TEST_F(database_queue_tests, push_data_count)
 
 TEST_F(database_queue_tests, push_data_count_no_writer)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -2124,7 +2124,7 @@ TEST_F(database_queue_tests, push_data_count_no_writer)
 
 TEST_F(database_queue_tests, push_pdp_count)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> participant_id = {0, 0, 0, 0};
@@ -2175,7 +2175,7 @@ TEST_F(database_queue_tests, push_pdp_count)
 
 TEST_F(database_queue_tests, push_pdp_count_no_participant)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> participant_id = {0, 0, 0, 0};
@@ -2213,7 +2213,7 @@ TEST_F(database_queue_tests, push_pdp_count_no_participant)
 
 TEST_F(database_queue_tests, push_edp_count)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> participant_id = {0, 0, 0, 0};
@@ -2264,7 +2264,7 @@ TEST_F(database_queue_tests, push_edp_count)
 
 TEST_F(database_queue_tests, push_edp_count_no_participant)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> participant_id = {0, 0, 0, 0};
@@ -2302,7 +2302,7 @@ TEST_F(database_queue_tests, push_edp_count_no_participant)
 
 TEST_F(database_queue_tests, push_discovery_times)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> participant_id = {0, 0, 0, 0};
@@ -2310,7 +2310,7 @@ TEST_F(database_queue_tests, push_discovery_times)
     uint64_t discovery_time = 1024;
     std::string participant_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.0";
     std::string remote_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.1";
-    std::chrono::steady_clock::time_point discovery_timestamp = std::chrono::steady_clock::time_point(std::chrono::nanoseconds(
+    std::chrono::system_clock::time_point discovery_timestamp = std::chrono::system_clock::time_point(std::chrono::nanoseconds(
                         discovery_time));
 
     // Build the participant GUID
@@ -2373,7 +2373,7 @@ TEST_F(database_queue_tests, push_discovery_times)
 
 TEST_F(database_queue_tests, push_discovery_times_no_participant)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> participant_id = {0, 0, 0, 0};
@@ -2381,7 +2381,7 @@ TEST_F(database_queue_tests, push_discovery_times_no_participant)
     uint64_t discovery_time = 1024;
     std::string participant_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.0";
     std::string remote_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.1";
-    std::chrono::steady_clock::time_point discovery_timestamp (std::chrono::seconds(discovery_time));
+    std::chrono::system_clock::time_point discovery_timestamp (std::chrono::seconds(discovery_time));
 
     // Build the participant GUID
     DatabaseDataQueue::StatisticsGuidPrefix participant_prefix;
@@ -2429,7 +2429,7 @@ TEST_F(database_queue_tests, push_discovery_times_no_participant)
 
 TEST_F(database_queue_tests, push_discovery_times_no_entity)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> participant_id = {0, 0, 0, 0};
@@ -2437,7 +2437,7 @@ TEST_F(database_queue_tests, push_discovery_times_no_entity)
     uint64_t discovery_time = 1024;
     std::string participant_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.0";
     std::string remote_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.1";
-    std::chrono::steady_clock::time_point discovery_timestamp (std::chrono::seconds(discovery_time));
+    std::chrono::system_clock::time_point discovery_timestamp (std::chrono::seconds(discovery_time));
 
     // Build the participant GUID
     DatabaseDataQueue::StatisticsGuidPrefix participant_prefix;
@@ -2485,7 +2485,7 @@ TEST_F(database_queue_tests, push_discovery_times_no_entity)
 
 TEST_F(database_queue_tests, push_sample_datas)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -2547,7 +2547,7 @@ TEST_F(database_queue_tests, push_sample_datas)
 
 TEST_F(database_queue_tests, push_sample_datas_no_writer)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 12> prefix = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     std::array<uint8_t, 4> writer_id = {0, 0, 0, 2};
@@ -2596,7 +2596,7 @@ TEST_F(database_queue_tests, push_sample_datas_no_writer)
 
 TEST_F(database_queue_tests, push_physical_data_process_exists)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string processname = "command";
     std::string pid = "1234";
     std::string username = "user";
@@ -2671,7 +2671,7 @@ TEST_F(database_queue_tests, push_physical_data_process_exists)
 
 TEST_F(database_queue_tests, push_physical_data_no_participant_exists)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string processname = "command";
     std::string pid = "1234";
     std::string username = "user";
@@ -2745,7 +2745,7 @@ TEST_F(database_queue_tests, push_physical_data_no_participant_exists)
 
 TEST_F(database_queue_tests, push_physical_data_no_process_exists)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string processname = "command";
     std::string pid = "1234";
     std::string username = "user";
@@ -2830,7 +2830,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_exists)
 
 TEST_F(database_queue_tests, push_physical_data_no_process_no_user_exists)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string processname = "command";
     std::string pid = "1234";
     std::string username = "user";
@@ -2922,7 +2922,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_exists)
 
 TEST_F(database_queue_tests, push_physical_data_no_process_no_user_no_host_exists)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string processname = "command";
     std::string pid = "1234";
     std::string username = "user";
@@ -3020,7 +3020,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_no_host_exist
 
 TEST_F(database_queue_tests, push_physical_data_wrong_processname_format)
 {
-    std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
     std::string processname = "command";
     std::string pid = "1234";
     std::string username = "user";


### PR DESCRIPTION
When saving the samples to the database, `system_clock` should be used instead of `steady_clock`.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>