### PR TITLE
[11282] Database select implementation

### DIFF
--- a/include/fastdds-statistics-backend/types/types.hpp
+++ b/include/fastdds-statistics-backend/types/types.hpp
@@ -161,7 +161,7 @@ enum class EntityKind
  *     | DATA_COUNT              | DataWriter        |               | 1            |
  *     | PDP_PACKETS             | DomainParticipant |               | 1            |
  *     | EDP_PACKETS             | DomainParticipant |               | 1            |
- *     | DISCOVERED_ENTITY       | DomainParticipant | DDSEntity     | 2            |
+ *     | DISCOVERY_TIME          | DomainParticipant | DDSEntity     | 2            |
  *     | SAMPLE_DATAS            | DataWriter        |               | 1            |
  */
 enum class DataKind : int32_t

--- a/include/fastdds-statistics-backend/types/types.hpp
+++ b/include/fastdds-statistics-backend/types/types.hpp
@@ -149,10 +149,10 @@ enum class EntityKind
  *     | NETWORK_LATENCY         | Locator           | Locator       | 2            |
  *     | PUBLICATION_THROUGHPUT  | DataWriter        |               | 1            |
  *     | SUBSCRIPTION_THROUGHPUT | DataReader        |               | 1            |
- *     | RTPS_PACKETS_SENT       | DataWriter        | Locator       | 2            |
- *     | RTPS_BYTES_SENT         | DataWriter        | Locator       | 2            |
- *     | RTPS_PACKETS_LOST       | DataWriter        | Locator       | 2            |
- *     | RTPS_BYTES_LOST         | DataWriter        | Locator       | 2            |
+ *     | RTPS_PACKETS_SENT       | DomainParticipant | Locator       | 2            |
+ *     | RTPS_BYTES_SENT         | DomainParticipant | Locator       | 2            |
+ *     | RTPS_PACKETS_LOST       | DomainParticipant | Locator       | 2            |
+ *     | RTPS_BYTES_LOST         | DomainParticipant | Locator       | 2            |
  *     | RESENT_DATA             | DataWriter        |               | 1            |
  *     | HEARTBEAT_COUNT         | DataWriter        |               | 1            |
  *     | ACKNACK_COUNT           | DataReader        |               | 1            |

--- a/src/cpp/database/data.hpp
+++ b/src/cpp/database/data.hpp
@@ -126,7 +126,7 @@ struct DomainParticipantData : RTPSData
      * represents whether the timepoint corresponds to a discovery/update (represented as ALIVE
      * with value 1), or to a un-discovery (represented as DISPOSED with value 0).
      */
-    std::map<EntityId, std::vector<std::pair<std::chrono::system_clock::time_point, bool>>> discovered_entity;
+    std::map<EntityId, std::vector<DiscoveryTimeSample>> discovered_entity;
 
     /*
      * Data reported by topic: eprosima::fastdds::statistics::PDP_PACKETS_TOPIC

--- a/src/cpp/database/data.hpp
+++ b/src/cpp/database/data.hpp
@@ -278,7 +278,7 @@ struct DataWriterData
      * The key of the map corresponds to the sequence number of the change.
      * The second one is the number of DATA/DATAFRAG sub-messages sent for sending that change.
      */
-    std::map<uint64_t, uint64_t> sample_datas;
+    std::map<uint64_t, std::vector<EntityCountSample>> sample_datas;
 
     /*
      * Data reported by topic: eprosima::fastdds::statistics::HISTORY_LATENCY_TOPIC

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -668,7 +668,7 @@ void Database::insert(
             if (writer)
             {
                 const SampleDatasCountSample& sample_datas = dynamic_cast<const SampleDatasCountSample&>(sample);
-                writer->data.sample_datas[sample_datas.sequence_number] = sample_datas.count;
+                writer->data.sample_datas[sample_datas.sequence_number].push_back(sample_datas);
                 break;
             }
             throw BadParameter(std::to_string(

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1118,6 +1118,20 @@ std::vector<const StatisticsSample*> Database::select(
         }
         case DataKind::NACKFRAG_COUNT:
         {
+            assert(EntityKind::DATAREADER == entity->kind);
+            auto reader = static_cast<const DataReader*>(entity.get());
+            /* Look for the samples between the given timestamps */
+            for (auto& sample : reader->data.nackfrag_count)
+            {
+                if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                {
+                    samples.push_back(&sample);
+                }
+                else if (sample.src_ts > t_to)
+                {
+                    break;
+                }
+            }
             break;
         }
         case DataKind::GAP_COUNT:

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1234,10 +1234,6 @@ std::vector<const StatisticsSample*> Database::select(
             }
             break;
         }
-        case DataKind::SAMPLE_DATAS:
-        {
-            break;
-        }
         // Any other data_type corresponds to a sample which needs two entities or a DataKind::INVALID
         default:
         {

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1136,6 +1136,20 @@ std::vector<const StatisticsSample*> Database::select(
         }
         case DataKind::GAP_COUNT:
         {
+            assert(EntityKind::DATAWRITER == entity->kind);
+            auto writer = static_cast<const DataWriter*>(entity.get());
+            /* Look for the samples between the given timestamps */
+            for (auto& sample : writer->data.gap_count)
+            {
+                if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                {
+                    samples.push_back(&sample);
+                }
+                else if (sample.src_ts > t_to)
+                {
+                    break;
+                }
+            }
             break;
         }
         case DataKind::DATA_COUNT:

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1082,6 +1082,20 @@ std::vector<const StatisticsSample*> Database::select(
         }
         case DataKind::HEARTBEAT_COUNT:
         {
+            assert(EntityKind::DATAWRITER == entity->kind);
+            auto writer = static_cast<const DataWriter*>(entity.get());
+            /* Look for the samples between the given timestamps */
+            for (auto& sample : writer->data.heartbeat_count)
+            {
+                if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                {
+                    samples.push_back(&sample);
+                }
+                else if (sample.src_ts > t_to)
+                {
+                    break;
+                }
+            }
             break;
         }
         case DataKind::ACKNACK_COUNT:

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -981,7 +981,7 @@ std::vector<const StatisticsSample*> Database::select(
             {
                 /* Look for the samples between the given timestamps */
                 // TODO(jlbueno) Knowing that the samples are ordered by timestamp it would be more efficient to
-                // implement a binary search (PR#58 Originally posted by @IkerLuengo in 
+                // implement a binary search (PR#58 Originally posted by @IkerLuengo in
                 // https://github.com/eProsima/Fast-DDS-statistics-backend/pull/58#discussion_r629383536)
                 for (auto& sample : reader->second)
                 {
@@ -1174,7 +1174,7 @@ std::vector<const StatisticsSample*> Database::select(
             auto writer = std::static_pointer_cast<const DataWriter>(entity);
             /* Look for the samples between the given timestamps */
             // TODO(jlbueno) Knowing that the samples are ordered by timestamp it would be more efficient to
-            // implement a binary search (PR#58 Originally posted by @IkerLuengo in 
+            // implement a binary search (PR#58 Originally posted by @IkerLuengo in
             // https://github.com/eProsima/Fast-DDS-statistics-backend/pull/58#discussion_r629383536)
             for (auto& sample : writer->data.publication_throughput)
             {
@@ -1388,7 +1388,7 @@ std::vector<const StatisticsSample*> Database::select(
         {
             /* Look for the samples between the given timestamps */
             // TODO(jlbueno) Knowing that the samples are ordered by timestamp it would be more efficient to
-            // implement a binary search (PR#58 Originally posted by @IkerLuengo in 
+            // implement a binary search (PR#58 Originally posted by @IkerLuengo in
             // https://github.com/eProsima/Fast-DDS-statistics-backend/pull/58#discussion_r629383536)
             for (auto& sample : seq_number->second)
             {

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1405,6 +1405,22 @@ std::vector<const StatisticsSample*> Database::select(
     return samples;
 }
 
+std::vector<const StatisticsSample*> Database::select(
+        DataKind data_type,
+        EntityId entity_id,
+        uint64_t sequence_number,
+        Timestamp t_from,
+        Timestamp t_to)
+{
+    (void)data_type;
+    (void)entity_id;
+    (void)sequence_number;
+    (void)t_from;
+    (void)t_to;
+    throw Unsupported("Not implemented yet");
+}
+
+
 std::vector<std::pair<EntityId, EntityId>> Database::get_entities_by_guid(
         EntityKind entity_kind,
         const std::string& guid) const

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1005,6 +1005,29 @@ std::vector<const StatisticsSample*> Database::select(
         }
         case DataKind::NETWORK_LATENCY:
         {
+            assert(EntityKind::LOCATOR == source_entity->kind);
+            assert(EntityKind::LOCATOR == target_entity->kind);
+            auto locator = static_cast<const Locator*>(source_entity.get());
+            for (auto& remote_locator : locator->data.network_latency_per_locator)
+            {
+                /* Look if the locator has information about the required locator */
+                if (remote_locator.first == entity_id_target)
+                {
+                    found = true;
+                    /* Look for the samples between the given timestamps */
+                    for (auto& sample : remote_locator.second)
+                    {
+                        if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                        {
+                            samples.push_back(&sample);
+                        }
+                        else if (sample.src_ts > t_to)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
             break;
         }
         case DataKind::RTPS_PACKETS_SENT:

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1067,14 +1067,95 @@ std::vector<const StatisticsSample*> Database::select(
         }
         case DataKind::RTPS_BYTES_SENT:
         {
+            assert(EntityKind::PARTICIPANT == source_entity->kind);
+            assert(EntityKind::LOCATOR == target_entity->kind);
+            auto participant = static_cast<const DomainParticipant*>(source_entity.get());
+            for (auto& locator : participant->data.rtps_bytes_sent)
+            {
+                /* Look if the participant has information about the required locator */
+                if (locator.first == entity_id_target)
+                {
+                    found = true;
+                    /* Look for the samples between the given timestamps */
+                    for (auto& sample : locator.second)
+                    {
+                        if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                        {
+                            samples.push_back(&sample);
+                        }
+                        else if (sample.src_ts > t_to)
+                        {
+                            break;
+                        }
+                    }
+                }
+                if (found)
+                {
+                    break;
+                }
+            }
             break;
         }
         case DataKind::RTPS_PACKETS_LOST:
         {
+            assert(EntityKind::PARTICIPANT == source_entity->kind);
+            assert(EntityKind::LOCATOR == target_entity->kind);
+            auto participant = static_cast<const DomainParticipant*>(source_entity.get());
+            for (auto& locator : participant->data.rtps_packets_lost)
+            {
+                /* Look if the participant has information about the required locator */
+                if (locator.first == entity_id_target)
+                {
+                    found = true;
+                    /* Look for the samples between the given timestamps */
+                    for (auto& sample : locator.second)
+                    {
+                        if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                        {
+                            samples.push_back(&sample);
+                        }
+                        else if (sample.src_ts > t_to)
+                        {
+                            break;
+                        }
+                    }
+                }
+                if (found)
+                {
+                    break;
+                }
+            }
             break;
         }
         case DataKind::RTPS_BYTES_LOST:
         {
+            assert(EntityKind::PARTICIPANT == source_entity->kind);
+            assert(EntityKind::LOCATOR == target_entity->kind);
+            auto participant = static_cast<const DomainParticipant*>(source_entity.get());
+            for (auto& locator : participant->data.rtps_bytes_lost)
+            {
+                /* Look if the participant has information about the required locator */
+                if (locator.first == entity_id_target)
+                {
+                    found = true;
+                    /* Look for the samples between the given timestamps */
+                    for (auto& sample : locator.second)
+                    {
+                        if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                        {
+                            samples.push_back(&sample);
+                        }
+                        else if (sample.src_ts > t_to)
+                        {
+                            break;
+                        }
+                    }
+                }
+                if (found)
+                {
+                    break;
+                }
+            }
             break;
         }
         case DataKind::DISCOVERY_TIME:

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1161,7 +1161,7 @@ std::vector<const StatisticsSample*> Database::select(
         {
             assert(EntityKind::PARTICIPANT == source_entity->kind);
             assert(EntityKind::PARTICIPANT == target_entity->kind || EntityKind::DATAREADER == target_entity->kind ||
-                EntityKind::DATAWRITER == target_entity->kind);
+                    EntityKind::DATAWRITER == target_entity->kind);
             auto participant = static_cast<const DomainParticipant*>(source_entity.get());
             for (auto& dds_entity : participant->data.discovered_entity)
             {
@@ -1458,7 +1458,6 @@ std::vector<const StatisticsSample*> Database::select(
     }
     return samples;
 }
-
 
 std::vector<std::pair<EntityId, EntityId>> Database::get_entities_by_guid(
         EntityKind entity_kind,

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1027,11 +1027,42 @@ std::vector<const StatisticsSample*> Database::select(
                         }
                     }
                 }
+                if (found)
+                {
+                    break;
+                }
             }
             break;
         }
         case DataKind::RTPS_PACKETS_SENT:
         {
+            assert(EntityKind::PARTICIPANT == source_entity->kind);
+            assert(EntityKind::LOCATOR == target_entity->kind);
+            auto participant = static_cast<const DomainParticipant*>(source_entity.get());
+            for (auto& locator : participant->data.rtps_packets_sent)
+            {
+                /* Look if the participant has information about the required locator */
+                if (locator.first == entity_id_target)
+                {
+                    found = true;
+                    /* Look for the samples between the given timestamps */
+                    for (auto& sample : locator.second)
+                    {
+                        if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                        {
+                            samples.push_back(&sample);
+                        }
+                        else if (sample.src_ts > t_to)
+                        {
+                            break;
+                        }
+                    }
+                }
+                if (found)
+                {
+                    break;
+                }
+            }
             break;
         }
         case DataKind::RTPS_BYTES_SENT:

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1190,6 +1190,20 @@ std::vector<const StatisticsSample*> Database::select(
         }
         case DataKind::EDP_PACKETS:
         {
+            assert(EntityKind::PARTICIPANT == entity->kind);
+            auto participant = static_cast<const DomainParticipant*>(entity.get());
+            /* Look for the samples between the given timestamps */
+            for (auto& sample : participant->data.edp_packets)
+            {
+                if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                {
+                    samples.push_back(&sample);
+                }
+                else if (sample.src_ts > t_to)
+                {
+                    break;
+                }
+            }
             break;
         }
         case DataKind::SAMPLE_DATAS:

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1002,6 +1002,24 @@ std::vector<const StatisticsSample*> Database::select(
             }
             break;
         }
+        case DataKind::SUBSCRIPTION_THROUGHPUT:
+        {
+            assert(EntityKind::DATAREADER == entity->kind);
+            auto reader = static_cast<const DataReader*>(entity.get());
+            /* Look for the samples between the given timestamps */
+            for (auto& sample : reader->data.subscription_throughput)
+            {
+                if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                {
+                    samples.push_back(&sample);
+                }
+                else if (sample.src_ts > t_to)
+                {
+                    break;
+                }
+            }
+            break;
+        }
         // Any other data_type corresponds to a sample which needs two entities or a DataKind::INVALID
         default:
         {

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1154,6 +1154,20 @@ std::vector<const StatisticsSample*> Database::select(
         }
         case DataKind::DATA_COUNT:
         {
+            assert(EntityKind::DATAWRITER == entity->kind);
+            auto writer = static_cast<const DataWriter*>(entity.get());
+            /* Look for the samples between the given timestamps */
+            for (auto& sample : writer->data.data_count)
+            {
+                if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                {
+                    samples.push_back(&sample);
+                }
+                else if (sample.src_ts > t_to)
+                {
+                    break;
+                }
+            }
             break;
         }
         case DataKind::PDP_PACKETS:

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1172,6 +1172,20 @@ std::vector<const StatisticsSample*> Database::select(
         }
         case DataKind::PDP_PACKETS:
         {
+            assert(EntityKind::PARTICIPANT == entity->kind);
+            auto participant = static_cast<const DomainParticipant*>(entity.get());
+            /* Look for the samples between the given timestamps */
+            for (auto& sample : participant->data.pdp_packets)
+            {
+                if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                {
+                    samples.push_back(&sample);
+                }
+                else if (sample.src_ts > t_to)
+                {
+                    break;
+                }
+            }
             break;
         }
         case DataKind::EDP_PACKETS:

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -949,6 +949,34 @@ std::vector<std::pair<EntityId, EntityId>> Database::get_entities_by_name(
     return entities;
 }
 
+std::vector<const StatisticsSample*> Database::select(
+        DataKind data_type,
+        EntityId entity_id_source,
+        EntityId entity_id_target,
+        Timestamp t_from,
+        Timestamp t_to)
+{
+    (void)data_type;
+    (void)entity_id_source;
+    (void)entity_id_target;
+    (void)t_from;
+    (void)t_to;
+    throw Unsupported("Not implemented yet");
+}
+
+std::vector<const StatisticsSample*> Database::select(
+        DataKind data_type,
+        EntityId entity_id,
+        Timestamp t_from,
+        Timestamp t_to)
+{
+    (void)data_type;
+    (void)entity_id;
+    (void)t_from;
+    (void)t_to;
+    throw Unsupported("Not implemented yet");
+}
+
 std::vector<std::pair<EntityId, EntityId>> Database::get_entities_by_guid(
         EntityKind entity_kind,
         const std::string& guid) const

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1020,6 +1020,56 @@ std::vector<const StatisticsSample*> Database::select(
             }
             break;
         }
+        case DataKind::RESENT_DATA:
+        {
+            assert(EntityKind::DATAWRITER == entity->kind);
+            auto writer = static_cast<const DataWriter*>(entity.get());
+            /* Look for the samples between the given timestamps */
+            for (auto& sample : writer->data.resent_datas)
+            {
+                if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                {
+                    samples.push_back(&sample);
+                }
+                else if (sample.src_ts > t_to)
+                {
+                    break;
+                }
+            }
+            break;
+        }
+        case DataKind::HEARTBEAT_COUNT:
+        {
+            break;
+        }
+        case DataKind::ACKNACK_COUNT:
+        {
+            break;
+        }
+        case DataKind::NACKFRAG_COUNT:
+        {
+            break;
+        }
+        case DataKind::GAP_COUNT:
+        {
+            break;
+        }
+        case DataKind::DATA_COUNT:
+        {
+            break;
+        }
+        case DataKind::PDP_PACKETS:
+        {
+            break;
+        }
+        case DataKind::EDP_PACKETS:
+        {
+            break;
+        }
+        case DataKind::SAMPLE_DATAS:
+        {
+            break;
+        }
         // Any other data_type corresponds to a sample which needs two entities or a DataKind::INVALID
         default:
         {

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1100,6 +1100,20 @@ std::vector<const StatisticsSample*> Database::select(
         }
         case DataKind::ACKNACK_COUNT:
         {
+            assert(EntityKind::DATAREADER == entity->kind);
+            auto reader = static_cast<const DataReader*>(entity.get());
+            /* Look for the samples between the given timestamps */
+            for (auto& sample : reader->data.acknack_count)
+            {
+                if (sample.src_ts >= t_from && sample.src_ts <= t_to)
+                {
+                    samples.push_back(&sample);
+                }
+                else if (sample.src_ts > t_to)
+                {
+                    break;
+                }
+            }
             break;
         }
         case DataKind::NACKFRAG_COUNT:

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -19,6 +19,7 @@
 #include <mutex>  // For std::unique_lock
 #include <shared_mutex>
 #include <string>
+#include <vector>
 
 #include <fastdds-statistics-backend/exception/Exception.hpp>
 #include <fastdds-statistics-backend/types/types.hpp>
@@ -957,12 +958,53 @@ std::vector<const StatisticsSample*> Database::select(
         Timestamp t_from,
         Timestamp t_to)
 {
-    (void)data_type;
-    (void)entity_id_source;
-    (void)entity_id_target;
-    (void)t_from;
-    (void)t_to;
-    throw Unsupported("Not implemented yet");
+    /* Check that the given timestamps are consistent */
+    if (t_to <= t_from)
+    {
+        throw BadParameter("Final timestamp must be strictly greater than the origin timestamp");
+    }
+
+    auto source_entity = get_entity(entity_id_source);
+    auto target_entity = get_entity(entity_id_target);
+
+    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+    std::vector<const StatisticsSample*> samples;
+    switch (data_type)
+    {
+        case DataKind::FASTDDS_LATENCY:
+        {
+            break;
+        }
+        case DataKind::NETWORK_LATENCY:
+        {
+            break;
+        }
+        case DataKind::RTPS_PACKETS_SENT:
+        {
+            break;
+        }
+        case DataKind::RTPS_BYTES_SENT:
+        {
+            break;
+        }
+        case DataKind::RTPS_PACKETS_LOST:
+        {
+            break;
+        }
+        case DataKind::RTPS_BYTES_LOST:
+        {
+            break;
+        }
+        case DataKind::DISCOVERY_TIME:
+        {
+            break;
+        }
+        default:
+        {
+            throw BadParameter("Incorrect DataKind");
+        }
+    }
+    return samples;
 }
 
 std::vector<const StatisticsSample*> Database::select(

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -104,6 +104,9 @@ public:
      *
      * For data types that relate to a single entity,
      * use the overloaded function that takes a single entity as argument.
+     * 
+     * For SAMPLE_DATAS DataKind,
+     * use the overloaded function that takes sequence numbers as arguments.
      *
      * \par Measurement time and intervals
      *
@@ -119,7 +122,6 @@ public:
      * @throws eprosima::statistics_backend::BadParameter when the parameters are not consistent:
      * 1. t_from must be less than t_to
      * 2. data_type must be of a type that relates to two entities.
-     * 3. entity_id_source and entity_id_target must coincide with the ones expected by data_type
      * @return A vector of pointers to StatisticSamples.
      */
     std::vector<const StatisticsSample*> select(
@@ -135,9 +137,12 @@ public:
      * Use this function for data types that relate to two entities,
      * as described in DataType.
      *
-     * For data types that relate to a single entity,
-     * use the overloaded function that takes a single entity as argument.
+     * For data types that relate to two entities,
+     * use the overloaded function that takes two entities as arguments.
      *
+     * For SAMPLE_DATAS DataKind,
+     * use the overloaded function that takes sequence numbers as arguments.
+
      * \par Measurement time and intervals
      *
      * \c t_from and \c t_to define the time interval for which the measurements will be returned.
@@ -150,13 +155,46 @@ public:
      * @param t_to Ending time of the returned measures.
      * @throws eprosima::statistics_backend::BadParameter when the parameters are not consistent:
      * 1. t_from must be less than t_to
-     * 2. data_type must be of a type that relates to a single entity.
-     * 3. entity_id must coincide with the EntityId expected by the given DataKind
+     * 2. data_type must be of a type that relates to a single entity except SAMPLE_DATAS.
      * @return A vector of pointers to StatisticSamples.
      */
     std::vector<const StatisticsSample*> select(
             DataKind data_type,
             EntityId entity_id,
+            Timestamp t_from,
+            Timestamp t_to);
+
+    /**
+     * @brief Select data from the database.
+     *
+     * Use this function only for SAMPLE_DATAS DataKind as described in DataType.
+     *
+     * For data types that relate to a single entity,
+     * use the overloaded function that takes a single entity as argument.
+     * 
+     * For data types that relate to two entities,
+     * use the overloaded function that takes two entities as arguments.
+     *
+     * \par Measurement time and intervals
+     *
+     * \c t_from and \c t_to define the time interval for which the measurements will be returned.
+     *
+     * \sa Database
+     *
+     * @param data_type The type of the measurement being requested
+     * @param entity_id Id of entity of the requested data
+     * @param sequence_number Sequence number of the requested sample
+     * @param t_from Starting time of the returned measures.
+     * @param t_to Ending time of the returned measures.
+     * @throws eprosima::statistics_backend::BadParameter when the parameters are not consistent:
+     * 1. t_from must be less than t_to
+     * 2. data_type must be of a SAMPLE_DATAS type.
+     * @return A vector of pointers to StatisticSamples.
+     */
+    std::vector<const StatisticsSample*> select(
+            DataKind data_type,
+            EntityId entity_id,
+            uint64_t sequence_number,
             Timestamp t_from,
             Timestamp t_to);
 

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -169,7 +169,7 @@ public:
      *
      * Use this function only for SAMPLE_DATAS DataKind as described in DataType.
      *
-     * For data types that relate to a single entity,
+     * For other data types that relate to a single entity,
      * use the overloaded function that takes a single entity as argument.
      *
      * For data types that relate to two entities,

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -104,7 +104,7 @@ public:
      *
      * For data types that relate to a single entity,
      * use the overloaded function that takes a single entity as argument.
-     * 
+     *
      * For SAMPLE_DATAS DataKind,
      * use the overloaded function that takes sequence numbers as arguments.
      *
@@ -171,7 +171,7 @@ public:
      *
      * For data types that relate to a single entity,
      * use the overloaded function that takes a single entity as argument.
-     * 
+     *
      * For data types that relate to two entities,
      * use the overloaded function that takes two entities as arguments.
      *

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -116,6 +116,10 @@ public:
      * @param entity_id_target Id of the target entity of the requested data
      * @param t_from Starting time of the returned measures.
      * @param t_to Ending time of the returned measures.
+     * @throws eprosima::statistics_backend::BadParameter when the parameters are not consistent:
+     * 1. t_from must be less than t_to
+     * 2. data_type must be of a type that relates to two entities.
+     * 3. entity_id_source and entity_id_target must coincide with the ones expected by data_type
      * @return A vector of pointers to StatisticSamples.
      */
     std::vector<const StatisticsSample*> select(
@@ -144,6 +148,10 @@ public:
      * @param entity_id Id of entity of the requested data
      * @param t_from Starting time of the returned measures.
      * @param t_to Ending time of the returned measures.
+     * @throws eprosima::statistics_backend::BadParameter when the parameters are not consistent:
+     * 1. t_from must be less than t_to
+     * 2. data_type must be of a type that relates to a single entity.
+     * 3. entity_id must coincide with the EntityId expected by the given DataKind
      * @return A vector of pointers to StatisticSamples.
      */
     std::vector<const StatisticsSample*> select(

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -252,6 +252,7 @@ set(DATABASE_TEST_LIST
     select_single_entity_invalid_needs_two_entities
     select_double_entity_invalid_needs_one_entity
     select_sample_datas_invalid_wrong_entity
+    select_invalid_entities
     select_invalid_timestamps
     select_fastdds_latency
     select_network_latency

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -261,6 +261,16 @@ set(DATABASE_TEST_LIST
     select_rtps_bytes_sent
     select_rtps_packets_lost
     select_rtps_bytes_lost
+    select_resent_data
+    select_heartbeat_count
+    select_acknack_count
+    select_nackfrag_count
+    select_gap_count
+    select_data_count
+    select_pdp_packets
+    select_edp_packets
+    select_discovery_time
+    select_sample_datas
 )
 
 foreach(test_name ${DATABASE_TEST_LIST})

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -254,6 +254,7 @@ set(DATABASE_TEST_LIST
     select_invalid_timestamps
     select_invalid_entity_ids
     select_fastdds_latency
+    select_network_latency
 )
 
 foreach(test_name ${DATABASE_TEST_LIST})

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -252,6 +252,7 @@ set(DATABASE_TEST_LIST
     select_single_entity_invalid_needs_two_entities
     select_double_entity_invalid_needs_one_entity
     select_invalid_timestamps
+    select_invalid_entity_ids
 )
 
 foreach(test_name ${DATABASE_TEST_LIST})

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -251,6 +251,7 @@ set(DATABASE_TEST_LIST
     # select
     select_single_entity_invalid_needs_two_entities
     select_double_entity_invalid_needs_one_entity
+    select_sample_datas_invalid_wrong_entity
     select_invalid_timestamps
     select_fastdds_latency
     select_network_latency
@@ -269,7 +270,7 @@ set(DATABASE_TEST_LIST
     select_pdp_packets
     select_edp_packets
     select_discovery_time
-#    select_sample_datas
+    select_sample_datas
 )
 
 foreach(test_name ${DATABASE_TEST_LIST})

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -253,6 +253,7 @@ set(DATABASE_TEST_LIST
     select_double_entity_invalid_needs_one_entity
     select_invalid_timestamps
     select_invalid_entity_ids
+    select_fastdds_latency
 )
 
 foreach(test_name ${DATABASE_TEST_LIST})

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -253,6 +253,7 @@ set(DATABASE_TEST_LIST
     select_double_entity_invalid_needs_one_entity
     select_sample_datas_invalid_wrong_entity
     select_invalid_entities
+    select_invalid_entity_id
     select_invalid_timestamps
     select_fastdds_latency
     select_network_latency

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -257,6 +257,10 @@ set(DATABASE_TEST_LIST
     select_network_latency
     select_publication_throughput
     select_subscription_throughput
+    select_rtps_packets_sent
+    select_rtps_bytes_sent
+    select_rtps_packets_lost
+    select_rtps_bytes_lost
 )
 
 foreach(test_name ${DATABASE_TEST_LIST})

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -255,6 +255,8 @@ set(DATABASE_TEST_LIST
     select_invalid_entity_ids
     select_fastdds_latency
     select_network_latency
+    select_publication_throughput
+    select_subscription_throughput
 )
 
 foreach(test_name ${DATABASE_TEST_LIST})

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -269,7 +269,7 @@ set(DATABASE_TEST_LIST
     select_pdp_packets
     select_edp_packets
     select_discovery_time
-    select_sample_datas
+#    select_sample_datas
 )
 
 foreach(test_name ${DATABASE_TEST_LIST})

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -248,6 +248,10 @@ set(DATABASE_TEST_LIST
     get_entities_by_name_other_kind
     # get_entity_kind
     get_entity_kind
+    # select
+    select_single_entity_invalid_needs_two_entities
+    select_double_entity_invalid_needs_one_entity
+    select_invalid_timestamps
 )
 
 foreach(test_name ${DATABASE_TEST_LIST})

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -252,7 +252,6 @@ set(DATABASE_TEST_LIST
     select_single_entity_invalid_needs_two_entities
     select_double_entity_invalid_needs_one_entity
     select_invalid_timestamps
-    select_invalid_entity_ids
     select_fastdds_latency
     select_network_latency
     select_publication_throughput

--- a/test/unittest/Database/DataTests.cpp
+++ b/test/unittest/Database/DataTests.cpp
@@ -114,7 +114,7 @@ TEST(database, datawriter_data_clear)
     data.last_reported_gap_count = count_sample;
     data.data_count.push_back(count_sample);
     data.last_reported_data_count = count_sample;
-    data.sample_datas[1] = 12;
+    data.sample_datas[1].push_back(count_sample);
     data.history2history_latency[EntityId(1)].push_back(data_sample);
 
     /* Check that data in cleared */

--- a/test/unittest/Database/DataTests.cpp
+++ b/test/unittest/Database/DataTests.cpp
@@ -32,6 +32,9 @@ TEST(database, domainparticipant_data_clear)
     ByteCountSample byte_sample;
     byte_sample.count = 13;
     byte_sample.magnitude_order = 2;
+    DiscoveryTimeSample time_sample;
+    time_sample.discovered = true;
+    time_sample.time = std::chrono::system_clock::now();
 
     // RTPSData
     data.rtps_packets_sent[EntityId(2)].push_back(count_sample);
@@ -44,9 +47,7 @@ TEST(database, domainparticipant_data_clear)
     data.last_reported_rtps_bytes_lost_count[EntityId(5)] = byte_sample;
 
     // DomainParticipantData
-    data.discovered_entity[EntityId(1)].push_back(
-        std::pair<std::chrono::system_clock::time_point, bool>(
-            std::chrono::system_clock::now(), true));
+    data.discovered_entity[EntityId(1)].push_back(time_sample);
     data.pdp_packets.push_back(count_sample);
     data.last_reported_pdp_packets = count_sample;
     data.edp_packets.push_back(count_sample);

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -617,6 +617,15 @@ public:
     std::string reader_name = "test_reader";
     std::shared_ptr<DataReader> reader;
     EntityId reader_id;
+
+    Timestamp src_ts = std::chrono::system_clock::now();
+    Timestamp mid1_ts = src_ts + std::chrono::seconds(1) - std::chrono::nanoseconds(1);
+    Timestamp sample1_ts = src_ts + std::chrono::seconds(1);
+    Timestamp mid2_ts = src_ts + std::chrono::seconds(1) + std::chrono::nanoseconds(1);
+    Timestamp mid3_ts = src_ts + std::chrono::seconds(5) - std::chrono::nanoseconds(1);
+    Timestamp sample2_ts = src_ts + std::chrono::seconds(5);
+    Timestamp sample3_ts = src_ts + std::chrono::seconds(11);
+    Timestamp end_ts = src_ts + std::chrono::seconds(15);
 };
 
 TEST_F(database_tests, insert_host)
@@ -2866,15 +2875,6 @@ TEST_F(database_tests, select_invalid_entity_ids)
 
 TEST_F(database_tests, select_fastdds_latency)
 {
-    Timestamp src_ts = std::chrono::system_clock::now();
-    Timestamp mid1_ts = src_ts + std::chrono::seconds(1) - std::chrono::nanoseconds(1);
-    Timestamp sample1_ts = src_ts + std::chrono::seconds(1);
-    Timestamp mid2_ts = src_ts + std::chrono::seconds(1) + std::chrono::nanoseconds(1);
-    Timestamp mid3_ts = src_ts + std::chrono::seconds(5) - std::chrono::nanoseconds(1);
-    Timestamp sample2_ts = src_ts + std::chrono::seconds(5);
-    Timestamp sample3_ts = src_ts + std::chrono::seconds(11);
-    Timestamp end_ts = src_ts + std::chrono::seconds(15);
-
     std::vector<const StatisticsSample*> output;
     ASSERT_NO_THROW(output = db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, src_ts, end_ts));
     EXPECT_EQ(output.size(), 0u);

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2725,7 +2725,6 @@ TEST_F(database_tests, select_fastdds_latency)
 TEST_F(database_tests, select_network_latency)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
@@ -2734,19 +2733,54 @@ TEST_F(database_tests, select_network_latency)
     sample_1.remote_locator = reader_locator->id;
     sample_1.data = 15;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample_1));
     NetworkLatencySample sample_2;
     sample_2.remote_locator = reader_locator->id;
     sample_2.data = 5;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample_2));
     NetworkLatencySample sample_3;
     sample_3.remote_locator = reader_locator->id;
     sample_3.data = 25;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample_3));
 
-    select_test(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
+        end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityDataSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityDataSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityDataSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
+        mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, mid1_ts,
+        mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityDataSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, mid2_ts,
+        mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id,
+        sample2_ts, sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityDataSample*>(data_output[0]);
+    sample2 = static_cast<const EntityDataSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, reader_locator->id, writer_locator->id, src_ts,

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -3128,8 +3128,8 @@ TEST_F(database_tests, select_rtps_packets_sent)
     sample_3.count = 70;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes rtps packets sent
-    // rtps packets sent stores the difference between each accumulated report and the previous one
+    EntityCountSample db_sample_2 = sample_2 - sample_1;
+    EntityCountSample db_sample_3 = sample_3 - sample_2;
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, src_ts,
@@ -3139,8 +3139,8 @@ TEST_F(database_tests, select_rtps_packets_sent)
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
     EXPECT_EQ(*sample1, sample_1);
-    EXPECT_EQ(*sample2, sample_2);
-    EXPECT_EQ(*sample3, sample_3);
+    EXPECT_EQ(*sample2, db_sample_2);
+    EXPECT_EQ(*sample3, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, src_ts,
@@ -3165,8 +3165,8 @@ TEST_F(database_tests, select_rtps_packets_sent)
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
-    EXPECT_EQ(*sample1, sample_2);
-    EXPECT_EQ(*sample2, sample_3);
+    EXPECT_EQ(*sample1, db_sample_2);
+    EXPECT_EQ(*sample2, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_locator->id, src_ts,
@@ -3199,8 +3199,8 @@ TEST_F(database_tests, select_rtps_bytes_sent)
     sample_3.magnitude_order = 3;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes rtps bytes sent
-    // rtps bytes sent stores the difference between each accumulated report and the previous one
+    ByteCountSample db_sample_2 = sample_2 - sample_1;
+    ByteCountSample db_sample_3 = sample_3 - sample_2;
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, src_ts,
@@ -3210,8 +3210,8 @@ TEST_F(database_tests, select_rtps_bytes_sent)
     auto sample2 = static_cast<const ByteCountSample*>(data_output[1]);
     auto sample3 = static_cast<const ByteCountSample*>(data_output[2]);
     EXPECT_EQ(*sample1, sample_1);
-    EXPECT_EQ(*sample2, sample_2);
-    EXPECT_EQ(*sample3, sample_3);
+    EXPECT_EQ(*sample2, db_sample_2);
+    EXPECT_EQ(*sample3, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, src_ts,
@@ -3236,8 +3236,8 @@ TEST_F(database_tests, select_rtps_bytes_sent)
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     sample2 = static_cast<const ByteCountSample*>(data_output[1]);
-    EXPECT_EQ(*sample1, sample_2);
-    EXPECT_EQ(*sample2, sample_3);
+    EXPECT_EQ(*sample1, db_sample_2);
+    EXPECT_EQ(*sample2, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_locator->id, src_ts,
@@ -3259,16 +3259,16 @@ TEST_F(database_tests, select_rtps_packets_lost)
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_1));
     RtpsPacketsLostSample sample_2;
     sample_2.remote_locator = writer_locator->id;
-    sample_2.count = 5;
+    sample_2.count = 25;
     sample_2.src_ts = sample2_ts;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
     RtpsPacketsLostSample sample_3;
     sample_3.remote_locator = writer_locator->id;
-    sample_3.count = 25;
+    sample_3.count = 65;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes rtps packets lost
-    // rtps packets lost stores the difference between each accumulated report and the previous one
+    EntityCountSample db_sample_2 = sample_2 - sample_1;
+    EntityCountSample db_sample_3 = sample_3 - sample_2;
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, src_ts,
@@ -3278,8 +3278,8 @@ TEST_F(database_tests, select_rtps_packets_lost)
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
     EXPECT_EQ(*sample1, sample_1);
-    EXPECT_EQ(*sample2, sample_2);
-    EXPECT_EQ(*sample3, sample_3);
+    EXPECT_EQ(*sample2, db_sample_2);
+    EXPECT_EQ(*sample3, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, src_ts,
@@ -3304,8 +3304,8 @@ TEST_F(database_tests, select_rtps_packets_lost)
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
-    EXPECT_EQ(*sample1, sample_2);
-    EXPECT_EQ(*sample2, sample_3);
+    EXPECT_EQ(*sample1, db_sample_2);
+    EXPECT_EQ(*sample2, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_locator->id, src_ts,
@@ -3338,8 +3338,8 @@ TEST_F(database_tests, select_rtps_bytes_lost)
     sample_3.magnitude_order = 3;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes rtps bytes lost
-    // rtps bytes lost stores the difference between each accumulated report and the previous one
+    ByteCountSample db_sample_2 = sample_2 - sample_1;
+    ByteCountSample db_sample_3 = sample_3 - sample_2;
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, src_ts,
@@ -3349,8 +3349,8 @@ TEST_F(database_tests, select_rtps_bytes_lost)
     auto sample2 = static_cast<const ByteCountSample*>(data_output[1]);
     auto sample3 = static_cast<const ByteCountSample*>(data_output[2]);
     EXPECT_EQ(*sample1, sample_1);
-    EXPECT_EQ(*sample2, sample_2);
-    EXPECT_EQ(*sample3, sample_3);
+    EXPECT_EQ(*sample2, db_sample_2);
+    EXPECT_EQ(*sample3, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, src_ts,
@@ -3375,8 +3375,8 @@ TEST_F(database_tests, select_rtps_bytes_lost)
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     sample2 = static_cast<const ByteCountSample*>(data_output[1]);
-    EXPECT_EQ(*sample1, sample_2);
-    EXPECT_EQ(*sample2, sample_3);
+    EXPECT_EQ(*sample1, db_sample_2);
+    EXPECT_EQ(*sample2, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_locator->id, src_ts,
@@ -3402,8 +3402,8 @@ TEST_F(database_tests, select_resent_data)
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes resent datas
-    // resent datas stores the difference between each accumulated report and the previous one
+    EntityCountSample db_sample_2 = sample_2 - sample_1;
+    EntityCountSample db_sample_3 = sample_3 - sample_2;
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RESENT_DATA, writer_id, src_ts, end_ts));
@@ -3412,8 +3412,8 @@ TEST_F(database_tests, select_resent_data)
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
     EXPECT_EQ(*sample1, sample_1);
-    EXPECT_EQ(*sample2, sample_2);
-    EXPECT_EQ(*sample3, sample_3);
+    EXPECT_EQ(*sample2, db_sample_2);
+    EXPECT_EQ(*sample3, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RESENT_DATA, writer_id, src_ts, mid1_ts));
@@ -3434,8 +3434,8 @@ TEST_F(database_tests, select_resent_data)
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
-    EXPECT_EQ(*sample1, sample_2);
-    EXPECT_EQ(*sample2, sample_3);
+    EXPECT_EQ(*sample1, db_sample_2);
+    EXPECT_EQ(*sample2, db_sample_3);
 }
 
 TEST_F(database_tests, select_heartbeat_count)
@@ -3456,8 +3456,8 @@ TEST_F(database_tests, select_heartbeat_count)
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes heartbeat count
-    // heartbeat count stores the difference between each accumulated report and the previous one
+    EntityCountSample db_sample_2 = sample_2 - sample_1;
+    EntityCountSample db_sample_3 = sample_3 - sample_2;
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::HEARTBEAT_COUNT, writer_id, src_ts, end_ts));
@@ -3466,8 +3466,8 @@ TEST_F(database_tests, select_heartbeat_count)
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
     EXPECT_EQ(*sample1, sample_1);
-    EXPECT_EQ(*sample2, sample_2);
-    EXPECT_EQ(*sample3, sample_3);
+    EXPECT_EQ(*sample2, db_sample_2);
+    EXPECT_EQ(*sample3, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::HEARTBEAT_COUNT, writer_id, src_ts, mid1_ts));
@@ -3488,8 +3488,8 @@ TEST_F(database_tests, select_heartbeat_count)
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
-    EXPECT_EQ(*sample1, sample_2);
-    EXPECT_EQ(*sample2, sample_3);
+    EXPECT_EQ(*sample1, db_sample_2);
+    EXPECT_EQ(*sample2, db_sample_3);
 }
 
 TEST_F(database_tests, select_acknack_count)
@@ -3510,8 +3510,8 @@ TEST_F(database_tests, select_acknack_count)
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes acknack count
-    //acknack count stores the difference between each accumulated report and the previous one
+    EntityCountSample db_sample_2 = sample_2 - sample_1;
+    EntityCountSample db_sample_3 = sample_3 - sample_2;
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::ACKNACK_COUNT, reader_id, src_ts, end_ts));
@@ -3520,8 +3520,8 @@ TEST_F(database_tests, select_acknack_count)
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
     EXPECT_EQ(*sample1, sample_1);
-    EXPECT_EQ(*sample2, sample_2);
-    EXPECT_EQ(*sample3, sample_3);
+    EXPECT_EQ(*sample2, db_sample_2);
+    EXPECT_EQ(*sample3, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::ACKNACK_COUNT, reader_id, src_ts, mid1_ts));
@@ -3542,8 +3542,8 @@ TEST_F(database_tests, select_acknack_count)
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
-    EXPECT_EQ(*sample1, sample_2);
-    EXPECT_EQ(*sample2, sample_3);
+    EXPECT_EQ(*sample1, db_sample_2);
+    EXPECT_EQ(*sample2, db_sample_3);
 }
 
 TEST_F(database_tests, select_nackfrag_count)
@@ -3564,8 +3564,8 @@ TEST_F(database_tests, select_nackfrag_count)
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes nackfrag count
-    // nackfrag count stores the difference between each accumulated report and the previous one
+    EntityCountSample db_sample_2 = sample_2 - sample_1;
+    EntityCountSample db_sample_3 = sample_3 - sample_2;
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NACKFRAG_COUNT, reader_id, src_ts, end_ts));
@@ -3574,8 +3574,8 @@ TEST_F(database_tests, select_nackfrag_count)
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
     EXPECT_EQ(*sample1, sample_1);
-    EXPECT_EQ(*sample2, sample_2);
-    EXPECT_EQ(*sample3, sample_3);
+    EXPECT_EQ(*sample2, db_sample_2);
+    EXPECT_EQ(*sample3, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NACKFRAG_COUNT, reader_id, src_ts, mid1_ts));
@@ -3596,8 +3596,8 @@ TEST_F(database_tests, select_nackfrag_count)
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
-    EXPECT_EQ(*sample1, sample_2);
-    EXPECT_EQ(*sample2, sample_3);
+    EXPECT_EQ(*sample1, db_sample_2);
+    EXPECT_EQ(*sample2, db_sample_3);
 }
 
 TEST_F(database_tests, select_gap_count)
@@ -3618,8 +3618,8 @@ TEST_F(database_tests, select_gap_count)
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes gap count
-    // gap count stores the difference between each accumulated report and the previous one
+    EntityCountSample db_sample_2 = sample_2 - sample_1;
+    EntityCountSample db_sample_3 = sample_3 - sample_2;
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::GAP_COUNT, writer_id, src_ts, end_ts));
@@ -3628,8 +3628,8 @@ TEST_F(database_tests, select_gap_count)
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
     EXPECT_EQ(*sample1, sample_1);
-    EXPECT_EQ(*sample2, sample_2);
-    EXPECT_EQ(*sample3, sample_3);
+    EXPECT_EQ(*sample2, db_sample_2);
+    EXPECT_EQ(*sample3, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::GAP_COUNT, writer_id, src_ts, mid1_ts));
@@ -3650,8 +3650,8 @@ TEST_F(database_tests, select_gap_count)
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
-    EXPECT_EQ(*sample1, sample_2);
-    EXPECT_EQ(*sample2, sample_3);
+    EXPECT_EQ(*sample1, db_sample_2);
+    EXPECT_EQ(*sample2, db_sample_3);
 }
 
 TEST_F(database_tests, select_data_count)
@@ -3672,8 +3672,8 @@ TEST_F(database_tests, select_data_count)
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes data count
-    // data count stores the difference between each accumulated report and the previous one
+    EntityCountSample db_sample_2 = sample_2 - sample_1;
+    EntityCountSample db_sample_3 = sample_3 - sample_2;
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::DATA_COUNT, writer_id, src_ts, end_ts));
@@ -3682,8 +3682,8 @@ TEST_F(database_tests, select_data_count)
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
     EXPECT_EQ(*sample1, sample_1);
-    EXPECT_EQ(*sample2, sample_2);
-    EXPECT_EQ(*sample3, sample_3);
+    EXPECT_EQ(*sample2, db_sample_2);
+    EXPECT_EQ(*sample3, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::DATA_COUNT, writer_id, src_ts, mid1_ts));
@@ -3704,8 +3704,8 @@ TEST_F(database_tests, select_data_count)
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
-    EXPECT_EQ(*sample1, sample_2);
-    EXPECT_EQ(*sample2, sample_3);
+    EXPECT_EQ(*sample1, db_sample_2);
+    EXPECT_EQ(*sample2, db_sample_3);
 }
 
 TEST_F(database_tests, select_pdp_packets)
@@ -3726,8 +3726,8 @@ TEST_F(database_tests, select_pdp_packets)
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes pdp packets
-    // pdp packets stores the difference between each accumulated report and the previous one
+    EntityCountSample db_sample_2 = sample_2 - sample_1;
+    EntityCountSample db_sample_3 = sample_3 - sample_2;
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, src_ts, end_ts));
@@ -3736,8 +3736,8 @@ TEST_F(database_tests, select_pdp_packets)
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
     EXPECT_EQ(*sample1, sample_1);
-    EXPECT_EQ(*sample2, sample_2);
-    EXPECT_EQ(*sample3, sample_3);
+    EXPECT_EQ(*sample2, db_sample_2);
+    EXPECT_EQ(*sample3, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, src_ts, mid1_ts));
@@ -3758,8 +3758,8 @@ TEST_F(database_tests, select_pdp_packets)
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
-    EXPECT_EQ(*sample1, sample_2);
-    EXPECT_EQ(*sample2, sample_3);
+    EXPECT_EQ(*sample1, db_sample_2);
+    EXPECT_EQ(*sample2, db_sample_3);
 }
 
 TEST_F(database_tests, select_edp_packets)
@@ -3780,8 +3780,8 @@ TEST_F(database_tests, select_edp_packets)
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes edp packets
-    // edp packets stores the difference between each accumulated report and the previous one
+    EntityCountSample db_sample_2 = sample_2 - sample_1;
+    EntityCountSample db_sample_3 = sample_3 - sample_2;
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::EDP_PACKETS, participant_id, src_ts, end_ts));
@@ -3790,8 +3790,8 @@ TEST_F(database_tests, select_edp_packets)
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
     EXPECT_EQ(*sample1, sample_1);
-    EXPECT_EQ(*sample2, sample_2);
-    EXPECT_EQ(*sample3, sample_3);
+    EXPECT_EQ(*sample2, db_sample_2);
+    EXPECT_EQ(*sample3, db_sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::EDP_PACKETS, participant_id, src_ts, mid1_ts));
@@ -3812,8 +3812,8 @@ TEST_F(database_tests, select_edp_packets)
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
-    EXPECT_EQ(*sample1, sample_2);
-    EXPECT_EQ(*sample2, sample_3);
+    EXPECT_EQ(*sample1, db_sample_2);
+    EXPECT_EQ(*sample2, db_sample_3);
 }
 
 TEST_F(database_tests, select_discovery_time)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2575,7 +2575,12 @@ TEST_F(database_tests, select_invalid_entity_ids)
     Timestamp t_from = std::chrono::system_clock::now();
     Timestamp t_to = t_from + std::chrono::seconds(1);
 
+    EntityId invalid_id;
+
     EXPECT_NO_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, invalid_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, invalid_id, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, process_id, t_from, t_to), BadParameter);
@@ -2596,6 +2601,9 @@ TEST_F(database_tests, select_invalid_entity_ids)
 
     EXPECT_NO_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, t_from, t_to));
     EXPECT_NO_THROW(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, writer_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, invalid_id, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, invalid_id, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, process_id, t_from, t_to), BadParameter);
@@ -2616,6 +2624,7 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, reader_id, writer_locator->id, t_from, t_to), BadParameter);
 
     EXPECT_NO_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, process_id, t_from, t_to), BadParameter);
@@ -2626,6 +2635,7 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_locator->id, t_from, t_to), BadParameter);
 
     EXPECT_NO_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, process_id, t_from, t_to), BadParameter);
@@ -2637,6 +2647,9 @@ TEST_F(database_tests, select_invalid_entity_ids)
 
     EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, writer_locator->id, t_from, t_to));
     EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, reader_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, invalid_id, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, process_id, t_from, t_to), BadParameter);
@@ -2659,6 +2672,9 @@ TEST_F(database_tests, select_invalid_entity_ids)
 
     EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, writer_locator->id, t_from, t_to));
     EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, reader_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, invalid_id, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, process_id, t_from, t_to), BadParameter);
@@ -2680,6 +2696,9 @@ TEST_F(database_tests, select_invalid_entity_ids)
 
     EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, writer_locator->id, t_from, t_to));
     EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, reader_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, invalid_id, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, process_id, t_from, t_to), BadParameter);
@@ -2702,6 +2721,9 @@ TEST_F(database_tests, select_invalid_entity_ids)
 
     EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, writer_locator->id, t_from, t_to));
     EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, reader_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, invalid_id, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, process_id, t_from, t_to), BadParameter);
@@ -2722,6 +2744,7 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, reader_locator->id, writer_id, t_from, t_to), BadParameter);
 
     EXPECT_NO_THROW(db.select(DataKind::RESENT_DATA, writer_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RESENT_DATA, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RESENT_DATA, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RESENT_DATA, process_id, t_from, t_to), BadParameter);
@@ -2732,6 +2755,7 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_THROW(db.select(DataKind::RESENT_DATA, writer_locator->id, t_from, t_to), BadParameter);
 
     EXPECT_NO_THROW(db.select(DataKind::HEARTBEAT_COUNT, writer_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, process_id, t_from, t_to), BadParameter);
@@ -2742,6 +2766,7 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, writer_locator->id, t_from, t_to), BadParameter);
 
     EXPECT_NO_THROW(db.select(DataKind::ACKNACK_COUNT, reader_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, process_id, t_from, t_to), BadParameter);
@@ -2752,6 +2777,7 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, writer_locator->id, t_from, t_to), BadParameter);
 
     EXPECT_NO_THROW(db.select(DataKind::NACKFRAG_COUNT, reader_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, process_id, t_from, t_to), BadParameter);
@@ -2762,6 +2788,7 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, writer_locator->id, t_from, t_to), BadParameter);
 
     EXPECT_NO_THROW(db.select(DataKind::GAP_COUNT, writer_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::GAP_COUNT, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::GAP_COUNT, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::GAP_COUNT, process_id, t_from, t_to), BadParameter);
@@ -2772,6 +2799,7 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_THROW(db.select(DataKind::GAP_COUNT, writer_locator->id, t_from, t_to), BadParameter);
 
     EXPECT_NO_THROW(db.select(DataKind::DATA_COUNT, writer_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::DATA_COUNT, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::DATA_COUNT, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::DATA_COUNT, process_id, t_from, t_to), BadParameter);
@@ -2782,6 +2810,7 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_THROW(db.select(DataKind::DATA_COUNT, writer_locator->id, t_from, t_to), BadParameter);
 
     EXPECT_NO_THROW(db.select(DataKind::PDP_PACKETS, participant_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::PDP_PACKETS, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::PDP_PACKETS, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::PDP_PACKETS, process_id, t_from, t_to), BadParameter);
@@ -2792,6 +2821,7 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_THROW(db.select(DataKind::PDP_PACKETS, writer_locator->id, t_from, t_to), BadParameter);
 
     EXPECT_NO_THROW(db.select(DataKind::EDP_PACKETS, participant_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::EDP_PACKETS, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::EDP_PACKETS, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::EDP_PACKETS, process_id, t_from, t_to), BadParameter);
@@ -2804,6 +2834,9 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_NO_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, participant_id, t_from, t_to));
     EXPECT_NO_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_id, t_from, t_to));
     EXPECT_NO_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, reader_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, invalid_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, invalid_id, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, process_id, t_from, t_to), BadParameter);
@@ -2812,8 +2845,15 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, writer_id, participant_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, reader_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, host_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, user_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, process_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, domain_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, topic_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, writer_locator->id, participant_id, t_from, t_to), BadParameter);
 
     EXPECT_NO_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, host_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, user_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, process_id, t_from, t_to), BadParameter);

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -3016,24 +3016,55 @@ TEST_F(database_tests, select_resent_data)
 TEST_F(database_tests, select_heartbeat_count)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::HEARTBEAT_COUNT, writer_id, src_ts, end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     HeartbeatCountSample sample_1;
     sample_1.count = 34;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_1));
     HeartbeatCountSample sample_2;
     sample_2.count = 43;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
     HeartbeatCountSample sample_3;
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_3));
+    // TODO Adjust this test after merging PR which fixes heartbeat count
+    // heartbeat count stores the difference between each accumulated report and the previous one
 
-    select_test(DataKind::HEARTBEAT_COUNT, writer_id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::HEARTBEAT_COUNT, writer_id, src_ts, end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::HEARTBEAT_COUNT, writer_id, src_ts, mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::HEARTBEAT_COUNT, writer_id, mid1_ts, mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::HEARTBEAT_COUNT, writer_id, mid2_ts, mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::HEARTBEAT_COUNT, writer_id, sample2_ts, sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 }
 
 TEST_F(database_tests, select_acknack_count)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2122,8 +2122,8 @@ TEST_F(database_tests, insert_sample_sample_datas)
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
 
     ASSERT_EQ(writer->data.sample_datas.size(), 2);
-    ASSERT_EQ(writer->data.sample_datas[sample.sequence_number], sample.count);
-    ASSERT_EQ(writer->data.sample_datas[sample_2.sequence_number], sample_2.count);
+    ASSERT_EQ(writer->data.sample_datas[sample.sequence_number][0], static_cast<EntityCountSample>(sample));
+    ASSERT_EQ(writer->data.sample_datas[sample_2.sequence_number][0], static_cast<EntityCountSample>(sample_2));
 }
 
 TEST_F(database_tests, insert_sample_sample_datas_wrong_entity)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -3179,24 +3179,56 @@ TEST_F(database_tests, select_nackfrag_count)
 TEST_F(database_tests, select_gap_count)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::GAP_COUNT, writer_id, src_ts, end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     GapCountSample sample_1;
     sample_1.count = 34;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_1));
     GapCountSample sample_2;
     sample_2.count = 43;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
     GapCountSample sample_3;
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_3));
 
-    select_test(DataKind::GAP_COUNT, writer_id, samples);
+    // TODO Adjust this test after merging PR which fixes resent datas
+    // resent datas stores the difference between each accumulated report and the previous one
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::GAP_COUNT, writer_id, src_ts, end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::GAP_COUNT, writer_id, src_ts, mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::GAP_COUNT, writer_id, mid1_ts, mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::GAP_COUNT, writer_id, mid2_ts, mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::GAP_COUNT, writer_id, sample2_ts, sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 }
 
 TEST_F(database_tests, select_data_count)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2922,6 +2922,66 @@ TEST_F(database_tests, select_fastdds_latency)
     EXPECT_EQ(*output[1], static_cast<StatisticsSample>(sample_3));
 }
 
+TEST_F(database_tests, select_network_latency)
+{
+    std::vector<const StatisticsSample*> output;
+    ASSERT_NO_THROW(output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
+        end_ts));
+    EXPECT_EQ(output.size(), 0u);
+
+    NetworkLatencySample sample_1;
+    sample_1.remote_locator = reader_locator->id;
+    sample_1.data = 15;
+    sample_1.src_ts = sample1_ts;
+    NetworkLatencySample sample_2;
+    sample_2.remote_locator = reader_locator->id;
+    sample_2.data = 5;
+    sample_2.src_ts = sample2_ts;
+    NetworkLatencySample sample_3;
+    sample_3.remote_locator = reader_locator->id;
+    sample_3.data = 25;
+    sample_3.src_ts = sample1_ts;
+    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample_1));
+    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample_2));
+    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample_3));
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
+        end_ts));
+    EXPECT_EQ(output.size(), 3u);
+    EXPECT_EQ(*output[0], static_cast<StatisticsSample>(sample_1));
+    EXPECT_EQ(*output[1], static_cast<StatisticsSample>(sample_2));
+    EXPECT_EQ(*output[2], static_cast<StatisticsSample>(sample_3));
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
+        mid1_ts));
+    EXPECT_EQ(output.size(), 0u);
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, mid1_ts,
+        mid2_ts));
+    EXPECT_EQ(output.size(), 1u);
+    EXPECT_EQ(*output[0], static_cast<StatisticsSample>(sample_1));
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, mid2_ts,
+        mid3_ts));
+    EXPECT_EQ(output.size(), 0u);
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, sample2_ts,
+        sample3_ts));
+    EXPECT_EQ(output.size(), 2u);
+    EXPECT_EQ(*output[0], static_cast<StatisticsSample>(sample_2));
+    EXPECT_EQ(*output[1], static_cast<StatisticsSample>(sample_3));
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::NETWORK_LATENCY, reader_locator->id, writer_locator->id, src_ts,
+        end_ts));
+    EXPECT_EQ(output.size(), 0u);
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2663,300 +2663,6 @@ TEST_F(database_tests, select_invalid_timestamps)
     EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, t_from, t_to), BadParameter);
 }
 
-TEST_F(database_tests, select_invalid_entity_ids)
-{
-    Timestamp t_from = std::chrono::system_clock::now();
-    Timestamp t_to = t_from + std::chrono::seconds(1);
-
-    EntityId invalid_id;
-
-    EXPECT_NO_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, invalid_id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, invalid_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, host_id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, user_id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, process_id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, domain_id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, topic_id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, participant_id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, reader_id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_locator->id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, reader_id, writer_id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, t_from, t_to));
-    EXPECT_NO_THROW(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, writer_locator->id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, invalid_id, reader_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, invalid_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, writer_locator->id, t_from, t_to),
-        BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, host_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, user_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, process_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, domain_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, topic_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, participant_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, reader_id, writer_locator->id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_locator->id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, writer_locator->id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, t_from, t_to));
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_locator->id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, invalid_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, host_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, user_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, process_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, domain_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, topic_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, reader_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, reader_locator->id, writer_locator->id, t_from, t_to),
-        BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, reader_locator->id, participant_id, t_from, t_to),
-        BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, t_from, t_to));
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_locator->id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, invalid_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, host_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, user_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, process_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, domain_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, topic_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, reader_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, reader_locator->id, writer_locator->id, t_from, t_to),
-        BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, reader_locator->id, participant_id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, t_from, t_to));
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_locator->id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, invalid_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, host_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, user_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, process_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, domain_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, topic_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, reader_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, reader_locator->id, writer_locator->id, t_from, t_to),
-        BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, reader_locator->id, participant_id, t_from, t_to),
-        BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, t_from, t_to));
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_locator->id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, invalid_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, host_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, user_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, process_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, domain_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, topic_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, reader_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, reader_locator->id, writer_locator->id, t_from, t_to), 
-        BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, reader_locator->id, participant_id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::RESENT_DATA, writer_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::RESENT_DATA, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RESENT_DATA, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RESENT_DATA, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RESENT_DATA, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RESENT_DATA, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RESENT_DATA, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RESENT_DATA, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RESENT_DATA, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RESENT_DATA, writer_locator->id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::HEARTBEAT_COUNT, writer_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, writer_locator->id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::ACKNACK_COUNT, reader_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, writer_locator->id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::NACKFRAG_COUNT, reader_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, writer_locator->id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::GAP_COUNT, writer_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::GAP_COUNT, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::GAP_COUNT, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::GAP_COUNT, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::GAP_COUNT, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::GAP_COUNT, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::GAP_COUNT, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::GAP_COUNT, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::GAP_COUNT, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::GAP_COUNT, writer_locator->id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::DATA_COUNT, writer_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::DATA_COUNT, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DATA_COUNT, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DATA_COUNT, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DATA_COUNT, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DATA_COUNT, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DATA_COUNT, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DATA_COUNT, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DATA_COUNT, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DATA_COUNT, writer_locator->id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::PDP_PACKETS, participant_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, writer_locator->id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::EDP_PACKETS, participant_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, writer_locator->id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, participant_id, t_from, t_to));
-    EXPECT_NO_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_id, t_from, t_to));
-    EXPECT_NO_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, reader_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, invalid_id, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, invalid_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, writer_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, reader_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, host_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, user_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, process_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, domain_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, topic_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, writer_locator->id, participant_id, t_from, t_to), BadParameter);
-
-    EXPECT_NO_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, reader_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_locator->id, t_from, t_to), BadParameter);
-}
-
 TEST_F(database_tests, select_fastdds_latency)
 {
     data_output.clear();
@@ -3018,24 +2724,53 @@ TEST_F(database_tests, select_network_latency)
 TEST_F(database_tests, select_publication_throughput)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, src_ts, end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     PublicationThroughputSample sample_1;
     sample_1.data = 15;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_1));
     PublicationThroughputSample sample_2;
     sample_2.data = 5;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
     PublicationThroughputSample sample_3;
     sample_3.data = 25;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_3));
 
-    select_test(DataKind::PUBLICATION_THROUGHPUT, writer_id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, src_ts, end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityDataSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityDataSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityDataSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, src_ts, mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, mid1_ts, mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityDataSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, mid2_ts, mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, sample2_ts, sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityDataSample*>(data_output[0]);
+    sample2 = static_cast<const EntityDataSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 }
 
 TEST_F(database_tests, select_subscription_throughput)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -612,13 +612,11 @@ public:
     std::string writer_name = "test_writer";
     std::shared_ptr<DataWriter> writer;
     EntityId writer_id;
-    EntityId writer_locator_id;
     std::string reader_locator_name = "test_reader_locator";
     std::shared_ptr<Locator> reader_locator;
     std::string reader_name = "test_reader";
     std::shared_ptr<DataReader> reader;
     EntityId reader_id;
-    EntityId reader_locator_id;
 };
 
 TEST_F(database_tests, insert_host)
@@ -2500,7 +2498,7 @@ TEST_F(database_tests, select_single_entity_invalid_needs_two_entities)
     Timestamp dst_timestamp = src_timestamp + std::chrono::seconds(1);
 
     EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, src_timestamp, dst_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, reader_locator_id, src_timestamp, dst_timestamp), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, src_timestamp, dst_timestamp), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, src_timestamp, dst_timestamp), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, src_timestamp, dst_timestamp), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, src_timestamp, dst_timestamp), BadParameter);

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -3303,8 +3303,8 @@ TEST_F(database_tests, select_pdp_packets)
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
-    // TODO Adjust this test after merging PR which fixes resent datas
-    // resent datas stores the difference between each accumulated report and the previous one
+    // TODO Adjust this test after merging PR which fixes pdp packets
+    // pdp packets stores the difference between each accumulated report and the previous one
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, src_ts, end_ts));
@@ -3342,24 +3342,55 @@ TEST_F(database_tests, select_pdp_packets)
 TEST_F(database_tests, select_edp_packets)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::EDP_PACKETS, participant_id, src_ts, end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     EdpCountSample sample_1;
     sample_1.count = 34;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_1));
     EdpCountSample sample_2;
     sample_2.count = 43;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
     EdpCountSample sample_3;
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
+    // TODO Adjust this test after merging PR which fixes edp packets
+    // edp packets stores the difference between each accumulated report and the previous one
 
-    select_test(DataKind::EDP_PACKETS, participant_id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::EDP_PACKETS, participant_id, src_ts, end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::EDP_PACKETS, participant_id, src_ts, mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::EDP_PACKETS, participant_id, mid1_ts, mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::EDP_PACKETS, participant_id, mid2_ts, mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::EDP_PACKETS, participant_id, sample2_ts, sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 }
 
 TEST_F(database_tests, select_discovery_time)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2998,7 +2998,7 @@ TEST_F(database_tests, select_network_latency)
     NetworkLatencySample sample_3;
     sample_3.remote_locator = reader_locator->id;
     sample_3.data = 25;
-    sample_3.src_ts = sample1_ts;
+    sample_3.src_ts = sample3_ts;
     samples.push_back(sample_3);
 
     select_test(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, samples);
@@ -3026,7 +3026,7 @@ TEST_F(database_tests, select_publication_throughput)
     samples.push_back(sample_2);
     PublicationThroughputSample sample_3;
     sample_3.data = 25;
-    sample_3.src_ts = sample1_ts;
+    sample_3.src_ts = sample3_ts;
     samples.push_back(sample_3);
 
     select_test(DataKind::PUBLICATION_THROUGHPUT, writer_id, samples);
@@ -3049,10 +3049,144 @@ TEST_F(database_tests, select_subscription_throughput)
     samples.push_back(sample_2);
     SubscriptionThroughputSample sample_3;
     sample_3.data = 25;
-    sample_3.src_ts = sample1_ts;
+    sample_3.src_ts = sample3_ts;
     samples.push_back(sample_3);
 
     select_test(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, samples);
+}
+
+TEST_F(database_tests, select_rtps_packets_sent)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, writer_id, reader_locator->id, src_ts,
+        end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    RtpsPacketsSentSample sample_1;
+    sample_1.remote_locator = reader_locator->id;
+    sample_1.count = 15;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    RtpsPacketsSentSample sample_2;
+    sample_2.remote_locator = reader_locator->id;
+    sample_2.count = 35;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    RtpsPacketsSentSample sample_3;
+    sample_3.remote_locator = reader_locator->id;
+    sample_3.count = 70;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::RTPS_PACKETS_SENT, writer_id, reader_locator->id, samples);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, writer_id, writer_locator->id, src_ts,
+        end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+}
+
+TEST_F(database_tests, select_rtps_bytes_sent)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, writer_id, reader_locator->id, src_ts,
+        end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    RtpsBytesSentSample sample_1;
+    sample_1.remote_locator = reader_locator->id;
+    sample_1.count = 15;
+    sample_1.magnitude_order = 2;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    RtpsBytesSentSample sample_2;
+    sample_2.remote_locator = reader_locator->id;
+    sample_2.count = 5;
+    sample_2.magnitude_order = 3;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    RtpsBytesSentSample sample_3;
+    sample_3.remote_locator = reader_locator->id;
+    sample_3.count = 25;
+    sample_3.magnitude_order = 3;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::RTPS_BYTES_SENT, writer_id, reader_locator->id, samples);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, writer_id, writer_locator->id, src_ts,
+        end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+}
+
+TEST_F(database_tests, select_rtps_packets_lost)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, writer_id, reader_locator->id, src_ts,
+        end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    RtpsPacketsLostSample sample_1;
+    sample_1.remote_locator = reader_locator->id;
+    sample_1.count = 15;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    RtpsPacketsLostSample sample_2;
+    sample_2.remote_locator = reader_locator->id;
+    sample_2.count = 5;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    RtpsPacketsLostSample sample_3;
+    sample_3.remote_locator = reader_locator->id;
+    sample_3.count = 25;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::RTPS_PACKETS_LOST, writer_id, reader_locator->id, samples);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, writer_id, writer_locator->id, src_ts,
+        end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+}
+
+TEST_F(database_tests, select_rtps_bytes_lost)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, writer_id, reader_locator->id, src_ts,
+        end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    RtpsBytesSentSample sample_1;
+    sample_1.remote_locator = reader_locator->id;
+    sample_1.count = 15;
+    sample_1.magnitude_order = 1;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    RtpsBytesSentSample sample_2;
+    sample_2.remote_locator = reader_locator->id;
+    sample_2.count = 5;
+    sample_2.magnitude_order = 2;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    RtpsBytesSentSample sample_3;
+    sample_3.remote_locator = reader_locator->id;
+    sample_3.count = 25;
+    sample_3.magnitude_order = 3;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::RTPS_BYTES_LOST, writer_id, reader_locator->id, samples);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, writer_id, writer_locator->id, src_ts,
+        end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
 }
 
 int main(

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2790,7 +2790,7 @@ TEST_F(database_tests, select_invalid_entities)
     ASSERT_DEATH(db.select(DataKind::SAMPLE_DATAS, participant_id, sequence_number, t_from, t_to), "");
     ASSERT_DEATH(db.select(DataKind::SAMPLE_DATAS, reader_id, sequence_number, t_from, t_to), "");
     ASSERT_DEATH(db.select(DataKind::SAMPLE_DATAS, writer_locator->id, sequence_number, t_from, t_to), "");
-#endif
+#endif // ifndef NDEBUG
 }
 
 TEST_F(database_tests, select_invalid_timestamps)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -3234,24 +3234,55 @@ TEST_F(database_tests, select_gap_count)
 TEST_F(database_tests, select_data_count)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::DATA_COUNT, writer_id, src_ts, end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     DataCountSample sample_1;
     sample_1.count = 34;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_1));
     DataCountSample sample_2;
     sample_2.count = 43;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
     DataCountSample sample_3;
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_3));
+    // TODO Adjust this test after merging PR which fixes data count
+    // data count stores the difference between each accumulated report and the previous one
 
-    select_test(DataKind::DATA_COUNT, writer_id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::DATA_COUNT, writer_id, src_ts, end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::DATA_COUNT, writer_id, src_ts, mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::DATA_COUNT, writer_id, mid1_ts, mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::DATA_COUNT, writer_id, mid2_ts, mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::DATA_COUNT, writer_id, sample2_ts, sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 }
 
 TEST_F(database_tests, select_pdp_packets)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2586,10 +2586,10 @@ TEST_F(database_tests, select_single_entity_invalid_needs_two_entities)
 
     EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, t_from, t_to), BadParameter);
 }
 
@@ -2622,14 +2622,20 @@ TEST_F(database_tests, select_invalid_timestamps)
         BadParameter);
     EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, t_from, t_to),
         BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, reader_locator->id, t_from, t_from), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, reader_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, reader_locator->id, t_from, t_from), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, reader_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, reader_locator->id, t_from, t_from), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, reader_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, reader_locator->id, t_from, t_from), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_locator->id, t_from, t_from),
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_locator->id, t_from, t_to),
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_locator->id, t_from, t_from),
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_locator->id, t_from, t_from),
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_locator->id, t_from, t_to),
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_locator->id, t_from, t_from),
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_id, t_from, t_from), BadParameter);
     EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_id, t_from, t_to), BadParameter);
 
@@ -2732,103 +2738,103 @@ TEST_F(database_tests, select_invalid_entity_ids)
     EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, writer_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, writer_locator->id, t_from, t_to), BadParameter);
 
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, writer_locator->id, t_from, t_to));
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, reader_locator->id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, t_from, t_to));
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, invalid_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, host_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, user_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, process_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, domain_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, topic_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, t_from, t_to),
-        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, reader_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, reader_locator->id, writer_locator->id, t_from, t_to),
         BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, reader_locator->id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, reader_locator->id, participant_id, t_from, t_to),
+        BadParameter);
 
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, writer_locator->id, t_from, t_to));
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, reader_locator->id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, t_from, t_to));
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, invalid_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, host_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, user_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, process_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, domain_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, topic_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, reader_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, reader_locator->id, writer_locator->id, t_from, t_to),
         BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, reader_locator->id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, reader_locator->id, participant_id, t_from, t_to), BadParameter);
 
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, writer_locator->id, t_from, t_to));
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, reader_locator->id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, t_from, t_to));
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, invalid_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, host_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, user_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, process_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, domain_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, topic_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, t_from, t_to),
-        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, reader_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, reader_locator->id, writer_locator->id, t_from, t_to),
         BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, reader_locator->id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, reader_locator->id, participant_id, t_from, t_to),
+        BadParameter);
 
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, writer_locator->id, t_from, t_to));
-    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, reader_locator->id, t_from, t_to));
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, t_from, t_to));
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, invalid_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, invalid_id, invalid_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, host_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, user_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, process_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, domain_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, topic_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, participant_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, writer_id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, host_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, user_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, process_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, domain_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, topic_id, writer_locator->id, t_from, t_to), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, reader_id, writer_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, reader_locator->id, writer_locator->id, t_from, t_to), 
         BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, reader_locator->id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, reader_locator->id, participant_id, t_from, t_to), BadParameter);
 
     EXPECT_NO_THROW(db.select(DataKind::RESENT_DATA, writer_id, t_from, t_to));
     EXPECT_THROW(db.select(DataKind::RESENT_DATA, invalid_id, t_from, t_to), BadParameter);
@@ -3059,30 +3065,30 @@ TEST_F(database_tests, select_rtps_packets_sent)
 {
     data_output.clear();
     samples.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, writer_id, reader_locator->id, src_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     RtpsPacketsSentSample sample_1;
-    sample_1.remote_locator = reader_locator->id;
+    sample_1.remote_locator = writer_locator->id;
     sample_1.count = 15;
     sample_1.src_ts = sample1_ts;
     samples.push_back(sample_1);
     RtpsPacketsSentSample sample_2;
-    sample_2.remote_locator = reader_locator->id;
+    sample_2.remote_locator = writer_locator->id;
     sample_2.count = 35;
     sample_2.src_ts = sample2_ts;
     samples.push_back(sample_2);
     RtpsPacketsSentSample sample_3;
-    sample_3.remote_locator = reader_locator->id;
+    sample_3.remote_locator = writer_locator->id;
     sample_3.count = 70;
     sample_3.src_ts = sample3_ts;
     samples.push_back(sample_3);
 
-    select_test(DataKind::RTPS_PACKETS_SENT, writer_id, reader_locator->id, samples);
+    select_test(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, samples);
 
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, writer_id, writer_locator->id, src_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 }
@@ -3091,33 +3097,33 @@ TEST_F(database_tests, select_rtps_bytes_sent)
 {
     data_output.clear();
     samples.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, writer_id, reader_locator->id, src_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     RtpsBytesSentSample sample_1;
-    sample_1.remote_locator = reader_locator->id;
+    sample_1.remote_locator = writer_locator->id;
     sample_1.count = 15;
     sample_1.magnitude_order = 2;
     sample_1.src_ts = sample1_ts;
     samples.push_back(sample_1);
     RtpsBytesSentSample sample_2;
-    sample_2.remote_locator = reader_locator->id;
+    sample_2.remote_locator = writer_locator->id;
     sample_2.count = 5;
     sample_2.magnitude_order = 3;
     sample_2.src_ts = sample2_ts;
     samples.push_back(sample_2);
     RtpsBytesSentSample sample_3;
-    sample_3.remote_locator = reader_locator->id;
+    sample_3.remote_locator = writer_locator->id;
     sample_3.count = 25;
     sample_3.magnitude_order = 3;
     sample_3.src_ts = sample3_ts;
     samples.push_back(sample_3);
 
-    select_test(DataKind::RTPS_BYTES_SENT, writer_id, reader_locator->id, samples);
+    select_test(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, samples);
 
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, writer_id, writer_locator->id, src_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 }
@@ -3126,30 +3132,30 @@ TEST_F(database_tests, select_rtps_packets_lost)
 {
     data_output.clear();
     samples.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, writer_id, reader_locator->id, src_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     RtpsPacketsLostSample sample_1;
-    sample_1.remote_locator = reader_locator->id;
+    sample_1.remote_locator = writer_locator->id;
     sample_1.count = 15;
     sample_1.src_ts = sample1_ts;
     samples.push_back(sample_1);
     RtpsPacketsLostSample sample_2;
-    sample_2.remote_locator = reader_locator->id;
+    sample_2.remote_locator = writer_locator->id;
     sample_2.count = 5;
     sample_2.src_ts = sample2_ts;
     samples.push_back(sample_2);
     RtpsPacketsLostSample sample_3;
-    sample_3.remote_locator = reader_locator->id;
+    sample_3.remote_locator = writer_locator->id;
     sample_3.count = 25;
     sample_3.src_ts = sample3_ts;
     samples.push_back(sample_3);
 
-    select_test(DataKind::RTPS_PACKETS_LOST, writer_id, reader_locator->id, samples);
+    select_test(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, samples);
 
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, writer_id, writer_locator->id, src_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 }
@@ -3158,33 +3164,33 @@ TEST_F(database_tests, select_rtps_bytes_lost)
 {
     data_output.clear();
     samples.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, writer_id, reader_locator->id, src_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     RtpsBytesSentSample sample_1;
-    sample_1.remote_locator = reader_locator->id;
+    sample_1.remote_locator = writer_locator->id;
     sample_1.count = 15;
     sample_1.magnitude_order = 1;
     sample_1.src_ts = sample1_ts;
     samples.push_back(sample_1);
     RtpsBytesSentSample sample_2;
-    sample_2.remote_locator = reader_locator->id;
+    sample_2.remote_locator = writer_locator->id;
     sample_2.count = 5;
     sample_2.magnitude_order = 2;
     sample_2.src_ts = sample2_ts;
     samples.push_back(sample_2);
     RtpsBytesSentSample sample_3;
-    sample_3.remote_locator = reader_locator->id;
+    sample_3.remote_locator = writer_locator->id;
     sample_3.count = 25;
     sample_3.magnitude_order = 3;
     sample_3.src_ts = sample3_ts;
     samples.push_back(sample_3);
 
-    select_test(DataKind::RTPS_BYTES_LOST, writer_id, reader_locator->id, samples);
+    select_test(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, samples);
 
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, writer_id, writer_locator->id, src_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 }

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2793,6 +2793,40 @@ TEST_F(database_tests, select_invalid_entities)
 #endif // ifndef NDEBUG
 }
 
+TEST_F(database_tests, select_invalid_entity_id)
+{
+    Timestamp t_from = std::chrono::system_clock::now();
+    Timestamp t_to = t_from + std::chrono::seconds(1);
+    uint64_t sequence_number = 1;
+    EntityId invalid_id;
+
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, invalid_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, invalid_id, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, invalid_id, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, invalid_id, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, invalid_id, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, invalid_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, invalid_id, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, invalid_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, invalid_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, invalid_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, invalid_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, invalid_id, sequence_number, t_from, t_from), BadParameter);
+}
+
 TEST_F(database_tests, select_invalid_timestamps)
 {
     Timestamp t_from = std::chrono::system_clock::now();
@@ -2871,7 +2905,7 @@ TEST_F(database_tests, select_fastdds_latency)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityDataSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityDataSample*>(data_output[2]);
@@ -2885,7 +2919,7 @@ TEST_F(database_tests, select_fastdds_latency)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -2895,7 +2929,7 @@ TEST_F(database_tests, select_fastdds_latency)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, sample2_ts, sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     sample2 = static_cast<const EntityDataSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -2928,7 +2962,7 @@ TEST_F(database_tests, select_network_latency)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
             end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityDataSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityDataSample*>(data_output[2]);
@@ -2944,7 +2978,7 @@ TEST_F(database_tests, select_network_latency)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, mid1_ts,
             mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -2956,7 +2990,7 @@ TEST_F(database_tests, select_network_latency)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id,
             sample2_ts, sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     sample2 = static_cast<const EntityDataSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -2989,7 +3023,7 @@ TEST_F(database_tests, select_publication_throughput)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityDataSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityDataSample*>(data_output[2]);
@@ -3003,7 +3037,7 @@ TEST_F(database_tests, select_publication_throughput)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3013,7 +3047,7 @@ TEST_F(database_tests, select_publication_throughput)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, sample2_ts, sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     sample2 = static_cast<const EntityDataSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3041,7 +3075,7 @@ TEST_F(database_tests, select_subscription_throughput)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityDataSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityDataSample*>(data_output[2]);
@@ -3055,7 +3089,7 @@ TEST_F(database_tests, select_subscription_throughput)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3065,7 +3099,7 @@ TEST_F(database_tests, select_subscription_throughput)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, sample2_ts, sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     sample2 = static_cast<const EntityDataSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3100,7 +3134,7 @@ TEST_F(database_tests, select_rtps_packets_sent)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, src_ts,
             end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
@@ -3116,7 +3150,7 @@ TEST_F(database_tests, select_rtps_packets_sent)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, mid1_ts,
             mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3128,7 +3162,7 @@ TEST_F(database_tests, select_rtps_packets_sent)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, sample2_ts,
             sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3171,7 +3205,7 @@ TEST_F(database_tests, select_rtps_bytes_sent)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, src_ts,
             end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     auto sample2 = static_cast<const ByteCountSample*>(data_output[1]);
     auto sample3 = static_cast<const ByteCountSample*>(data_output[2]);
@@ -3187,7 +3221,7 @@ TEST_F(database_tests, select_rtps_bytes_sent)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, mid1_ts,
             mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3199,7 +3233,7 @@ TEST_F(database_tests, select_rtps_bytes_sent)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, sample2_ts,
             sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     sample2 = static_cast<const ByteCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3239,7 +3273,7 @@ TEST_F(database_tests, select_rtps_packets_lost)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, src_ts,
             end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
@@ -3255,7 +3289,7 @@ TEST_F(database_tests, select_rtps_packets_lost)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, mid1_ts,
             mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3267,7 +3301,7 @@ TEST_F(database_tests, select_rtps_packets_lost)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, sample2_ts,
             sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3310,7 +3344,7 @@ TEST_F(database_tests, select_rtps_bytes_lost)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, src_ts,
             end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     auto sample2 = static_cast<const ByteCountSample*>(data_output[1]);
     auto sample3 = static_cast<const ByteCountSample*>(data_output[2]);
@@ -3326,7 +3360,7 @@ TEST_F(database_tests, select_rtps_bytes_lost)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, mid1_ts,
             mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3338,7 +3372,7 @@ TEST_F(database_tests, select_rtps_bytes_lost)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, sample2_ts,
             sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     sample2 = static_cast<const ByteCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3373,7 +3407,7 @@ TEST_F(database_tests, select_resent_data)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RESENT_DATA, writer_id, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
@@ -3387,7 +3421,7 @@ TEST_F(database_tests, select_resent_data)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RESENT_DATA, writer_id, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3397,7 +3431,7 @@ TEST_F(database_tests, select_resent_data)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RESENT_DATA, writer_id, sample2_ts, sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3427,7 +3461,7 @@ TEST_F(database_tests, select_heartbeat_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::HEARTBEAT_COUNT, writer_id, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
@@ -3441,7 +3475,7 @@ TEST_F(database_tests, select_heartbeat_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::HEARTBEAT_COUNT, writer_id, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3451,7 +3485,7 @@ TEST_F(database_tests, select_heartbeat_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::HEARTBEAT_COUNT, writer_id, sample2_ts, sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3481,7 +3515,7 @@ TEST_F(database_tests, select_acknack_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::ACKNACK_COUNT, reader_id, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
@@ -3495,7 +3529,7 @@ TEST_F(database_tests, select_acknack_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::ACKNACK_COUNT, reader_id, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3505,7 +3539,7 @@ TEST_F(database_tests, select_acknack_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::ACKNACK_COUNT, reader_id, sample2_ts, sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3535,7 +3569,7 @@ TEST_F(database_tests, select_nackfrag_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NACKFRAG_COUNT, reader_id, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
@@ -3549,7 +3583,7 @@ TEST_F(database_tests, select_nackfrag_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NACKFRAG_COUNT, reader_id, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3559,7 +3593,7 @@ TEST_F(database_tests, select_nackfrag_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NACKFRAG_COUNT, reader_id, sample2_ts, sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3589,7 +3623,7 @@ TEST_F(database_tests, select_gap_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::GAP_COUNT, writer_id, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
@@ -3603,7 +3637,7 @@ TEST_F(database_tests, select_gap_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::GAP_COUNT, writer_id, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3613,7 +3647,7 @@ TEST_F(database_tests, select_gap_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::GAP_COUNT, writer_id, sample2_ts, sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3643,7 +3677,7 @@ TEST_F(database_tests, select_data_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::DATA_COUNT, writer_id, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
@@ -3657,7 +3691,7 @@ TEST_F(database_tests, select_data_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::DATA_COUNT, writer_id, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3667,7 +3701,7 @@ TEST_F(database_tests, select_data_count)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::DATA_COUNT, writer_id, sample2_ts, sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3697,7 +3731,7 @@ TEST_F(database_tests, select_pdp_packets)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
@@ -3711,7 +3745,7 @@ TEST_F(database_tests, select_pdp_packets)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3721,7 +3755,7 @@ TEST_F(database_tests, select_pdp_packets)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, sample2_ts, sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3751,7 +3785,7 @@ TEST_F(database_tests, select_edp_packets)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::EDP_PACKETS, participant_id, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
@@ -3765,7 +3799,7 @@ TEST_F(database_tests, select_edp_packets)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::EDP_PACKETS, participant_id, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3775,7 +3809,7 @@ TEST_F(database_tests, select_edp_packets)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::EDP_PACKETS, participant_id, sample2_ts, sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3809,7 +3843,7 @@ TEST_F(database_tests, select_discovery_time)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::DISCOVERY_TIME, participant_id, reader_id, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const DiscoveryTimeSample*>(data_output[0]);
     auto sample2 = static_cast<const DiscoveryTimeSample*>(data_output[1]);
     auto sample3 = static_cast<const DiscoveryTimeSample*>(data_output[2]);
@@ -3823,7 +3857,7 @@ TEST_F(database_tests, select_discovery_time)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::DISCOVERY_TIME, participant_id, reader_id, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const DiscoveryTimeSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3834,7 +3868,7 @@ TEST_F(database_tests, select_discovery_time)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::DISCOVERY_TIME, participant_id, reader_id, sample2_ts,
             sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const DiscoveryTimeSample*>(data_output[0]);
     sample2 = static_cast<const DiscoveryTimeSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
@@ -3852,6 +3886,7 @@ TEST_F(database_tests, select_discovery_time)
 TEST_F(database_tests, select_sample_datas)
 {
     uint64_t sequence_number = 3;
+    uint64_t sequence_number_unknown = 14;
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, src_ts, end_ts));
     EXPECT_EQ(data_output.size(), 0u);
@@ -3874,7 +3909,7 @@ TEST_F(database_tests, select_sample_datas)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, src_ts, end_ts));
-    ASSERT_GE(data_output.size(), 3u);
+    ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
@@ -3888,7 +3923,7 @@ TEST_F(database_tests, select_sample_datas)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, mid1_ts, mid2_ts));
-    ASSERT_GE(data_output.size(), 1u);
+    ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
@@ -3899,11 +3934,16 @@ TEST_F(database_tests, select_sample_datas)
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, sample2_ts,
             sample3_ts));
-    ASSERT_GE(data_output.size(), 2u);
+    ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
     EXPECT_EQ(*sample1, sample_2);
     EXPECT_EQ(*sample2, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number_unknown, src_ts,
+            end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
 }
 
 int main(

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2534,10 +2534,36 @@ TEST_F(database_tests, select_double_entity_invalid_needs_one_entity)
     EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, reader_id, t_from, t_to), BadParameter);
 }
 
+TEST_F(database_tests, select_sample_datas_invalid_wrong_entity)
+{
+    Timestamp t_from = std::chrono::system_clock::now();
+    Timestamp t_to = t_from + std::chrono::seconds(1);
+    uint64_t sequence_number = 3;
+
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, writer_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, writer_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, reader_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, reader_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, writer_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, writer_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, participant_id, sequence_number, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, participant_id, sequence_number, t_from, t_to), BadParameter);
+}
+
 TEST_F(database_tests, select_invalid_timestamps)
 {
     Timestamp t_from = std::chrono::system_clock::now();
     Timestamp t_to = t_from - std::chrono::nanoseconds(1);
+    uint64_t sequence_number = 3;
 
     EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, t_from, t_from), BadParameter);
     EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, t_from, t_to), BadParameter);
@@ -2582,11 +2608,9 @@ TEST_F(database_tests, select_invalid_timestamps)
     EXPECT_THROW(db.select(DataKind::PDP_PACKETS, participant_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::EDP_PACKETS, participant_id, t_from, t_from), BadParameter);
     EXPECT_THROW(db.select(DataKind::EDP_PACKETS, participant_id, t_from, t_to), BadParameter);
-    // TODO(jlbueno) SAMPLE_DATAS should be fixed once requirement #11497 has been implemented
-/*
-    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, t_from, t_from), BadParameter);
-    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, t_from, t_to), BadParameter);
-*/
+
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, t_from, t_to), BadParameter);
 }
 
 TEST_F(database_tests, select_fastdds_latency)
@@ -3591,34 +3615,62 @@ TEST_F(database_tests, select_discovery_time)
     EXPECT_EQ(data_output.size(), 0u);
 }
 
-// TODO(jlbueno) This test needs to be fixed once requirement #11497 has been implemented.
-/*
 TEST_F(database_tests, select_sample_datas)
 {
+    uint64_t sequence_number = 3;
     data_output.clear();
-    samples.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, src_ts, end_ts));
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, src_ts, end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     SampleDatasCountSample sample_1;
-    sample_1.count = 34;
-    sample_1.sequence_number = 2;
+    sample_1.count = 5;
+    sample_1.sequence_number = 3;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_1));
     SampleDatasCountSample sample_2;
-    sample_2.count = 15;
-    sample_2.sequence_number = 1;
+    sample_2.count = 10;
+    sample_2.sequence_number = 3;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
     SampleDatasCountSample sample_3;
-    sample_3.count = 44;
-    sample_3.sequence_number = 2;
+    sample_3.count = 24;
+    sample_3.sequence_number = 3;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_3));
 
-    select_test(DataKind::SAMPLE_DATAS, writer_id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, src_ts, end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, src_ts, mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, mid1_ts, mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, mid2_ts, mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, sample2_ts, 
+        sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 }
-*/
 
 int main(
         int argc,

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2776,24 +2776,53 @@ TEST_F(database_tests, select_publication_throughput)
 TEST_F(database_tests, select_subscription_throughput)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, src_ts, end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     SubscriptionThroughputSample sample_1;
     sample_1.data = 15;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_1));
     SubscriptionThroughputSample sample_2;
     sample_2.data = 5;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_2));
     SubscriptionThroughputSample sample_3;
     sample_3.data = 25;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_3));
 
-    select_test(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, src_ts, end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityDataSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityDataSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityDataSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, src_ts, mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, mid1_ts, mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityDataSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, mid2_ts, mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, sample2_ts, sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityDataSample*>(data_output[0]);
+    sample2 = static_cast<const EntityDataSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 }
 
 TEST_F(database_tests, select_rtps_packets_sent)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2591,6 +2591,7 @@ TEST_F(database_tests, select_single_entity_invalid_needs_two_entities)
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, t_from, t_to), BadParameter);
 }
 
 TEST_F(database_tests, select_double_entity_invalid_needs_one_entity)
@@ -2659,8 +2660,11 @@ TEST_F(database_tests, select_invalid_timestamps)
     EXPECT_THROW(db.select(DataKind::PDP_PACKETS, participant_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::EDP_PACKETS, participant_id, t_from, t_from), BadParameter);
     EXPECT_THROW(db.select(DataKind::EDP_PACKETS, participant_id, t_from, t_to), BadParameter);
+    // TODO(jlbueno) SAMPLE_DATAS should be fixed once requirement #11497 has been implemented
+/*
     EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, t_from, t_from), BadParameter);
     EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, t_from, t_to), BadParameter);
+*/
 }
 
 TEST_F(database_tests, select_fastdds_latency)
@@ -3459,6 +3463,8 @@ TEST_F(database_tests, select_discovery_time)
     EXPECT_EQ(data_output.size(), 0u);
 }
 
+// TODO(jlbueno) This test needs to be fixed once requirement #11497 has been implemented.
+/*
 TEST_F(database_tests, select_sample_datas)
 {
     data_output.clear();
@@ -3484,6 +3490,7 @@ TEST_F(database_tests, select_sample_datas)
 
     select_test(DataKind::SAMPLE_DATAS, writer_id, samples);
 }
+*/
 
 int main(
         int argc,

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2568,22 +2568,22 @@ TEST_F(database_tests, select_invalid_timestamps)
     EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, t_from, t_from), BadParameter);
     EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, t_from, t_from),
-        BadParameter);
+            BadParameter);
     EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, t_from, t_to),
-        BadParameter);
+            BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_locator->id, t_from, t_from),
-        BadParameter);
+            BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_locator->id, t_from, t_to),
-        BadParameter);
+            BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_locator->id, t_from, t_from),
-        BadParameter);
+            BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_locator->id, t_from, t_from),
-        BadParameter);
+            BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_locator->id, t_from, t_to),
-        BadParameter);
+            BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_locator->id, t_from, t_from),
-        BadParameter);
+            BadParameter);
     EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_locator->id, t_from, t_to), BadParameter);
     EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_id, t_from, t_from), BadParameter);
     EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_id, t_from, t_to), BadParameter);
@@ -2672,7 +2672,7 @@ TEST_F(database_tests, select_network_latency)
 {
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
-        end_ts));
+            end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     NetworkLatencySample sample_1;
@@ -2693,7 +2693,7 @@ TEST_F(database_tests, select_network_latency)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
-        end_ts));
+            end_ts));
     ASSERT_GE(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityDataSample*>(data_output[1]);
@@ -2704,24 +2704,24 @@ TEST_F(database_tests, select_network_latency)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
-        mid1_ts));
+            mid1_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, mid1_ts,
-        mid2_ts));
+            mid2_ts));
     ASSERT_GE(data_output.size(), 1u);
     sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, mid2_ts,
-        mid3_ts));
+            mid3_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id,
-        sample2_ts, sample3_ts));
+            sample2_ts, sample3_ts));
     ASSERT_GE(data_output.size(), 2u);
     sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     sample2 = static_cast<const EntityDataSample*>(data_output[1]);
@@ -2730,7 +2730,7 @@ TEST_F(database_tests, select_network_latency)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, reader_locator->id, writer_locator->id, src_ts,
-        end_ts));
+            end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 }
 
@@ -2842,7 +2842,7 @@ TEST_F(database_tests, select_rtps_packets_sent)
 {
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, src_ts,
-        end_ts));
+            end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     RtpsPacketsSentSample sample_1;
@@ -2865,7 +2865,7 @@ TEST_F(database_tests, select_rtps_packets_sent)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, src_ts,
-        end_ts));
+            end_ts));
     ASSERT_GE(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
@@ -2876,24 +2876,24 @@ TEST_F(database_tests, select_rtps_packets_sent)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, src_ts,
-        mid1_ts));
+            mid1_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, mid1_ts,
-        mid2_ts));
+            mid2_ts));
     ASSERT_GE(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, mid2_ts,
-        mid3_ts));
+            mid3_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, sample2_ts,
-        sample3_ts));
+            sample3_ts));
     ASSERT_GE(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
@@ -2902,7 +2902,7 @@ TEST_F(database_tests, select_rtps_packets_sent)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_locator->id, src_ts,
-        end_ts));
+            end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 }
 
@@ -2910,7 +2910,7 @@ TEST_F(database_tests, select_rtps_bytes_sent)
 {
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, src_ts,
-        end_ts));
+            end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     RtpsBytesSentSample sample_1;
@@ -2936,7 +2936,7 @@ TEST_F(database_tests, select_rtps_bytes_sent)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, src_ts,
-        end_ts));
+            end_ts));
     ASSERT_GE(data_output.size(), 3u);
     auto sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     auto sample2 = static_cast<const ByteCountSample*>(data_output[1]);
@@ -2947,24 +2947,24 @@ TEST_F(database_tests, select_rtps_bytes_sent)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, src_ts,
-        mid1_ts));
+            mid1_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, mid1_ts,
-        mid2_ts));
+            mid2_ts));
     ASSERT_GE(data_output.size(), 1u);
     sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, mid2_ts,
-        mid3_ts));
+            mid3_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, sample2_ts,
-        sample3_ts));
+            sample3_ts));
     ASSERT_GE(data_output.size(), 2u);
     sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     sample2 = static_cast<const ByteCountSample*>(data_output[1]);
@@ -2973,7 +2973,7 @@ TEST_F(database_tests, select_rtps_bytes_sent)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_locator->id, src_ts,
-        end_ts));
+            end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 }
 
@@ -2981,7 +2981,7 @@ TEST_F(database_tests, select_rtps_packets_lost)
 {
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, src_ts,
-        end_ts));
+            end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     RtpsPacketsLostSample sample_1;
@@ -3004,7 +3004,7 @@ TEST_F(database_tests, select_rtps_packets_lost)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, src_ts,
-        end_ts));
+            end_ts));
     ASSERT_GE(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
@@ -3015,24 +3015,24 @@ TEST_F(database_tests, select_rtps_packets_lost)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, src_ts,
-        mid1_ts));
+            mid1_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, mid1_ts,
-        mid2_ts));
+            mid2_ts));
     ASSERT_GE(data_output.size(), 1u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, mid2_ts,
-        mid3_ts));
+            mid3_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, sample2_ts,
-        sample3_ts));
+            sample3_ts));
     ASSERT_GE(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);
@@ -3041,7 +3041,7 @@ TEST_F(database_tests, select_rtps_packets_lost)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_locator->id, src_ts,
-        end_ts));
+            end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 }
 
@@ -3049,7 +3049,7 @@ TEST_F(database_tests, select_rtps_bytes_lost)
 {
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, src_ts,
-        end_ts));
+            end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     RtpsBytesLostSample sample_1;
@@ -3075,7 +3075,7 @@ TEST_F(database_tests, select_rtps_bytes_lost)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, src_ts,
-        end_ts));
+            end_ts));
     ASSERT_GE(data_output.size(), 3u);
     auto sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     auto sample2 = static_cast<const ByteCountSample*>(data_output[1]);
@@ -3086,24 +3086,24 @@ TEST_F(database_tests, select_rtps_bytes_lost)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, src_ts,
-        mid1_ts));
+            mid1_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, mid1_ts,
-        mid2_ts));
+            mid2_ts));
     ASSERT_GE(data_output.size(), 1u);
     sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, mid2_ts,
-        mid3_ts));
+            mid3_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, sample2_ts,
-        sample3_ts));
+            sample3_ts));
     ASSERT_GE(data_output.size(), 2u);
     sample1 = static_cast<const ByteCountSample*>(data_output[0]);
     sample2 = static_cast<const ByteCountSample*>(data_output[1]);
@@ -3112,7 +3112,7 @@ TEST_F(database_tests, select_rtps_bytes_lost)
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_locator->id, src_ts,
-        end_ts));
+            end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 }
 
@@ -3598,8 +3598,8 @@ TEST_F(database_tests, select_discovery_time)
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::DISCOVERY_TIME, participant_id, reader_id, sample2_ts, 
-        sample3_ts));
+    ASSERT_NO_THROW(data_output = db.select(DataKind::DISCOVERY_TIME, participant_id, reader_id, sample2_ts,
+            sample3_ts));
     ASSERT_GE(data_output.size(), 2u);
     sample1 = static_cast<const DiscoveryTimeSample*>(data_output[0]);
     sample2 = static_cast<const DiscoveryTimeSample*>(data_output[1]);
@@ -3663,8 +3663,8 @@ TEST_F(database_tests, select_sample_datas)
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, sample2_ts, 
-        sample3_ts));
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, sequence_number, sample2_ts,
+            sample3_ts));
     ASSERT_GE(data_output.size(), 2u);
     sample1 = static_cast<const EntityCountSample*>(data_output[0]);
     sample2 = static_cast<const EntityCountSample*>(data_output[1]);

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2559,6 +2559,240 @@ TEST_F(database_tests, select_sample_datas_invalid_wrong_entity)
     EXPECT_THROW(db.select(DataKind::EDP_PACKETS, participant_id, sequence_number, t_from, t_to), BadParameter);
 }
 
+TEST_F(database_tests, select_invalid_entities)
+{
+#ifndef NDEBUG
+    // Test assertions
+
+    Timestamp t_from = std::chrono::system_clock::now();
+    Timestamp t_to = t_from + std::chrono::seconds(1);
+    uint64_t sequence_number = 1;
+
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, host_id, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, user_id, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, process_id, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, domain_id, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, topic_id, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, participant_id, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, reader_id, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, reader_locator->id, reader_id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, writer_id, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, writer_id, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, writer_id, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, writer_id, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, writer_id, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, writer_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, writer_id, writer_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::FASTDDS_LATENCY, writer_id, writer_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, host_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, user_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, process_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, domain_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, topic_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, participant_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, writer_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_id, reader_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, writer_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, reader_id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::PUBLICATION_THROUGHPUT, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PUBLICATION_THROUGHPUT, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PUBLICATION_THROUGHPUT, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PUBLICATION_THROUGHPUT, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PUBLICATION_THROUGHPUT, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PUBLICATION_THROUGHPUT, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PUBLICATION_THROUGHPUT, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, writer_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, writer_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, host_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, user_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, process_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, domain_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, topic_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, reader_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, writer_locator->id, reader_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, host_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, user_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, process_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, domain_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, topic_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, writer_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, reader_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, writer_locator->id, reader_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, participant_id, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, participant_id, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, participant_id, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, participant_id, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, participant_id, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, participant_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, host_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, user_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, process_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, domain_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, topic_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, reader_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, writer_locator->id, reader_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, host_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, user_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, process_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, domain_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, topic_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, writer_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, reader_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, writer_locator->id, reader_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, participant_id, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, participant_id, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, participant_id, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, participant_id, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, participant_id, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, participant_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::RESENT_DATA, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RESENT_DATA, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RESENT_DATA, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RESENT_DATA, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RESENT_DATA, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RESENT_DATA, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RESENT_DATA, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::RESENT_DATA, writer_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::HEARTBEAT_COUNT, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::HEARTBEAT_COUNT, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::HEARTBEAT_COUNT, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::HEARTBEAT_COUNT, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::HEARTBEAT_COUNT, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::HEARTBEAT_COUNT, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::HEARTBEAT_COUNT, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::HEARTBEAT_COUNT, writer_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::ACKNACK_COUNT, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::ACKNACK_COUNT, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::ACKNACK_COUNT, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::ACKNACK_COUNT, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::ACKNACK_COUNT, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::ACKNACK_COUNT, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::ACKNACK_COUNT, writer_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::ACKNACK_COUNT, writer_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::NACKFRAG_COUNT, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NACKFRAG_COUNT, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NACKFRAG_COUNT, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NACKFRAG_COUNT, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NACKFRAG_COUNT, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NACKFRAG_COUNT, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NACKFRAG_COUNT, writer_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NACKFRAG_COUNT, writer_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::GAP_COUNT, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::GAP_COUNT, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::GAP_COUNT, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::GAP_COUNT, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::GAP_COUNT, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::GAP_COUNT, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::GAP_COUNT, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::GAP_COUNT, writer_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::DATA_COUNT, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DATA_COUNT, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DATA_COUNT, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DATA_COUNT, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DATA_COUNT, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DATA_COUNT, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DATA_COUNT, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DATA_COUNT, writer_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::PDP_PACKETS, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PDP_PACKETS, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PDP_PACKETS, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PDP_PACKETS, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PDP_PACKETS, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PDP_PACKETS, writer_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PDP_PACKETS, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::PDP_PACKETS, writer_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::EDP_PACKETS, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::EDP_PACKETS, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::EDP_PACKETS, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::EDP_PACKETS, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::EDP_PACKETS, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::EDP_PACKETS, writer_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::EDP_PACKETS, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::EDP_PACKETS, writer_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, host_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, user_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, process_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, domain_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, topic_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, writer_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, reader_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, writer_locator->id, participant_id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, participant_id, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, participant_id, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, participant_id, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, participant_id, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, participant_id, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_locator->id, t_from, t_to), "");
+
+    ASSERT_DEATH(db.select(DataKind::SAMPLE_DATAS, host_id, sequence_number, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SAMPLE_DATAS, user_id, sequence_number, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SAMPLE_DATAS, process_id, sequence_number, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SAMPLE_DATAS, domain_id, sequence_number, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SAMPLE_DATAS, topic_id, sequence_number, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SAMPLE_DATAS, participant_id, sequence_number, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SAMPLE_DATAS, reader_id, sequence_number, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::SAMPLE_DATAS, writer_locator->id, sequence_number, t_from, t_to), "");
+#endif
+}
+
 TEST_F(database_tests, select_invalid_timestamps)
 {
     Timestamp t_from = std::chrono::system_clock::now();

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -3288,24 +3288,55 @@ TEST_F(database_tests, select_data_count)
 TEST_F(database_tests, select_pdp_packets)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, src_ts, end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     PdpCountSample sample_1;
     sample_1.count = 34;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_1));
     PdpCountSample sample_2;
     sample_2.count = 43;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
     PdpCountSample sample_3;
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
+    // TODO Adjust this test after merging PR which fixes resent datas
+    // resent datas stores the difference between each accumulated report and the previous one
 
-    select_test(DataKind::PDP_PACKETS, participant_id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, src_ts, end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, src_ts, mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, mid1_ts, mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, mid2_ts, mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, sample2_ts, sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 }
 
 TEST_F(database_tests, select_edp_packets)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2962,24 +2962,55 @@ TEST_F(database_tests, select_rtps_bytes_lost)
 TEST_F(database_tests, select_resent_data)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RESENT_DATA, writer_id, src_ts, end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     ResentDataSample sample_1;
     sample_1.count = 34;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_1));
     ResentDataSample sample_2;
     sample_2.count = 43;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
     ResentDataSample sample_3;
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_3));
+    // TODO Adjust this test after merging PR which fixes resent datas
+    // resent datas stores the difference between each accumulated report and the previous one
 
-    select_test(DataKind::RESENT_DATA, writer_id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RESENT_DATA, writer_id, src_ts, end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RESENT_DATA, writer_id, src_ts, mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RESENT_DATA, writer_id, mid1_ts, mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RESENT_DATA, writer_id, mid2_ts, mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RESENT_DATA, writer_id, sample2_ts, sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 }
 
 TEST_F(database_tests, select_heartbeat_count)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2982,6 +2982,98 @@ TEST_F(database_tests, select_network_latency)
     EXPECT_EQ(output.size(), 0u);
 }
 
+TEST_F(database_tests, select_publication_throughput)
+{
+    std::vector<const StatisticsSample*> output;
+    ASSERT_NO_THROW(output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, src_ts, end_ts));
+    EXPECT_EQ(output.size(), 0u);
+
+    PublicationThroughputSample sample_1;
+    sample_1.data = 15;
+    sample_1.src_ts = sample1_ts;
+    PublicationThroughputSample sample_2;
+    sample_2.data = 5;
+    sample_2.src_ts = sample2_ts;
+    PublicationThroughputSample sample_3;
+    sample_3.data = 25;
+    sample_3.src_ts = sample1_ts;
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_1));
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
+    ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_3));
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, src_ts, end_ts));
+    EXPECT_EQ(output.size(), 3u);
+    EXPECT_EQ(*output[0], static_cast<StatisticsSample>(sample_1));
+    EXPECT_EQ(*output[1], static_cast<StatisticsSample>(sample_2));
+    EXPECT_EQ(*output[2], static_cast<StatisticsSample>(sample_3));
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, src_ts, mid1_ts));
+    EXPECT_EQ(output.size(), 0u);
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, mid1_ts, mid2_ts));
+    EXPECT_EQ(output.size(), 1u);
+    EXPECT_EQ(*output[0], static_cast<StatisticsSample>(sample_1));
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, mid2_ts, mid3_ts));
+    EXPECT_EQ(output.size(), 0u);
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, sample2_ts, sample3_ts));
+    EXPECT_EQ(output.size(), 2u);
+    EXPECT_EQ(*output[0], static_cast<StatisticsSample>(sample_2));
+    EXPECT_EQ(*output[1], static_cast<StatisticsSample>(sample_3));
+}
+
+TEST_F(database_tests, select_subscription_throughput)
+{
+    std::vector<const StatisticsSample*> output;
+    ASSERT_NO_THROW(output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, src_ts, end_ts));
+    EXPECT_EQ(output.size(), 0u);
+
+    SubscriptionThroughputSample sample_1;
+    sample_1.data = 15;
+    sample_1.src_ts = sample1_ts;
+    SubscriptionThroughputSample sample_2;
+    sample_2.data = 5;
+    sample_2.src_ts = sample2_ts;
+    SubscriptionThroughputSample sample_3;
+    sample_3.data = 25;
+    sample_3.src_ts = sample1_ts;
+    ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_1));
+    ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_2));
+    ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_3));
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, src_ts, end_ts));
+    EXPECT_EQ(output.size(), 3u);
+    EXPECT_EQ(*output[0], static_cast<StatisticsSample>(sample_1));
+    EXPECT_EQ(*output[1], static_cast<StatisticsSample>(sample_2));
+    EXPECT_EQ(*output[2], static_cast<StatisticsSample>(sample_3));
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, src_ts, mid1_ts));
+    EXPECT_EQ(output.size(), 0u);
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, mid1_ts, mid2_ts));
+    EXPECT_EQ(output.size(), 1u);
+    EXPECT_EQ(*output[0], static_cast<StatisticsSample>(sample_1));
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, mid2_ts, mid3_ts));
+    EXPECT_EQ(output.size(), 0u);
+
+    output.clear();
+    ASSERT_NO_THROW(output = db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, sample2_ts, sample3_ts));
+    EXPECT_EQ(output.size(), 2u);
+    EXPECT_EQ(*output[0], static_cast<StatisticsSample>(sample_2));
+    EXPECT_EQ(*output[1], static_cast<StatisticsSample>(sample_3));
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2895,7 +2895,6 @@ TEST_F(database_tests, select_subscription_throughput)
 TEST_F(database_tests, select_rtps_packets_sent)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
@@ -2904,19 +2903,54 @@ TEST_F(database_tests, select_rtps_packets_sent)
     sample_1.remote_locator = writer_locator->id;
     sample_1.count = 15;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_1));
     RtpsPacketsSentSample sample_2;
     sample_2.remote_locator = writer_locator->id;
     sample_2.count = 35;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
     RtpsPacketsSentSample sample_3;
     sample_3.remote_locator = writer_locator->id;
     sample_3.count = 70;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
 
-    select_test(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, src_ts,
+        end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, src_ts,
+        mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, mid1_ts,
+        mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, mid2_ts,
+        mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, sample2_ts,
+        sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_SENT, participant_id, reader_locator->id, src_ts,

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2961,7 +2961,6 @@ TEST_F(database_tests, select_rtps_packets_sent)
 TEST_F(database_tests, select_rtps_bytes_sent)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
@@ -2971,21 +2970,56 @@ TEST_F(database_tests, select_rtps_bytes_sent)
     sample_1.count = 15;
     sample_1.magnitude_order = 2;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_1));
     RtpsBytesSentSample sample_2;
     sample_2.remote_locator = writer_locator->id;
     sample_2.count = 5;
     sample_2.magnitude_order = 3;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
     RtpsBytesSentSample sample_3;
     sample_3.remote_locator = writer_locator->id;
     sample_3.count = 25;
     sample_3.magnitude_order = 3;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
 
-    select_test(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, src_ts,
+        end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const ByteCountSample*>(data_output[0]);
+    auto sample2 = static_cast<const ByteCountSample*>(data_output[1]);
+    auto sample3 = static_cast<const ByteCountSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, src_ts,
+        mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, mid1_ts,
+        mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const ByteCountSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, mid2_ts,
+        mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, sample2_ts,
+        sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const ByteCountSample*>(data_output[0]);
+    sample2 = static_cast<const ByteCountSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_SENT, participant_id, reader_locator->id, src_ts,
@@ -2996,7 +3030,6 @@ TEST_F(database_tests, select_rtps_bytes_sent)
 TEST_F(database_tests, select_rtps_packets_lost)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
@@ -3005,19 +3038,54 @@ TEST_F(database_tests, select_rtps_packets_lost)
     sample_1.remote_locator = writer_locator->id;
     sample_1.count = 15;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_1));
     RtpsPacketsLostSample sample_2;
     sample_2.remote_locator = writer_locator->id;
     sample_2.count = 5;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
     RtpsPacketsLostSample sample_3;
     sample_3.remote_locator = writer_locator->id;
     sample_3.count = 25;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
 
-    select_test(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, src_ts,
+        end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, src_ts,
+        mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, mid1_ts,
+        mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, mid2_ts,
+        mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, sample2_ts,
+        sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_PACKETS_LOST, participant_id, reader_locator->id, src_ts,
@@ -3028,31 +3096,65 @@ TEST_F(database_tests, select_rtps_packets_lost)
 TEST_F(database_tests, select_rtps_bytes_lost)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, src_ts,
         end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
-    RtpsBytesSentSample sample_1;
+    RtpsBytesLostSample sample_1;
     sample_1.remote_locator = writer_locator->id;
     sample_1.count = 15;
     sample_1.magnitude_order = 1;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
-    RtpsBytesSentSample sample_2;
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_1));
+    RtpsBytesLostSample sample_2;
     sample_2.remote_locator = writer_locator->id;
     sample_2.count = 5;
     sample_2.magnitude_order = 2;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
-    RtpsBytesSentSample sample_3;
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
+    RtpsBytesLostSample sample_3;
     sample_3.remote_locator = writer_locator->id;
     sample_3.count = 25;
     sample_3.magnitude_order = 3;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
 
-    select_test(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, src_ts,
+        end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const ByteCountSample*>(data_output[0]);
+    auto sample2 = static_cast<const ByteCountSample*>(data_output[1]);
+    auto sample3 = static_cast<const ByteCountSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, src_ts,
+        mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, mid1_ts,
+        mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const ByteCountSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, mid2_ts,
+        mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, sample2_ts,
+        sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const ByteCountSample*>(data_output[0]);
+    sample2 = static_cast<const ByteCountSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 
     data_output.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::RTPS_BYTES_LOST, participant_id, reader_locator->id, src_ts,

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -3195,6 +3195,253 @@ TEST_F(database_tests, select_rtps_bytes_lost)
     EXPECT_EQ(data_output.size(), 0u);
 }
 
+TEST_F(database_tests, select_resent_data)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::RESENT_DATA, writer_id, src_ts, end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    ResentDataSample sample_1;
+    sample_1.count = 34;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    ResentDataSample sample_2;
+    sample_2.count = 43;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    ResentDataSample sample_3;
+    sample_3.count = 44;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::RESENT_DATA, writer_id, samples);
+}
+
+TEST_F(database_tests, select_heartbeat_count)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::HEARTBEAT_COUNT, writer_id, src_ts, end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    HeartbeatCountSample sample_1;
+    sample_1.count = 34;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    HeartbeatCountSample sample_2;
+    sample_2.count = 43;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    HeartbeatCountSample sample_3;
+    sample_3.count = 44;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::HEARTBEAT_COUNT, writer_id, samples);
+}
+
+TEST_F(database_tests, select_acknack_count)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::ACKNACK_COUNT, reader_id, src_ts, end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    AcknackCountSample sample_1;
+    sample_1.count = 34;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    AcknackCountSample sample_2;
+    sample_2.count = 43;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    AcknackCountSample sample_3;
+    sample_3.count = 44;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::ACKNACK_COUNT, reader_id, samples);
+}
+
+TEST_F(database_tests, select_nackfrag_count)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NACKFRAG_COUNT, reader_id, src_ts, end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    NackfragCountSample sample_1;
+    sample_1.count = 34;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    NackfragCountSample sample_2;
+    sample_2.count = 43;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    NackfragCountSample sample_3;
+    sample_3.count = 44;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::NACKFRAG_COUNT, reader_id, samples);
+}
+
+TEST_F(database_tests, select_gap_count)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::GAP_COUNT, writer_id, src_ts, end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    GapCountSample sample_1;
+    sample_1.count = 34;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    GapCountSample sample_2;
+    sample_2.count = 43;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    GapCountSample sample_3;
+    sample_3.count = 44;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::GAP_COUNT, writer_id, samples);
+}
+
+TEST_F(database_tests, select_data_count)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::DATA_COUNT, writer_id, src_ts, end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    DataCountSample sample_1;
+    sample_1.count = 34;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    DataCountSample sample_2;
+    sample_2.count = 43;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    DataCountSample sample_3;
+    sample_3.count = 44;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::DATA_COUNT, writer_id, samples);
+}
+
+TEST_F(database_tests, select_pdp_packets)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::PDP_PACKETS, participant_id, src_ts, end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    PdpCountSample sample_1;
+    sample_1.count = 34;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    PdpCountSample sample_2;
+    sample_2.count = 43;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    PdpCountSample sample_3;
+    sample_3.count = 44;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::PDP_PACKETS, participant_id, samples);
+}
+
+TEST_F(database_tests, select_edp_packets)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::EDP_PACKETS, participant_id, src_ts, end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    EdpCountSample sample_1;
+    sample_1.count = 34;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    EdpCountSample sample_2;
+    sample_2.count = 43;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    EdpCountSample sample_3;
+    sample_3.count = 44;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::EDP_PACKETS, participant_id, samples);
+}
+
+TEST_F(database_tests, select_discovery_time)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::DISCOVERY_TIME, participant_id, reader_id, src_ts, end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    DiscoveryTimeSample sample_1;
+    sample_1.remote_entity = reader_id;
+    sample_1.time = std::chrono::system_clock::now();
+    sample_1.discovered = true;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    DiscoveryTimeSample sample_2;
+    sample_2.remote_entity = reader_id;
+    sample_2.time = std::chrono::system_clock::now() + std::chrono::seconds(1);
+    sample_2.discovered = false;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    DiscoveryTimeSample sample_3;
+    sample_3.remote_entity = reader_id;
+    sample_3.time = std::chrono::system_clock::now() + std::chrono::seconds(17);
+    sample_3.discovered = true;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::DISCOVERY_TIME, participant_id, reader_id, samples);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::DISCOVERY_TIME, participant_id, participant_id, src_ts, end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::DISCOVERY_TIME, participant_id, writer_id, src_ts, end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+}
+
+TEST_F(database_tests, select_sample_datas)
+{
+    data_output.clear();
+    samples.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::SAMPLE_DATAS, writer_id, src_ts, end_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    SampleDatasCountSample sample_1;
+    sample_1.count = 34;
+    sample_1.sequence_number = 2;
+    sample_1.src_ts = sample1_ts;
+    samples.push_back(sample_1);
+    SampleDatasCountSample sample_2;
+    sample_2.count = 15;
+    sample_2.sequence_number = 1;
+    sample_2.src_ts = sample2_ts;
+    samples.push_back(sample_2);
+    SampleDatasCountSample sample_3;
+    sample_3.count = 44;
+    sample_3.sequence_number = 2;
+    sample_3.src_ts = sample3_ts;
+    samples.push_back(sample_3);
+
+    select_test(DataKind::SAMPLE_DATAS, writer_id, samples);
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2494,52 +2494,334 @@ TEST_F(database_tests, get_entity_kind)
 
 TEST_F(database_tests, select_single_entity_invalid_needs_two_entities)
 {
-    Timestamp src_timestamp = std::chrono::system_clock::now();
-    Timestamp dst_timestamp = src_timestamp + std::chrono::seconds(1);
+    Timestamp t_from = std::chrono::system_clock::now();
+    Timestamp t_to = t_from + std::chrono::seconds(1);
 
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, src_timestamp, dst_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, src_timestamp, dst_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, src_timestamp, dst_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, src_timestamp, dst_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, src_timestamp, dst_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, src_timestamp, dst_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, src_timestamp, dst_timestamp), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, t_from, t_to), BadParameter);
 }
 
 TEST_F(database_tests, select_double_entity_invalid_needs_one_entity)
 {
-    Timestamp src_timestamp = std::chrono::system_clock::now();
-    Timestamp dst_timestamp = src_timestamp + std::chrono::seconds(1);
+    Timestamp t_from = std::chrono::system_clock::now();
+    Timestamp t_to = t_from + std::chrono::seconds(1);
 
-    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, reader_id, src_timestamp, dst_timestamp),
-        BadParameter);
-    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, writer_id, src_timestamp, dst_timestamp),
-        BadParameter);
-    EXPECT_THROW(db.select(DataKind::RESENT_DATA, writer_id, reader_id, src_timestamp, dst_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, writer_id, reader_id, src_timestamp, dst_timestamp),
-        BadParameter);
-    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, reader_id, writer_id, src_timestamp, dst_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, reader_id, writer_id, src_timestamp, dst_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::GAP_COUNT, writer_id, reader_id, src_timestamp, dst_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::DATA_COUNT, writer_id, reader_id, src_timestamp, dst_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, participant_id, writer_id, src_timestamp, dst_timestamp),
-        BadParameter);
-    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, participant_id, writer_id, src_timestamp, dst_timestamp),
-        BadParameter);
-    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, reader_id, src_timestamp, dst_timestamp), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, reader_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, reader_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, participant_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, participant_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, reader_id, t_from, t_to), BadParameter);
 }
 
 TEST_F(database_tests, select_invalid_timestamps)
 {
-    Timestamp src_timestamp = std::chrono::system_clock::now();
-    Timestamp dst_timestamp = src_timestamp - std::chrono::nanoseconds(1);
+    Timestamp t_from = std::chrono::system_clock::now();
+    Timestamp t_to = t_from - std::chrono::nanoseconds(1);
 
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, src_timestamp, src_timestamp),
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, t_from, t_from),
         BadParameter);
-    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, src_timestamp, dst_timestamp),
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, t_from, t_to),
         BadParameter);
-    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, src_timestamp, src_timestamp), BadParameter);
-    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, src_timestamp, dst_timestamp), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, reader_locator->id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, reader_locator->id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, reader_locator->id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, reader_locator->id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, reader_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_id, t_from, t_to), BadParameter);
+
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, writer_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, writer_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, reader_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, reader_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, writer_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, writer_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, participant_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, participant_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, t_from, t_from), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, t_from, t_to), BadParameter);
+}
+
+TEST_F(database_tests, select_invalid_entity_ids)
+{
+    Timestamp t_from = std::chrono::system_clock::now();
+    Timestamp t_to = t_from + std::chrono::seconds(1);
+
+    EXPECT_NO_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, reader_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, host_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, user_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, process_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, domain_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, topic_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, participant_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, reader_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, writer_locator->id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::FASTDDS_LATENCY, reader_id, writer_id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, t_from, t_to));
+    EXPECT_NO_THROW(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, writer_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, writer_locator->id, t_from, t_to),
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, host_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, user_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, process_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, domain_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, topic_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, participant_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, writer_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NETWORK_LATENCY, reader_id, writer_locator->id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PUBLICATION_THROUGHPUT, writer_locator->id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, reader_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SUBSCRIPTION_THROUGHPUT, writer_locator->id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, writer_locator->id, t_from, t_to));
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, reader_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, host_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, user_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, process_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, domain_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, topic_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, participant_id, writer_locator->id, t_from, t_to),
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, reader_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, reader_locator->id, writer_locator->id, t_from, t_to),
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_SENT, reader_locator->id, writer_id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, writer_locator->id, t_from, t_to));
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, reader_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, host_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, user_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, process_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, domain_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, topic_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, participant_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, reader_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, reader_locator->id, writer_locator->id, t_from, t_to),
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_SENT, reader_locator->id, writer_id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, writer_locator->id, t_from, t_to));
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, reader_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, host_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, user_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, process_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, domain_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, topic_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, participant_id, writer_locator->id, t_from, t_to),
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, reader_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, reader_locator->id, writer_locator->id, t_from, t_to),
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_PACKETS_LOST, reader_locator->id, writer_id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, writer_locator->id, t_from, t_to));
+    EXPECT_NO_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, reader_locator->id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, writer_id, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, host_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, user_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, process_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, domain_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, topic_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, participant_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, reader_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, reader_locator->id, writer_locator->id, t_from, t_to), 
+        BadParameter);
+    EXPECT_THROW(db.select(DataKind::RTPS_BYTES_LOST, reader_locator->id, writer_id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::RESENT_DATA, writer_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::RESENT_DATA, writer_locator->id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::HEARTBEAT_COUNT, writer_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::HEARTBEAT_COUNT, writer_locator->id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::ACKNACK_COUNT, reader_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::ACKNACK_COUNT, writer_locator->id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::NACKFRAG_COUNT, reader_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::NACKFRAG_COUNT, writer_locator->id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::GAP_COUNT, writer_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::GAP_COUNT, writer_locator->id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::DATA_COUNT, writer_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DATA_COUNT, writer_locator->id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::PDP_PACKETS, participant_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::PDP_PACKETS, writer_locator->id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::EDP_PACKETS, participant_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, writer_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::EDP_PACKETS, writer_locator->id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, participant_id, t_from, t_to));
+    EXPECT_NO_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_id, t_from, t_to));
+    EXPECT_NO_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, reader_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, participant_id, writer_locator->id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, writer_id, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::DISCOVERY_TIME, reader_id, participant_id, t_from, t_to), BadParameter);
+
+    EXPECT_NO_THROW(db.select(DataKind::SAMPLE_DATAS, writer_id, t_from, t_to));
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, host_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, user_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, process_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, domain_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, topic_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, participant_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, reader_id, t_from, t_to), BadParameter);
+    EXPECT_THROW(db.select(DataKind::SAMPLE_DATAS, writer_locator->id, t_from, t_to), BadParameter);
 }
 
 int main(

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -3125,24 +3125,55 @@ TEST_F(database_tests, select_acknack_count)
 TEST_F(database_tests, select_nackfrag_count)
 {
     data_output.clear();
-    samples.clear();
     ASSERT_NO_THROW(data_output = db.select(DataKind::NACKFRAG_COUNT, reader_id, src_ts, end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     NackfragCountSample sample_1;
     sample_1.count = 34;
     sample_1.src_ts = sample1_ts;
-    samples.push_back(sample_1);
+    ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_1));
     NackfragCountSample sample_2;
     sample_2.count = 43;
     sample_2.src_ts = sample2_ts;
-    samples.push_back(sample_2);
+    ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_2));
     NackfragCountSample sample_3;
     sample_3.count = 44;
     sample_3.src_ts = sample3_ts;
-    samples.push_back(sample_3);
+    ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_3));
+    // TODO Adjust this test after merging PR which fixes nackfrag count
+    // nackfrag count stores the difference between each accumulated report and the previous one
 
-    select_test(DataKind::NACKFRAG_COUNT, reader_id, samples);
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NACKFRAG_COUNT, reader_id, src_ts, end_ts));
+    ASSERT_GE(data_output.size(), 3u);
+    auto sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    auto sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    auto sample3 = static_cast<const EntityCountSample*>(data_output[2]);
+    EXPECT_EQ(*sample1, sample_1);
+    EXPECT_EQ(*sample2, sample_2);
+    EXPECT_EQ(*sample3, sample_3);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NACKFRAG_COUNT, reader_id, src_ts, mid1_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NACKFRAG_COUNT, reader_id, mid1_ts, mid2_ts));
+    ASSERT_GE(data_output.size(), 1u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    EXPECT_EQ(*sample1, sample_1);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NACKFRAG_COUNT, reader_id, mid2_ts, mid3_ts));
+    EXPECT_EQ(data_output.size(), 0u);
+
+    data_output.clear();
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NACKFRAG_COUNT, reader_id, sample2_ts, sample3_ts));
+    ASSERT_GE(data_output.size(), 2u);
+    sample1 = static_cast<const EntityCountSample*>(data_output[0]);
+    sample2 = static_cast<const EntityCountSample*>(data_output[1]);
+    EXPECT_EQ(*sample1, sample_2);
+    EXPECT_EQ(*sample2, sample_3);
 }
 
 TEST_F(database_tests, select_gap_count)


### PR DESCRIPTION
This PR implements and tests the database select methods. It also adds a new overload to the select method to account for the `SAMPLE_DATAS` samples. It modifies the `sample_datas` and `discovered_entity` vectors so they inherit from `StatisticsSample` so the select method can return the pointers to their samples.