### PR TITLE
Create locator entities without association to other entities [11705]

### DIFF
--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -796,7 +796,7 @@ void Database::link_endpoint_with_locator(
         }
         if (dw_exists)
         {
-            endpoint = dw_it->second;    
+            endpoint = dw_it->second;
         }
         else
         {
@@ -819,7 +819,8 @@ void Database::link_endpoint_with_locator(
             }
             else
             {
-                throw BadParameter("EntityId " + std::to_string(endpoint_id.value()) + " does not identify a known endpoint");
+                throw BadParameter("EntityId " + std::to_string(
+                                  endpoint_id.value()) + " does not identify a known endpoint");
             }
         }
     }
@@ -836,7 +837,7 @@ void Database::link_endpoint_with_locator(
     auto locator = locator_it->second;
 
     // Add endpoint to locator's collection
-    if(endpoint->kind == EntityKind::DATAWRITER)
+    if (endpoint->kind == EntityKind::DATAWRITER)
     {
         locator->data_writers[endpoint->id] = std::dynamic_pointer_cast<DataWriter> (endpoint);
     }
@@ -2009,22 +2010,6 @@ template<>
 std::map<EntityId, std::map<EntityId, std::shared_ptr<DataWriter>>>& Database::dds_endpoints<DataWriter>()
 {
     return datawriters_;
-}
-
-template<>
-void Database::insert_ddsendpoint_to_locator(
-        std::shared_ptr<DataWriter>& endpoint,
-        std::shared_ptr<Locator>& locator)
-{
-    locator->data_writers[endpoint->id] = endpoint;
-}
-
-template<>
-void Database::insert_ddsendpoint_to_locator(
-        std::shared_ptr<DataReader>& endpoint,
-        std::shared_ptr<Locator>& locator)
-{
-    locator->data_readers[endpoint->id] = endpoint;
 }
 
 DatabaseDump Database::dump_database()

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -356,6 +356,37 @@ EntityId Database::insert(
             auto data_writer = std::static_pointer_cast<DataWriter>(entity);
             return insert_ddsendpoint<DataWriter>(data_writer);
         }
+        case EntityKind::LOCATOR:
+        {
+            std::shared_ptr<Locator> locator = std::static_pointer_cast<Locator>(entity);
+
+            /* Check that locator name is not empty */
+            if (locator->name.empty())
+            {
+                throw BadParameter("Locator name cannot be empty");
+            }
+
+            /* Check that this is indeed a new locator, and that its name is unique */
+            for (auto locator_it: locators_)
+            {
+                if (locator.get() == locator_it.second.get())
+                {
+                    throw BadParameter("Locator already exists in the database");
+                }
+                if (locator->name == locator_it.second->name)
+                {
+                    throw BadParameter("Locator with name " + locator->name + " already exists in the database");
+                }
+            }
+
+            /* Insert locator in the database */
+            locator->data_readers.clear();
+            locator->data_writers.clear();
+            locator->data.clear();
+            locator->id = generate_entity_id();
+            locators_[locator->id] = locator;
+            return locator->id;
+        }
         default:
         {
             break;
@@ -740,6 +771,88 @@ void Database::link_participant_with_process(
 
     /* Add entry to processes_by_domain_ */
     processes_by_domain_[domain_id][process_it->first] = process_it->second;
+}
+
+void Database::link_endpoint_with_locator(
+        const EntityId& endpoint_id,
+        const EntityId& locator_id)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+
+    /* Get the endpoint */
+    std::shared_ptr<DDSEndpoint> endpoint;
+    {
+        /* Get the Datawriter */
+        std::map<EntityId, std::shared_ptr<DataWriter>>::iterator dw_it;
+        bool dw_exists = false;
+        for (auto domain_it : datawriters_)
+        {
+            dw_it = domain_it.second.find(endpoint_id);
+            if (dw_it != domain_it.second.end())
+            {
+                dw_exists = true;
+                break;
+            }
+        }
+        if (dw_exists)
+        {
+            endpoint = dw_it->second;    
+        }
+        else
+        {
+            /* Get the Datareader */
+            std::map<EntityId, std::shared_ptr<DataReader>>::iterator dr_it;
+            bool dr_exists = false;
+            for (auto domain_it : datareaders_)
+            {
+                dr_it = domain_it.second.find(endpoint_id);
+                if (dr_it != domain_it.second.end())
+                {
+                    dr_exists = true;
+                    break;
+                }
+            }
+
+            if (dr_exists)
+            {
+                endpoint = dr_it->second;
+            }
+            else
+            {
+                throw BadParameter("EntityId " + std::to_string(endpoint_id.value()) + " does not identify a known endpoint");
+            }
+        }
+    }
+
+    /* Get the locator */
+    auto locator_it = locators_.find(locator_id);
+    if (locator_it == locators_.end())
+    {
+        throw BadParameter("EntityId " + std::to_string(locator_id.value()) + " does not identify a known locator");
+    }
+
+    // Not storing the std::shared_ptr<Locator> in a local variable results in the locator->second
+    // being moved when inserting it into the map. This causes a SEGFAULT later on when accessing to it.
+    auto locator = locator_it->second;
+
+    // Add endpoint to locator's collection
+    if(endpoint->kind == EntityKind::DATAWRITER)
+    {
+        locator->data_writers[endpoint->id] = std::dynamic_pointer_cast<DataWriter> (endpoint);
+    }
+    else // Datareader
+    {
+        locator->data_readers[endpoint->id] = std::dynamic_pointer_cast<DataReader> (endpoint);
+    }
+
+    // Add locator to endpoint's collection
+    endpoint->locators[locator_id] = locator;
+
+    // Add reader's locators to locators_by_participant_
+    locators_by_participant_[endpoint->participant->id][locator_id] = locator;
+
+    // Add reader's participant to participants_by_locator_
+    participants_by_locator_[locator_id][endpoint->participant->id] = endpoint->participant;
 }
 
 const std::shared_ptr<const Entity> Database::get_entity(

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -791,14 +791,11 @@ void Database::link_endpoint_with_locator(
             if (dw_it != domain_it.second.end())
             {
                 dw_exists = true;
+                endpoint = dw_it->second;
                 break;
             }
         }
-        if (dw_exists)
-        {
-            endpoint = dw_it->second;
-        }
-        else
+        if (!dw_exists)
         {
             /* Get the Datareader */
             std::map<EntityId, std::shared_ptr<DataReader>>::iterator dr_it;
@@ -809,15 +806,12 @@ void Database::link_endpoint_with_locator(
                 if (dr_it != domain_it.second.end())
                 {
                     dr_exists = true;
+                    endpoint = dr_it->second;
                     break;
                 }
             }
 
-            if (dr_exists)
-            {
-                endpoint = dr_it->second;
-            }
-            else
+            if (!dr_exists)
             {
                 throw BadParameter("EntityId " + std::to_string(
                                   endpoint_id.value()) + " does not identify a known endpoint");

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -87,7 +87,7 @@ public:
             const EntityId& participant_id,
             const EntityId& process_id);
 
-	/**
+    /**
      * @brief Create the link between a endpoint and a locator
      *
      * This operation entails:
@@ -355,19 +355,6 @@ protected:
             const std::shared_ptr<const Entity>& entity) const;
 
     /**
-     * @brief Auxiliar function for boilerplate code to update a Locator with either a DataReader or a DataWriter using it
-     *
-     * @tparam T The DDSEndpoint to add to the Locator list. Only DDSEndpoint and its derived classes are allowed.
-     * @param endpoint The endpoint of type T to add to the list of the locator
-     * @param locator The locator that will be updated with endpoint
-     * @return The EntityId of the inserted DDSEndpoint
-     */
-    template<typename T>
-    void insert_ddsendpoint_to_locator(
-            std::shared_ptr<T>& endpoint,
-            std::shared_ptr<Locator>& locator);
-
-    /**
      * @brief Auxiliar function for boilerplate code to insert either a DataReader or a DataWriter
      *
      * @tparam T The DDSEndpoint to insert. Only DDSEndpoint and its derived classes are allowed.
@@ -577,17 +564,6 @@ protected:
     //! Read-write synchronization mutex
     mutable std::shared_timed_mutex mutex_;
 };
-
-template<>
-void Database::insert_ddsendpoint_to_locator(
-        std::shared_ptr<DataWriter>& endpoint,
-        std::shared_ptr<Locator>& locator);
-
-template<>
-void Database::insert_ddsendpoint_to_locator(
-        std::shared_ptr<DataReader>& endpoint,
-        std::shared_ptr<Locator>& locator);
-
 
 } //namespace database
 } //namespace statistics_backend

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -88,7 +88,7 @@ public:
             const EntityId& process_id);
 
     /**
-     * @brief Create the link between a endpoint and a locator
+     * @brief Create the link between an endpoint and a locator
      *
      * This operation entails:
      *     1. Adding the endpoint to the locator's list of endpoints
@@ -432,16 +432,17 @@ protected:
             }
         }
 
-        /* Add endpoint to participant' collection */
+        /* Insert endpoint in the database */
+        endpoint->data.clear();
         endpoint->id = generate_entity_id();
+        dds_endpoints<T>()[endpoint->participant->domain->id][endpoint->id] = endpoint;
+
+        /* Add endpoint to participant' collection */
         (*(endpoint->participant)).template ddsendpoints<T>()[endpoint->id] = endpoint;
 
         /* Add endpoint to topics's collection */
-        endpoint->data.clear();
         (*(endpoint->topic)).template ddsendpoints<T>()[endpoint->id] = endpoint;
 
-        /* Insert endpoint in the database */
-        dds_endpoints<T>()[endpoint->participant->domain->id][endpoint->id] = endpoint;
         return endpoint->id;
     }
 

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -87,6 +87,25 @@ public:
             const EntityId& participant_id,
             const EntityId& process_id);
 
+	/**
+     * @brief Create the link between a endpoint and a locator
+     *
+     * This operation entails:
+     *     1. Adding the endpoint to the locator's list of endpoints
+     *     2. Adding the locator to the endpoint's list of locators
+     *     3. Adding entry to locators_by_participant_
+     *     4. Adding entry to participants_by_locator_
+     *
+     * @param endpoint_id The EntityId of the endpoint
+     * @param locator_id The EntityId of the locator
+     * @throw eprosima::statistics_backend::BadParameter in the following cases:
+     *            * The endpoint does not exist in the database
+     *            * The locator does not exist in the database
+     */
+    void link_endpoint_with_locator(
+            const EntityId& endpoint_id,
+            const EntityId& locator_id);
+
     /**
      * @brief Erase all the data related to a domain
      *
@@ -377,12 +396,6 @@ protected:
             throw BadParameter("Endpoint GUID cannot be empty");
         }
 
-        /* Check that locators is not empty */
-        if (endpoint->locators.empty())
-        {
-            throw BadParameter("Endpoint locators cannot be empty");
-        }
-
         /* Check that participant exits */
         bool participant_exists = false;
         for (auto participant_it : participants_[endpoint->participant->domain->id])
@@ -435,19 +448,6 @@ protected:
         /* Add endpoint to participant' collection */
         endpoint->id = generate_entity_id();
         (*(endpoint->participant)).template ddsendpoints<T>()[endpoint->id] = endpoint;
-
-        /* Add to x_by_y_ collections and to locators_ */
-        for (auto locator_it : endpoint->locators)
-        {
-            // Add locator to locators_
-            locators_[locator_it.first] = locator_it.second;
-            // Add reader's locators to locators_by_participant_
-            locators_by_participant_[endpoint->participant->id][locator_it.first] = locator_it.second;
-            // Add reader's participant to participants_by_locator_
-            participants_by_locator_[locator_it.first][endpoint->participant->id] = endpoint->participant;
-            // Add endpoint to locator's collection
-            insert_ddsendpoint_to_locator(endpoint, locator_it.second);
-        }
 
         /* Add endpoint to topics's collection */
         endpoint->data.clear();

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -172,11 +172,20 @@ set(DATABASE_TEST_LIST
     # Insert invalid
     insert_invalid
     insert_locator
+    insert_locator_two
+    insert_locator_two_same_name
+    insert_locator_duplicated
+    insert_locator_empty_name
     # Link participant with process
     link_participant_with_process_unlinked
     link_participant_with_process_wrong_participant
     link_participant_with_process_wrong_process
     link_participant_with_process_linked_participant
+    # Link endpoint with locator
+    link_endpoint_with_locator_unlinked
+    link_endpoint_with_locator_wrong_endpoint
+    link_endpoint_with_locator_wrong_locator
+    link_endpoint_with_locator_two_valid
     # Insert samples
     insert_sample_history_latency
     insert_sample_history_latency_wrong_entity

--- a/test/unittest/Database/DatabaseDumpTests.cpp
+++ b/test/unittest/Database/DatabaseDumpTests.cpp
@@ -136,11 +136,7 @@ void initialize_empty_entities(
                         DATAREADER_DEFAULT_NAME(index)), QOS_DEFAULT, GUID_DEFAULT(index), participant, topic);
     std::shared_ptr<Locator> locator = std::make_shared<Locator>(std::string(LOCATOR_DEFAULT_NAME(index)));
 
-    locator->id = db.generate_entity_id();
-
-    dw->locators[locator->id] = locator;
-    dr->locators[locator->id] = locator;
-
+    ASSERT_NE(db.insert(locator), EntityId::invalid());
     ASSERT_NE(db.insert(host), EntityId::invalid());
     ASSERT_NE(db.insert(user), EntityId::invalid());
     ASSERT_NE(db.insert(process), EntityId::invalid());
@@ -151,9 +147,8 @@ void initialize_empty_entities(
     ASSERT_NE(db.insert(dr), EntityId::invalid());
 
     db.link_participant_with_process(participant->id, process->id);
-
-    locator->data_writers[dw->id] = dw;
-    locator->data_readers[dr->id] = dr;
+    db.link_endpoint_with_locator(dw->id, locator->id);
+    db.link_endpoint_with_locator(dr->id, locator->id);
 }
 
 void initialize_database(

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -45,7 +45,7 @@ void insert_ddsendpoint_valid()
     auto domain_id = db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
-    auto participant_id = db.insert(participant);
+    db.insert(participant);
     auto topic = std::make_shared<Topic>("test_topic_name", "test_topic_type", domain);
     db.insert(topic);
 
@@ -54,11 +54,7 @@ void insert_ddsendpoint_valid()
     std::string endpoint_guid = "test_guid";
     auto endpoint = std::make_shared<T>(
         endpoint_name, db.test_qos, endpoint_guid, participant, topic);
-    // Create a locator for the endpoint
-    auto locator = std::make_shared<Locator>("test_locator");
-    auto locator_id = db.insert(locator);
     auto endpoint_id = db.insert(endpoint);
-    db.link_endpoint_with_locator(endpoint_id, locator_id);
 
     /* Check that the endpoint is correctly inserted in participant */
     ASSERT_EQ(participant->ddsendpoints<T>().size(), 1);
@@ -67,28 +63,6 @@ void insert_ddsendpoint_valid()
     /* Check that the endpoint is correctly inserted in topic */
     ASSERT_EQ(topic->ddsendpoints<T>().size(), 1);
     ASSERT_EQ(topic->ddsendpoints<T>()[endpoint_id].get(), endpoint.get());
-
-    /* Check x_by_y_ collections and locators_ */
-    auto locators = db.locators();
-    auto locators_by_participant = db.locators_by_participant();
-    auto participants_by_locator = db.participants_by_locator();
-    ASSERT_EQ(locators_by_participant[participant_id].size(), endpoint->locators.size());
-    ASSERT_EQ(participants_by_locator[locator->id].size(), endpoint->locators.size());
-    for (auto locator_it : endpoint->locators)
-    {
-        // Check that the endpoint's locators are correctly inserted in locators_
-        ASSERT_NE(
-            locators.find(locator_it.first),
-            locators.end());
-        // Check that the endpoint's locators are correctly inserted in locators_by_participant_
-        ASSERT_NE(
-            locators_by_participant[participant_id].find(locator_it.first),
-            locators_by_participant[participant_id].end());
-        // Check that the endpoint's participant is correctly inserted in participants_by_locator_
-        ASSERT_NE(
-            participants_by_locator[locator_it.first].find(participant_id),
-            participants_by_locator[locator_it.first].end());
-    }
 
     /* Check that the ddsendpoint is inserted correctly inserted in the endpoints_<T> collection */
     auto endpoints = db.get_dds_endpoints<T>();
@@ -115,7 +89,7 @@ void insert_ddsendpoint_two_valid()
     auto domain_id = db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
-    auto participant_id = db.insert(participant);
+    db.insert(participant);
     auto topic = std::make_shared<Topic>("test_topic_name", "test_topic_type", domain);
     db.insert(topic);
 
@@ -124,19 +98,13 @@ void insert_ddsendpoint_two_valid()
     std::string endpoint_guid = "test_guid";
     auto endpoint = std::make_shared<T>(
         endpoint_name, db.test_qos, endpoint_guid, participant, topic);
-    auto locator = std::make_shared<Locator>("test_locator");
-    auto locator_id = db.insert(locator);
     auto endpoint_id = db.insert(endpoint);
-    db.link_endpoint_with_locator(endpoint_id, locator_id);
 
     std::string endpoint_name_2 = "test_endpoint_2";
     std::string endpoint_guid_2 = "test_guid_2";
     auto endpoint_2 = std::make_shared<T>(
         endpoint_name_2, db.test_qos, endpoint_guid_2, participant, topic);
-    auto locator_2 = std::make_shared<Locator>("test_locator_2");
-    auto locator_id_2 = db.insert(locator_2);
     auto endpoint_id_2 = db.insert(endpoint_2);
-    db.link_endpoint_with_locator(endpoint_id_2, locator_id_2);
 
     /* Check that the endpoints are correctly inserted in participant */
     ASSERT_EQ(participant->ddsendpoints<T>().size(), 2);
@@ -147,45 +115,6 @@ void insert_ddsendpoint_two_valid()
     ASSERT_EQ(topic->ddsendpoints<T>().size(), 2);
     ASSERT_EQ(topic->ddsendpoints<T>()[endpoint_id].get(), endpoint.get());
     ASSERT_EQ(topic->ddsendpoints<T>()[endpoint_id_2].get(), endpoint_2.get());
-
-    /* Check x_by_y_ collections and locators_ */
-    auto locators = db.locators();
-    auto locators_by_participant = db.locators_by_participant();
-    auto participants_by_locator = db.participants_by_locator();
-    ASSERT_EQ(locators_by_participant[participant_id].size(), endpoint->locators.size() * 2);
-    ASSERT_EQ(participants_by_locator[locator->id].size(), endpoint->locators.size());
-    ASSERT_EQ(participants_by_locator[locator_2->id].size(), endpoint_2->locators.size());
-    for (auto locator_it : endpoint->locators)
-    {
-        // Check that the endpoint's locators are correctly inserted in locators_
-        ASSERT_NE(
-            locators.find(locator_it.first),
-            locators.end());
-        // Check that the endpoint's locators are correctly inserted in locators_by_participant_
-        ASSERT_NE(
-            locators_by_participant[participant_id].find(locator_it.first),
-            locators_by_participant[participant_id].end());
-        // Check that the endpoint's participant is correctly inserted in participants_by_locator_
-        ASSERT_NE(
-            participants_by_locator[locator_it.first].find(participant_id),
-            participants_by_locator[locator_it.first].end());
-    }
-
-    for (auto locator_it : endpoint_2->locators)
-    {
-        // Check that the endpoint's locators are correctly inserted in locators_
-        ASSERT_NE(
-            locators.find(locator_it.first),
-            locators.end());
-        // Check that the endpoint's locators are correctly inserted in locators_by_participant_
-        ASSERT_NE(
-            locators_by_participant[participant_id].find(locator_it.first),
-            locators_by_participant[participant_id].end());
-        // Check that the endpoint's participant is correctly inserted in participants_by_locator_
-        ASSERT_NE(
-            participants_by_locator[locator_it.first].find(participant_id),
-            participants_by_locator[locator_it.first].end());
-    }
 
     /* Check that the ddsendpoint is inserted correctly inserted in the endpoints_<T> collection */
     auto endpoints = db.get_dds_endpoints<T>();
@@ -223,9 +152,6 @@ void insert_ddsendpoint_duplicated()
     /* Insert a DDSEndpoint twice */
     auto endpoint = std::make_shared<T>(
         "test_endpoint", db.test_qos, "test_guid", participant, topic);
-    auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
-    endpoint->locators[locator->id] = locator;
     db.insert(endpoint);
     ASSERT_THROW(db.insert(endpoint), BadParameter);
 }
@@ -254,9 +180,6 @@ void insert_ddsendpoint_wrong_participant()
         "test_participant_2", db.test_qos, "01.02.03.04.05", process, domain);
     auto endpoint = std::make_shared<T>(
         "test_endpoint", db.test_qos, "test_guid", participant_2, topic);
-    auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
-    endpoint->locators[locator->id] = locator;
     ASSERT_THROW(db.insert(endpoint), BadParameter);
 }
 
@@ -283,9 +206,6 @@ void insert_ddsendpoint_wrong_topic()
     auto topic_2 = std::make_shared<Topic>("test_topic_name_2", "test_topic_type_2", domain);
     auto endpoint = std::make_shared<T>(
         "test_endpoint", db.test_qos, "test_guid", participant, topic_2);
-    auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
-    endpoint->locators[locator->id] = locator;
     ASSERT_THROW(db.insert(endpoint), BadParameter);
 }
 
@@ -311,9 +231,6 @@ void insert_ddsendpoint_empty_name()
     /* Insert a DDSEndpoint with a non-inserted topic */
     auto endpoint = std::make_shared<T>(
         "", db.test_qos, "test_guid", participant, topic);
-    auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
-    endpoint->locators[locator->id] = locator;
     ASSERT_THROW(db.insert(endpoint), BadParameter);
 }
 
@@ -339,9 +256,6 @@ void insert_ddsendpoint_empty_qos()
     /* Insert a DDSEndpoint with a non-inserted topic */
     auto endpoint = std::make_shared<T>(
         "test_endpoint", Qos(), "test_guid", participant, topic);
-    auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
-    endpoint->locators[locator->id] = locator;
     ASSERT_THROW(db.insert(endpoint), BadParameter);
 }
 
@@ -367,9 +281,6 @@ void insert_ddsendpoint_empty_guid()
     /* Insert a DDSEndpoint with a non-inserted topic */
     auto endpoint = std::make_shared<T>(
         "test_endpoint", db.test_qos, "", participant, topic);
-    auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
-    endpoint->locators[locator->id] = locator;
     ASSERT_THROW(db.insert(endpoint), BadParameter);
 }
 
@@ -421,14 +332,10 @@ void insert_ddsendpoint_two_same_domain_same_guid()
     std::string endpoint_guid = "test_guid";
     auto endpoint = std::make_shared<T>(
         "test_endpoint", db.test_qos, endpoint_guid, participant, topic);
-    auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
-    endpoint->locators[locator->id] = locator;
     db.insert(endpoint);
 
     auto endpoint_2 = std::make_shared<T>(
         "test_endpoint_2", db.test_qos, endpoint_guid, participant, topic);
-    endpoint_2->locators[locator->id] = locator;
     ASSERT_THROW(db.insert(endpoint_2), BadParameter);
 }
 
@@ -462,14 +369,10 @@ void insert_ddsendpoint_two_diff_domain_same_guid()
     std::string endpoint_guid = "test_guid";
     auto endpoint = std::make_shared<T>(
         "test_endpoint", db.test_qos, endpoint_guid, participant, topic);
-    auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
-    endpoint->locators[locator->id] = locator;
     db.insert(endpoint);
 
     auto endpoint_2 = std::make_shared<T>(
         "test_endpoint_2", db.test_qos, endpoint_guid, participant_2, topic_2);
-    endpoint_2->locators[locator->id] = locator;
     ASSERT_THROW(db.insert(endpoint_2), BadParameter);
 }
 
@@ -496,12 +399,12 @@ public:
         db.insert(writer_locator);
         writer.reset(new DataWriter(writer_name, db.test_qos, writer_guid, participant, topic));
         writer_id = db.insert(writer);
-        db.link_endpoint_with_locator(writer_id,writer_locator->id);
+        db.link_endpoint_with_locator(writer_id, writer_locator->id);
         reader_locator.reset(new Locator(reader_locator_name));
         db.insert(reader_locator);
         reader.reset(new DataReader(reader_name, db.test_qos, reader_guid, participant, topic));
         reader_id = db.insert(reader);
-        db.link_endpoint_with_locator(reader_id,reader_locator->id);
+        db.link_endpoint_with_locator(reader_id, reader_locator->id);
     }
 
     DataBaseTest db;
@@ -1496,6 +1399,54 @@ TEST_F(database_tests, insert_locator)
     ASSERT_EQ(locator_name, locators[locator_id]->name);
 }
 
+TEST_F(database_tests, insert_locator_two)
+{
+    /* Insert two locators */
+    DataBaseTest db;
+    std::string locator_name = "test_locator";
+    std::string locator_name_2 = "test_locator_2";
+    std::shared_ptr<Locator> locator = std::make_shared<Locator>(locator_name);
+    std::shared_ptr<Locator> locator_2 = std::make_shared<Locator>(locator_name_2);
+    EntityId locator_id = db.insert(locator);
+    EntityId locator_id_2 = db.insert(locator_2);
+
+    /* Check that the locators are inserted correctly */
+    std::map<EntityId, std::shared_ptr<Locator>> locators = db.locators();
+    ASSERT_EQ(locators.size(), 2);
+    ASSERT_NE(locators.find(locator_id), locators.end());
+    ASSERT_NE(locators.find(locator_id_2), locators.end());
+    ASSERT_EQ(locator_name, locators[locator_id]->name);
+    ASSERT_EQ(locator_name_2, locators[locator_id_2]->name);
+}
+
+TEST_F(database_tests, insert_locator_two_same_name)
+{
+    /* Insert two locators */
+    DataBaseTest db;
+    std::string locator_name = "test_locator";
+    std::shared_ptr<Locator> locator = std::make_shared<Locator>(locator_name);
+    std::shared_ptr<Locator> locator_2 = std::make_shared<Locator>(locator_name);
+    db.insert(locator);
+    ASSERT_THROW(db.insert(locator_2), BadParameter);
+}
+
+TEST_F(database_tests, insert_locator_duplicated)
+{
+    /* Insert a locator twice */
+    DataBaseTest db;
+    std::shared_ptr<Locator> locator = std::make_shared<Locator>("test_locator");
+    db.insert(locator);
+    ASSERT_THROW(db.insert(locator), BadParameter);
+}
+
+TEST_F(database_tests, insert_locator_empty_name)
+{
+    /* Insert a locator with empty name */
+    DataBaseTest db;
+    auto locator = std::make_shared<Locator>("");
+    ASSERT_THROW(db.insert(locator), BadParameter);
+}
+
 TEST_F(database_tests, insert_invalid)
 {
     /* Insert an entity */
@@ -1600,6 +1551,227 @@ TEST_F(database_tests, link_participant_with_process_linked_participant)
     /* Link participant with process twice */
     ASSERT_NO_THROW(db.link_participant_with_process(participant_id, process_id));
     ASSERT_THROW(db.link_participant_with_process(participant_id, process_id), BadParameter);
+}
+
+template<typename T>
+void link_endpoint_with_locator_unlinked()
+{
+    /* Insert a host, user,process, domain, topic, participant, endpoint, and locator */
+    DataBaseTest db;
+    auto host = std::make_shared<Host>("test_host");
+    db.insert(host);
+    auto user = std::make_shared<User>("test_user", host);
+    db.insert(user);
+    auto process = std::make_shared<Process>("test_process", "test_pid", user);
+    db.insert(process);
+    auto domain = std::make_shared<Domain>("test_domain");
+    db.insert(domain);
+    auto participant = std::make_shared<DomainParticipant>(
+        "test_participant", db.test_qos, "01.02.03.04", process, domain);
+    auto participant_id = db.insert(participant);
+    auto topic = std::make_shared<Topic>("test_topic_name", "test_topic_type", domain);
+    db.insert(topic);
+
+    /* Insert a DDSEndpoint */
+    std::string endpoint_name = "test_endpoint";
+    std::string endpoint_guid = "test_guid";
+    auto endpoint = std::make_shared<T>(
+        endpoint_name, db.test_qos, endpoint_guid, participant, topic);
+    // Create a locator for the endpoint
+    auto locator = std::make_shared<Locator>("test_locator");
+    auto locator_id = db.insert(locator);
+    auto endpoint_id = db.insert(endpoint);
+    db.link_endpoint_with_locator(endpoint_id, locator_id);
+
+    /* Check x_by_y_ collections and locators_ */
+    auto locators = db.locators();
+    auto locators_by_participant = db.locators_by_participant();
+    auto participants_by_locator = db.participants_by_locator();
+    ASSERT_EQ(locators_by_participant[participant_id].size(), endpoint->locators.size());
+    ASSERT_EQ(participants_by_locator[locator->id].size(), endpoint->locators.size());
+    for (auto locator_it : endpoint->locators)
+    {
+        // Check that the endpoint's locators are correctly inserted in locators_
+        ASSERT_NE(
+            locators.find(locator_it.first),
+            locators.end());
+        // Check that the endpoint's locators are correctly inserted in locators_by_participant_
+        ASSERT_NE(
+            locators_by_participant[participant_id].find(locator_it.first),
+            locators_by_participant[participant_id].end());
+        // Check that the endpoint's participant is correctly inserted in participants_by_locator_
+        ASSERT_NE(
+            participants_by_locator[locator_it.first].find(participant_id),
+            participants_by_locator[locator_it.first].end());
+    }
+}
+
+TEST_F(database_tests, link_endpoint_with_locator_unlinked)
+{
+    link_endpoint_with_locator_unlinked<DataReader>();
+    link_endpoint_with_locator_unlinked<DataWriter>();
+}
+
+template<typename T>
+void link_endpoint_with_locator_wrong_endpoint()
+{
+    /* Insert a host, user,process, domain, topic, participant, endpoint, and locator */
+    DataBaseTest db;
+    auto host = std::make_shared<Host>("test_host");
+    db.insert(host);
+    auto user = std::make_shared<User>("test_user", host);
+    db.insert(user);
+    auto process = std::make_shared<Process>("test_process", "test_pid", user);
+    db.insert(process);
+    auto domain = std::make_shared<Domain>("test_domain");
+    db.insert(domain);
+    auto participant = std::make_shared<DomainParticipant>(
+        "test_participant", db.test_qos, "01.02.03.04", process, domain);
+    db.insert(participant);
+    auto topic = std::make_shared<Topic>("test_topic_name", "test_topic_type", domain);
+    db.insert(topic);
+
+    /* Insert a DDSEndpoint */
+    std::string endpoint_name = "test_endpoint";
+    std::string endpoint_guid = "test_guid";
+    auto endpoint = std::make_shared<T>(
+        endpoint_name, db.test_qos, endpoint_guid, participant, topic);
+    // Create a locator for the endpoint
+    auto locator = std::make_shared<Locator>("test_locator");
+    auto locator_id = db.insert(locator);
+    db.insert(endpoint);
+
+    /* Link another endpoint with locator */
+    ASSERT_THROW(db.link_endpoint_with_locator(EntityId(12), locator_id), BadParameter);
+}
+
+TEST_F(database_tests, link_endpoint_with_locator_wrong_endpoint)
+{
+    link_endpoint_with_locator_wrong_endpoint<DataReader>();
+    link_endpoint_with_locator_wrong_endpoint<DataWriter>();
+}
+
+template<typename T>
+void link_endpoint_with_locator_wrong_locator()
+{
+    /* Insert a host, user,process, domain, topic, participant, endpoint, and locator */
+    DataBaseTest db;
+    auto host = std::make_shared<Host>("test_host");
+    db.insert(host);
+    auto user = std::make_shared<User>("test_user", host);
+    db.insert(user);
+    auto process = std::make_shared<Process>("test_process", "test_pid", user);
+    db.insert(process);
+    auto domain = std::make_shared<Domain>("test_domain");
+    db.insert(domain);
+    auto participant = std::make_shared<DomainParticipant>(
+        "test_participant", db.test_qos, "01.02.03.04", process, domain);
+    db.insert(participant);
+    auto topic = std::make_shared<Topic>("test_topic_name", "test_topic_type", domain);
+    db.insert(topic);
+
+    /* Insert a DDSEndpoint */
+    std::string endpoint_name = "test_endpoint";
+    std::string endpoint_guid = "test_guid";
+    auto endpoint = std::make_shared<T>(
+        endpoint_name, db.test_qos, endpoint_guid, participant, topic);
+    // Create a locator for the endpoint
+    auto locator = std::make_shared<Locator>("test_locator");
+    db.insert(locator);
+    auto endpoint_id = db.insert(endpoint);
+
+    /* Link endpoint with another locator */
+    ASSERT_THROW(db.link_endpoint_with_locator(endpoint_id, EntityId(12)), BadParameter);
+}
+
+TEST_F(database_tests, link_endpoint_with_locator_wrong_locator)
+{
+    link_endpoint_with_locator_wrong_locator<DataReader>();
+    link_endpoint_with_locator_wrong_locator<DataWriter>();
+}
+
+template<typename T>
+void link_endpoint_with_locator_two_valid()
+{
+    /* Insert a host, user,process, domain, topic, participant, endpoint, and locator */
+    DataBaseTest db;
+    auto host = std::make_shared<Host>("test_host");
+    db.insert(host);
+    auto user = std::make_shared<User>("test_user", host);
+    db.insert(user);
+    auto process = std::make_shared<Process>("test_process", "test_pid", user);
+    db.insert(process);
+    auto domain = std::make_shared<Domain>("test_domain");
+    db.insert(domain);
+    auto participant = std::make_shared<DomainParticipant>(
+        "test_participant", db.test_qos, "01.02.03.04", process, domain);
+    auto participant_id = db.insert(participant);
+    auto topic = std::make_shared<Topic>("test_topic_name", "test_topic_type", domain);
+    db.insert(topic);
+
+    /* Insert two DDSEndpoint */
+    std::string endpoint_name = "test_endpoint";
+    std::string endpoint_guid = "test_guid";
+    auto endpoint = std::make_shared<T>(
+        endpoint_name, db.test_qos, endpoint_guid, participant, topic);
+    auto locator = std::make_shared<Locator>("test_locator");
+    auto locator_id = db.insert(locator);
+    auto endpoint_id = db.insert(endpoint);
+    db.link_endpoint_with_locator(endpoint_id, locator_id);
+
+    std::string endpoint_name_2 = "test_endpoint_2";
+    std::string endpoint_guid_2 = "test_guid_2";
+    auto endpoint_2 = std::make_shared<T>(
+        endpoint_name_2, db.test_qos, endpoint_guid_2, participant, topic);
+    auto locator_2 = std::make_shared<Locator>("test_locator_2");
+    auto locator_id_2 = db.insert(locator_2);
+    auto endpoint_id_2 = db.insert(endpoint_2);
+    db.link_endpoint_with_locator(endpoint_id_2, locator_id_2);
+
+    /* Check x_by_y_ collections and locators_ */
+    auto locators = db.locators();
+    auto locators_by_participant = db.locators_by_participant();
+    auto participants_by_locator = db.participants_by_locator();
+    ASSERT_EQ(locators_by_participant[participant_id].size(), endpoint->locators.size() * 2);
+    ASSERT_EQ(participants_by_locator[locator->id].size(), endpoint->locators.size());
+    ASSERT_EQ(participants_by_locator[locator_2->id].size(), endpoint_2->locators.size());
+    for (auto locator_it : endpoint->locators)
+    {
+        // Check that the endpoint's locators are correctly inserted in locators_
+        ASSERT_NE(
+            locators.find(locator_it.first),
+            locators.end());
+        // Check that the endpoint's locators are correctly inserted in locators_by_participant_
+        ASSERT_NE(
+            locators_by_participant[participant_id].find(locator_it.first),
+            locators_by_participant[participant_id].end());
+        // Check that the endpoint's participant is correctly inserted in participants_by_locator_
+        ASSERT_NE(
+            participants_by_locator[locator_it.first].find(participant_id),
+            participants_by_locator[locator_it.first].end());
+    }
+
+    for (auto locator_it : endpoint_2->locators)
+    {
+        // Check that the endpoint's locators are correctly inserted in locators_
+        ASSERT_NE(
+            locators.find(locator_it.first),
+            locators.end());
+        // Check that the endpoint's locators are correctly inserted in locators_by_participant_
+        ASSERT_NE(
+            locators_by_participant[participant_id].find(locator_it.first),
+            locators_by_participant[participant_id].end());
+        // Check that the endpoint's participant is correctly inserted in participants_by_locator_
+        ASSERT_NE(
+            participants_by_locator[locator_it.first].find(participant_id),
+            participants_by_locator[locator_it.first].end());
+    }
+}
+
+TEST_F(database_tests, link_endpoint_with_locator_two_valid)
+{
+    link_endpoint_with_locator_two_valid<DataReader>();
+    link_endpoint_with_locator_two_valid<DataWriter>();
 }
 
 TEST_F(database_tests, insert_sample_history_latency)

--- a/test/unittest/TestUtils/DatabaseUtils.hpp
+++ b/test/unittest/TestUtils/DatabaseUtils.hpp
@@ -175,39 +175,43 @@ public:
         db.insert(topic2);
         entities[12] = topic2;
 
-        auto datareader1 = std::make_shared<DataReader>("datareader1", "qos", "11.12.13.14", participant2, topic2);
         auto reader_locator1 = std::make_shared<Locator>("reader_locator1");
-        reader_locator1->id = db.generate_entity_id();
-        datareader1->locators[reader_locator1->id] = reader_locator1;
-        db.insert(datareader1);
-        entities[13] = datareader1;
+        db.insert(reader_locator1);
         entities[17] = reader_locator1;
 
-        auto datareader2 = std::make_shared<DataReader>("datareader2", "qos", "15.16.17.18", participant2, topic2);
+        auto datareader1 = std::make_shared<DataReader>("datareader1", "qos", "11.12.13.14", participant2, topic2);
+        db.insert(datareader1);
+        db.link_endpoint_with_locator(datareader1->id, reader_locator1->id);
+        entities[13] = datareader1;
+
         auto reader_locator2 = std::make_shared<Locator>("reader_locator2");
-        reader_locator2->id = db.generate_entity_id();
-        datareader2->locators[reader_locator1->id] = reader_locator1;
-        datareader2->locators[reader_locator2->id] = reader_locator2;
-        db.insert(datareader2);
-        entities[14] = datareader2;
+        db.insert(reader_locator2);
         entities[18] = reader_locator2;
 
-        auto datawriter1 = std::make_shared<DataWriter>("datawriter1", "qos", "21.22.23.24", participant2, topic2);
+        auto datareader2 = std::make_shared<DataReader>("datareader2", "qos", "15.16.17.18", participant2, topic2);
+        db.insert(datareader2);
+        db.link_endpoint_with_locator(datareader2->id, reader_locator1->id);
+        db.link_endpoint_with_locator(datareader2->id, reader_locator2->id);
+        entities[14] = datareader2;
+
         auto writer_locator1 = std::make_shared<Locator>("writer_locator1");
-        writer_locator1->id = db.generate_entity_id();
-        datawriter1->locators[writer_locator1->id] = writer_locator1;
-        db.insert(datawriter1);
-        entities[15] = datawriter1;
+        db.insert(writer_locator1);
         entities[19] = writer_locator1;
 
-        auto datawriter2 = std::make_shared<DataWriter>("datawriter2", "qos", "25.26.27.28", participant2, topic2);
+        auto datawriter1 = std::make_shared<DataWriter>("datawriter1", "qos", "21.22.23.24", participant2, topic2);
+        db.insert(datawriter1);
+        db.link_endpoint_with_locator(datawriter1->id, writer_locator1->id);
+        entities[15] = datawriter1;
+
         auto writer_locator2 = std::make_shared<Locator>("writer_locator2");
-        writer_locator2->id = db.generate_entity_id();
-        datawriter2->locators[writer_locator1->id] = writer_locator1;
-        datawriter2->locators[writer_locator2->id] = writer_locator2;
-        db.insert(datawriter2);
-        entities[16] = datawriter2;
+        db.insert(writer_locator2);
         entities[20] = writer_locator2;
+
+        auto datawriter2 = std::make_shared<DataWriter>("datawriter2", "qos", "25.26.27.28", participant2, topic2);
+        db.insert(datawriter2);
+        db.link_endpoint_with_locator(datawriter2->id, writer_locator1->id);
+        db.link_endpoint_with_locator(datawriter2->id, writer_locator2->id);
+        entities[16] = datawriter2;
 
         return entities;
     }


### PR DESCRIPTION
-Modified some tests: now the creation and link of a locator is different.
-Database::insert_ddsendpoint_to_locator methods removed, they are no longer needed.