### PR TITLE
Statistics messages are of specific subtype [11769]

### DIFF
--- a/src/cpp/subscriber/StatisticsReaderListener.cpp
+++ b/src/cpp/subscriber/StatisticsReaderListener.cpp
@@ -26,7 +26,6 @@
 #include <fastrtps/types/TypesBase.h>
 
 #include <database/database_queue.hpp>
-
 #include <topic_types/types.h>
 
 namespace eprosima {

--- a/src/cpp/subscriber/StatisticsReaderListener.cpp
+++ b/src/cpp/subscriber/StatisticsReaderListener.cpp
@@ -21,9 +21,13 @@
 
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <fastdds/dds/topic/TopicDescription.hpp>
+#include <fastdds/statistics/topic_names.hpp>
 #include <fastrtps/types/TypesBase.h>
 
 #include <database/database_queue.hpp>
+
+#include <topic_types/types.h>
 
 namespace eprosima {
 namespace statistics_backend {
@@ -31,6 +35,29 @@ namespace subscriber {
 
 using namespace eprosima::fastrtps::types;
 using namespace eprosima::fastdds::statistics;
+using namespace eprosima::fastdds::dds;
+
+
+static const std::map<std::string, EventKind> topics =
+{
+    {HISTORY_LATENCY_TOPIC,         HISTORY2HISTORY_LATENCY},
+    {NETWORK_LATENCY_TOPIC,         NETWORK_LATENCY},
+    {PUBLICATION_THROUGHPUT_TOPIC,  PUBLICATION_THROUGHPUT},
+    {SUBSCRIPTION_THROUGHPUT_TOPIC, SUBSCRIPTION_THROUGHPUT},
+    {RTPS_SENT_TOPIC,               RTPS_SENT},
+    {RTPS_LOST_TOPIC,               RTPS_LOST},
+    {RESENT_DATAS_TOPIC,            RESENT_DATAS},
+    {HEARTBEAT_COUNT_TOPIC,         HEARTBEAT_COUNT},
+    {ACKNACK_COUNT_TOPIC,           ACKNACK_COUNT},
+    {NACKFRAG_COUNT_TOPIC,          NACKFRAG_COUNT},
+    {GAP_COUNT_TOPIC,               GAP_COUNT},
+    {DATA_COUNT_TOPIC,              DATA_COUNT},
+    {PDP_PACKETS_TOPIC,             PDP_PACKETS},
+    {EDP_PACKETS_TOPIC,             EDP_PACKETS},
+    {DISCOVERY_TOPIC,               DISCOVERED_ENTITY},
+    {SAMPLE_DATAS_TOPIC,            SAMPLE_DATAS},
+    {PHYSICAL_DATA_TOPIC,           PHYSICAL_DATA}
+};
 
 StatisticsReaderListener::StatisticsReaderListener(
         database::DatabaseDataQueue* data_queue) noexcept
@@ -39,22 +66,119 @@ StatisticsReaderListener::StatisticsReaderListener(
 {
 }
 
+template<typename T>
+bool StatisticsReaderListener::get_available_data(
+    eprosima::fastdds::dds::DataReader* reader,
+    T& inner_data,
+    std::chrono::system_clock::time_point& timestamp)
+{
+    SampleInfo info;
+    if (reader->take_next_sample(&inner_data, &info) == ReturnCode_t::RETCODE_OK)
+    {
+        if (!info.valid_data)
+        {
+            // Received data not valid
+            return false;
+        }
+        timestamp =
+                std::chrono::system_clock::time_point (std::chrono::nanoseconds(info.source_timestamp.to_ns()));
+        return true;
+    }
+    return false;
+}
+
 void StatisticsReaderListener::on_data_available(
         eprosima::fastdds::dds::DataReader* reader)
 {
     std::shared_ptr<Data> data = std::make_shared<Data>();
-    eprosima::fastdds::dds::SampleInfo info;
-    while (reader->take_next_sample(data.get(), &info) == ReturnCode_t::RETCODE_OK)
-    {
-        if (!info.valid_data)
-        {
-            return;
-        }
+    std::chrono::system_clock::time_point timestamp;
 
-        std::chrono::system_clock::time_point timestamp =
-                std::chrono::system_clock::time_point (std::chrono::nanoseconds(info.source_timestamp.to_ns()));
-        data_queue_->push(timestamp, data);
+    const std::string& topic_name = reader->get_topicdescription()->get_name();
+
+    bool enqueue = false;
+    if (HISTORY_LATENCY_TOPIC == topic_name)
+    {
+        WriterReaderData inner_data;
+        if (get_available_data(reader, inner_data, timestamp))
+        {
+            data->writer_reader_data(inner_data);
+            enqueue = true;
+        }
     }
+    else if (NETWORK_LATENCY_TOPIC == topic_name)
+    {
+        Locator2LocatorData inner_data;
+        if (get_available_data(reader, inner_data, timestamp))
+        {
+            data->locator2locator_data(inner_data);
+            enqueue = true;
+        }
+    }
+    else if (PUBLICATION_THROUGHPUT_TOPIC == topic_name || SUBSCRIPTION_THROUGHPUT_TOPIC == topic_name)
+    {
+        EntityData inner_data;
+        if (get_available_data(reader, inner_data, timestamp))
+        {
+            data->entity_data(inner_data);
+            enqueue = true;
+        }
+    }
+    else if (RTPS_SENT_TOPIC == topic_name || RTPS_LOST_TOPIC == topic_name)
+    {
+        Entity2LocatorTraffic inner_data;
+        if (get_available_data(reader, inner_data, timestamp))
+        {
+            data->entity2locator_traffic(inner_data);
+            enqueue = true;
+        }
+    }
+    else if (RESENT_DATAS_TOPIC == topic_name || HEARTBEAT_COUNT_TOPIC == topic_name ||
+            ACKNACK_COUNT_TOPIC == topic_name || NACKFRAG_COUNT_TOPIC == topic_name || GAP_COUNT_TOPIC == topic_name ||
+            DATA_COUNT_TOPIC == topic_name || PDP_PACKETS_TOPIC == topic_name || EDP_PACKETS_TOPIC == topic_name)
+    {
+        EntityCount inner_data;
+        if (get_available_data(reader, inner_data, timestamp))
+        {
+            data->entity_count(inner_data);
+            enqueue = true;
+        }
+    }
+    else if (DISCOVERY_TOPIC == topic_name)
+    {
+        DiscoveryTime inner_data;
+        if (get_available_data(reader, inner_data, timestamp))
+        {
+            data->discovery_time(inner_data);
+            enqueue = true;
+        }
+    }
+    else if (SAMPLE_DATAS_TOPIC == topic_name)
+    {
+        SampleIdentityCount inner_data;
+        if (get_available_data(reader, inner_data, timestamp))
+        {
+            data->sample_identity_count(inner_data);
+            enqueue = true;
+        }
+    }
+    else if (PHYSICAL_DATA_TOPIC == topic_name)
+    {
+        PhysicalData inner_data;
+        if (get_available_data(reader, inner_data, timestamp))
+        {
+            data->physical_data(inner_data);
+            enqueue = true;
+        }
+    }
+
+    if (!enqueue)
+    {
+        // Nothing to push to queue
+        return;
+    }
+
+    data->_d(topics.at(topic_name));
+    data_queue_->push(timestamp, data);
 }
 
 } //namespace database

--- a/src/cpp/subscriber/StatisticsReaderListener.cpp
+++ b/src/cpp/subscriber/StatisticsReaderListener.cpp
@@ -68,9 +68,9 @@ StatisticsReaderListener::StatisticsReaderListener(
 
 template<typename T>
 bool StatisticsReaderListener::get_available_data(
-    eprosima::fastdds::dds::DataReader* reader,
-    T& inner_data,
-    std::chrono::system_clock::time_point& timestamp)
+        eprosima::fastdds::dds::DataReader* reader,
+        T& inner_data,
+        std::chrono::system_clock::time_point& timestamp)
 {
     SampleInfo info;
     if (reader->take_next_sample(&inner_data, &info) == ReturnCode_t::RETCODE_OK)

--- a/src/cpp/subscriber/StatisticsReaderListener.hpp
+++ b/src/cpp/subscriber/StatisticsReaderListener.hpp
@@ -66,6 +66,12 @@ public:
 
 protected:
 
+    template<typename T>
+    bool get_available_data(
+        eprosima::fastdds::dds::DataReader* reader,
+        T& inner_data,
+        std::chrono::system_clock::time_point& timestamp);
+
     //! Reference to the database queues
     database::DatabaseDataQueue* data_queue_;
 

--- a/src/cpp/subscriber/StatisticsReaderListener.hpp
+++ b/src/cpp/subscriber/StatisticsReaderListener.hpp
@@ -68,9 +68,9 @@ protected:
 
     template<typename T>
     bool get_available_data(
-        eprosima::fastdds::dds::DataReader* reader,
-        T& inner_data,
-        std::chrono::system_clock::time_point& timestamp);
+            eprosima::fastdds::dds::DataReader* reader,
+            T& inner_data,
+            std::chrono::system_clock::time_point& timestamp);
 
     //! Reference to the database queues
     database::DatabaseDataQueue* data_queue_;

--- a/test/TrafficInjector/TrafficInjector.h
+++ b/test/TrafficInjector/TrafficInjector.h
@@ -75,7 +75,8 @@ class TrafficInjector
 
 public:
 
-    TrafficInjector(DomainId domain_id = 0)
+    TrafficInjector(
+            DomainId domain_id = 0)
     {
         participant_ = DomainParticipantFactory::get_instance()->create_participant(
             domain_id, eprosima::fastdds::dds::PARTICIPANT_QOS_DEFAULT);

--- a/test/TrafficInjector/TrafficInjector.h
+++ b/test/TrafficInjector/TrafficInjector.h
@@ -23,6 +23,7 @@
 #include <exception/Exception.hpp>
 #include <topic_types/types.h>
 #include <topic_types/typesPubSubTypes.h>
+#include <types/types.hpp>
 
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
@@ -74,10 +75,10 @@ class TrafficInjector
 
 public:
 
-    TrafficInjector()
+    TrafficInjector(DomainId domain_id = 0)
     {
         participant_ = DomainParticipantFactory::get_instance()->create_participant(
-            0, eprosima::fastdds::dds::PARTICIPANT_QOS_DEFAULT);
+            domain_id, eprosima::fastdds::dds::PARTICIPANT_QOS_DEFAULT);
         publisher_ = participant_->create_publisher(eprosima::fastdds::dds::PUBLISHER_QOS_DEFAULT);
     }
 
@@ -633,71 +634,71 @@ private:
         {
             case StatisticsEventKind::HISTORY2HISTORY_LATENCY:
                 serializers_[kind]->deserialize(&data, msg.at("WriterReaderData"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.writer_reader_data());
                 break;
             case StatisticsEventKind::NETWORK_LATENCY:
                 serializers_[kind]->deserialize(&data, msg.at("locator2locator_data"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.locator2locator_data());
                 break;
             case StatisticsEventKind::PUBLICATION_THROUGHPUT:
                 serializers_[kind]->deserialize(&data, msg.at("entity_data"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.entity_data());
                 break;
             case StatisticsEventKind::SUBSCRIPTION_THROUGHPUT:
                 serializers_[kind]->deserialize(&data, msg.at("entity_data"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.entity_data());
                 break;
             case StatisticsEventKind::RTPS_SENT:
                 serializers_[kind]->deserialize(&data, msg.at("entity2locator_traffic"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.entity2locator_traffic());
                 break;
             case StatisticsEventKind::RTPS_LOST:
                 serializers_[kind]->deserialize(&data, msg.at("entity2locator_traffic"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.entity2locator_traffic());
                 break;
             case StatisticsEventKind::RESENT_DATAS:
                 serializers_[kind]->deserialize(&data, msg.at("entity_count"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.entity_count());
                 break;
             case StatisticsEventKind::HEARTBEAT_COUNT:
                 serializers_[kind]->deserialize(&data, msg.at("entity_count"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.entity_count());
                 break;
             case StatisticsEventKind::ACKNACK_COUNT:
                 serializers_[kind]->deserialize(&data, msg.at("entity_count"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.entity_count());
                 break;
             case StatisticsEventKind::NACKFRAG_COUNT:
                 serializers_[kind]->deserialize(&data, msg.at("entity_count"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.entity_count());
                 break;
             case StatisticsEventKind::GAP_COUNT:
                 serializers_[kind]->deserialize(&data, msg.at("entity_count"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.entity_count());
                 break;
             case StatisticsEventKind::DATA_COUNT:
                 serializers_[kind]->deserialize(&data, msg.at("entity_count"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.entity_count());
                 break;
             case StatisticsEventKind::PDP_PACKETS:
                 serializers_[kind]->deserialize(&data, msg.at("entity_count"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.entity_count());
                 break;
             case StatisticsEventKind::EDP_PACKETS:
                 serializers_[kind]->deserialize(&data, msg.at("entity_count"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.entity_count());
                 break;
             case StatisticsEventKind::DISCOVERED_ENTITY:
                 serializers_[kind]->deserialize(&data, msg.at("discovery_time"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.discovery_time());
                 break;
             case StatisticsEventKind::SAMPLE_DATAS:
                 serializers_[kind]->deserialize(&data, msg.at("sample_identity_count"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.sample_identity_count());
                 break;
             case StatisticsEventKind::PHYSICAL_DATA:
                 serializers_[kind]->deserialize(&data, msg.at("physical_data"));
-                data_writers_[kind]->write(&data);
+                data_writers_[kind]->write(&data.physical_data());
                 break;
         }
     }

--- a/test/mock/dds/DataReader/fastdds/dds/subscriber/DataReader.hpp
+++ b/test/mock/dds/DataReader/fastdds/dds/subscriber/DataReader.hpp
@@ -51,12 +51,6 @@ protected:
     using StatisticsDiscoveryTime = eprosima::fastdds::statistics::DiscoveryTime;
     using StatisticsSampleIdentityCount = eprosima::fastdds::statistics::SampleIdentityCount;
     using StatisticsPhysicalData = eprosima::fastdds::statistics::PhysicalData;
-    using StatisticsEntityId = eprosima::fastdds::statistics::detail::EntityId_s;
-    using StatisticsGuidPrefix = eprosima::fastdds::statistics::detail::GuidPrefix_s;
-    using StatisticsGuid = eprosima::fastdds::statistics::detail::GUID_s;
-    using StatisticsSequenceNumber = eprosima::fastdds::statistics::detail::SequenceNumber_s;
-    using StatisticsSampleIdentity = eprosima::fastdds::statistics::detail::SampleIdentity_s;
-    using StatisticsLocator = eprosima::fastdds::statistics::detail::Locator_s;
 
 public:
 

--- a/test/unittest/StatisticsReaderListener/StatisticsReaderListenerTests.cpp
+++ b/test/unittest/StatisticsReaderListener/StatisticsReaderListenerTests.cpp
@@ -14,6 +14,7 @@
 
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <fastdds/statistics/topic_names.hpp>
 
 #include <database/database.hpp>
 #include <database/database_queue.hpp>
@@ -116,14 +117,111 @@ TEST_F(statistics_reader_listener_tests, not_valid_data)
     std::shared_ptr<SampleInfo> info = get_default_info();
     info->valid_data = false;
 
+    // Expectation: The insert method is never called
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
+
     // Add to the history
     std::shared_ptr<StatisticsData> data = std::make_shared<StatisticsData>();
     add_sample_to_reader_history(data, info);
 
-    // Expectation: The insert method is never called
-    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
+    // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(HISTORY_LATENCY_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
 
     // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(NETWORK_LATENCY_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(PUBLICATION_THROUGHPUT_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(SUBSCRIPTION_THROUGHPUT_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(RTPS_SENT_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(RTPS_LOST_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(RESENT_DATAS_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(HEARTBEAT_COUNT_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(ACKNACK_COUNT_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(NACKFRAG_COUNT_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(GAP_COUNT_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(DATA_COUNT_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(PDP_PACKETS_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(EDP_PACKETS_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(DISCOVERY_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(SAMPLE_DATAS_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Insert the data on the queue and wait until processed
+    add_sample_to_reader_history(data, info);
+    datareader_.set_topic_name(PHYSICAL_DATA_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 
@@ -195,6 +293,7 @@ TEST_F(statistics_reader_listener_tests, new_history_latency_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(HISTORY_LATENCY_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -258,6 +357,7 @@ TEST_F(statistics_reader_listener_tests, new_network_latency_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(NETWORK_LATENCY_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -308,6 +408,7 @@ TEST_F(statistics_reader_listener_tests, new_publication_throughput_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(PUBLICATION_THROUGHPUT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -358,6 +459,7 @@ TEST_F(statistics_reader_listener_tests, new_subscription_throughput_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(SUBSCRIPTION_THROUGHPUT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -440,6 +542,7 @@ TEST_F(statistics_reader_listener_tests, new_rtps_sent_received)
             .WillOnce(Invoke(&args2, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(RTPS_SENT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -522,6 +625,7 @@ TEST_F(statistics_reader_listener_tests, new_rtps_lost_received)
             .WillOnce(Invoke(&args2, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(RTPS_LOST_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -572,6 +676,7 @@ TEST_F(statistics_reader_listener_tests, new_resent_datas_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(RESENT_DATAS_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -622,6 +727,7 @@ TEST_F(statistics_reader_listener_tests, new_heartbeat_count_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(HEARTBEAT_COUNT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -672,6 +778,7 @@ TEST_F(statistics_reader_listener_tests, new_acknack_count_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(ACKNACK_COUNT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -722,6 +829,7 @@ TEST_F(statistics_reader_listener_tests, new_nackfrag_count_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(NACKFRAG_COUNT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -772,6 +880,7 @@ TEST_F(statistics_reader_listener_tests, new_gap_count_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(GAP_COUNT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -822,6 +931,7 @@ TEST_F(statistics_reader_listener_tests, new_data_count_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(DATA_COUNT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -872,6 +982,7 @@ TEST_F(statistics_reader_listener_tests, new_pdp_count_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(PDP_PACKETS_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -922,6 +1033,7 @@ TEST_F(statistics_reader_listener_tests, new_edp_count_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(EDP_PACKETS_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -992,6 +1104,7 @@ TEST_F(statistics_reader_listener_tests, new_discovery_times_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(DISCOVERY_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -1053,6 +1166,7 @@ TEST_F(statistics_reader_listener_tests, new_sample_datas_received)
             .WillRepeatedly(Invoke(&args, &InsertDataArgs::insert));
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(SAMPLE_DATAS_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -1132,6 +1246,7 @@ TEST_F(statistics_reader_listener_tests, new_physical_data_received)
     EXPECT_CALL(database_, link_participant_with_process(EntityId(1), EntityId(4))).Times(1);
 
     // Insert the data on the queue and wait until processed
+    datareader_.set_topic_name(PHYSICAL_DATA_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }

--- a/test/unittest/StatisticsReaderListener/StatisticsReaderListenerTests.cpp
+++ b/test/unittest/StatisticsReaderListener/StatisticsReaderListenerTests.cpp
@@ -296,6 +296,11 @@ TEST_F(statistics_reader_listener_tests, new_history_latency_received)
     datareader_.set_topic_name(HISTORY_LATENCY_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
 }
 
 TEST_F(statistics_reader_listener_tests, new_network_latency_received)
@@ -360,6 +365,11 @@ TEST_F(statistics_reader_listener_tests, new_network_latency_received)
     datareader_.set_topic_name(NETWORK_LATENCY_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
 }
 
 TEST_F(statistics_reader_listener_tests, new_publication_throughput_received)
@@ -411,6 +421,11 @@ TEST_F(statistics_reader_listener_tests, new_publication_throughput_received)
     datareader_.set_topic_name(PUBLICATION_THROUGHPUT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
 }
 
 TEST_F(statistics_reader_listener_tests, new_subscription_throughput_received)
@@ -460,6 +475,11 @@ TEST_F(statistics_reader_listener_tests, new_subscription_throughput_received)
 
     // Insert the data on the queue and wait until processed
     datareader_.set_topic_name(SUBSCRIPTION_THROUGHPUT_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -545,6 +565,11 @@ TEST_F(statistics_reader_listener_tests, new_rtps_sent_received)
     datareader_.set_topic_name(RTPS_SENT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
 }
 
 TEST_F(statistics_reader_listener_tests, new_rtps_lost_received)
@@ -628,6 +653,11 @@ TEST_F(statistics_reader_listener_tests, new_rtps_lost_received)
     datareader_.set_topic_name(RTPS_LOST_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
 }
 
 TEST_F(statistics_reader_listener_tests, new_resent_datas_received)
@@ -677,6 +707,11 @@ TEST_F(statistics_reader_listener_tests, new_resent_datas_received)
 
     // Insert the data on the queue and wait until processed
     datareader_.set_topic_name(RESENT_DATAS_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -730,6 +765,11 @@ TEST_F(statistics_reader_listener_tests, new_heartbeat_count_received)
     datareader_.set_topic_name(HEARTBEAT_COUNT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
 }
 
 TEST_F(statistics_reader_listener_tests, new_acknack_count_received)
@@ -779,6 +819,11 @@ TEST_F(statistics_reader_listener_tests, new_acknack_count_received)
 
     // Insert the data on the queue and wait until processed
     datareader_.set_topic_name(ACKNACK_COUNT_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -832,6 +877,11 @@ TEST_F(statistics_reader_listener_tests, new_nackfrag_count_received)
     datareader_.set_topic_name(NACKFRAG_COUNT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
 }
 
 TEST_F(statistics_reader_listener_tests, new_gap_count_received)
@@ -881,6 +931,11 @@ TEST_F(statistics_reader_listener_tests, new_gap_count_received)
 
     // Insert the data on the queue and wait until processed
     datareader_.set_topic_name(GAP_COUNT_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -934,6 +989,11 @@ TEST_F(statistics_reader_listener_tests, new_data_count_received)
     datareader_.set_topic_name(DATA_COUNT_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
 }
 
 TEST_F(statistics_reader_listener_tests, new_pdp_count_received)
@@ -985,6 +1045,11 @@ TEST_F(statistics_reader_listener_tests, new_pdp_count_received)
     datareader_.set_topic_name(PDP_PACKETS_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
 }
 
 TEST_F(statistics_reader_listener_tests, new_edp_count_received)
@@ -1034,6 +1099,11 @@ TEST_F(statistics_reader_listener_tests, new_edp_count_received)
 
     // Insert the data on the queue and wait until processed
     datareader_.set_topic_name(EDP_PACKETS_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -1107,6 +1177,11 @@ TEST_F(statistics_reader_listener_tests, new_discovery_times_received)
     datareader_.set_topic_name(DISCOVERY_TOPIC);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
 }
 
 TEST_F(statistics_reader_listener_tests, new_sample_datas_received)
@@ -1167,6 +1242,11 @@ TEST_F(statistics_reader_listener_tests, new_sample_datas_received)
 
     // Insert the data on the queue and wait until processed
     datareader_.set_topic_name(SAMPLE_DATAS_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }
@@ -1247,6 +1327,11 @@ TEST_F(statistics_reader_listener_tests, new_physical_data_received)
 
     // Insert the data on the queue and wait until processed
     datareader_.set_topic_name(PHYSICAL_DATA_TOPIC);
+    reader_listener_.on_data_available(&datareader_);
+    data_queue_.flush();
+
+    // Expectation: The insert method is not called if there is no data in the queue
+    EXPECT_CALL(database_, insert(_, _, _)).Times(0);
     reader_listener_.on_data_available(&datareader_);
     data_queue_.flush();
 }


### PR DESCRIPTION
Statistics message listeners were implemented in such a way that the expected data type was the aggregated  type, instead of the specific subtype of each topic. This PR resolves this issue.

Also, topics that were filtered out on the user listeners were designed not to be processed by the database. On a later design review, it was decided that the database should be updated with all the info, and only the user callbacks must be filtered according to the provided mask.