### PR TITLE
set domain listener [11472]

### DIFF
--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -174,6 +174,23 @@ void StatisticsBackend::set_physical_listener(
     details::StatisticsBackendData::get_instance()->unlock();
 }
 
+void StatisticsBackend::set_domain_listener(
+        EntityId monitor_id,
+        DomainListener* listener,
+        CallbackMask callback_mask,
+        DataKindMask data_mask)
+{
+    auto monitor = details::StatisticsBackendData::get_instance()->monitors_by_entity_.find(monitor_id);
+    if (monitor == details::StatisticsBackendData::get_instance()->monitors_by_entity_.end())
+    {
+        throw BadParameter("There is no monitor with the given ID");
+    }
+
+    monitor->second->domain_listener = listener;
+    monitor->second->domain_callback_mask = callback_mask;
+    monitor->second->data_mask = data_mask;
+}
+
 EntityId StatisticsBackend::init_monitor(
         DomainId domain_id,
         DomainListener* domain_listener,
@@ -332,18 +349,6 @@ void StatisticsBackend::clear_monitor(
         EntityId monitor_id)
 {
     static_cast<void>(monitor_id);
-}
-
-void StatisticsBackend::set_domain_listener(
-        EntityId monitor_id,
-        DomainListener* listener,
-        CallbackMask callback_mask,
-        DataKindMask data_mask)
-{
-    static_cast<void>(monitor_id);
-    static_cast<void>(listener);
-    static_cast<void>(callback_mask);
-    static_cast<void>(data_mask);
 }
 
 std::vector<EntityId> StatisticsBackend::get_entities(

--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -196,16 +196,17 @@ void StatisticsBackendData::on_domain_entity_discovery(
     {
         case EntityKind::PARTICIPANT:
         {
+            // The status must be recorded regardless of the callback
+            prepare_entity_discovery_status(discovery_status, monitor->second->participant_status_);
+
             if (should_call_domain_listener(monitor->second, CallbackKind::ON_PARTICIPANT_DISCOVERY))
             {
-                prepare_entity_discovery_status(discovery_status, monitor->second->participant_status_);
                 monitor->second->domain_listener->on_participant_discovery(domain_id, entity_id,
                         monitor->second->participant_status_);
                 monitor->second->participant_status_.on_status_read();
             }
             else if (should_call_physical_listener(CallbackKind::ON_PARTICIPANT_DISCOVERY))
             {
-                prepare_entity_discovery_status(discovery_status, monitor->second->participant_status_);
                 physical_listener_->on_participant_discovery(domain_id, entity_id,
                         monitor->second->participant_status_);
                 monitor->second->participant_status_.on_status_read();
@@ -214,16 +215,17 @@ void StatisticsBackendData::on_domain_entity_discovery(
         }
         case EntityKind::TOPIC:
         {
+            // The status must be recorded regardless of the callback
+            prepare_entity_discovery_status(discovery_status, monitor->second->topic_status_);
+
             if (should_call_domain_listener(monitor->second, CallbackKind::ON_TOPIC_DISCOVERY))
             {
-                prepare_entity_discovery_status(discovery_status, monitor->second->topic_status_);
                 monitor->second->domain_listener->on_topic_discovery(domain_id, entity_id,
                         monitor->second->topic_status_);
                 monitor->second->topic_status_.on_status_read();
             }
             else if (should_call_physical_listener(CallbackKind::ON_TOPIC_DISCOVERY))
             {
-                prepare_entity_discovery_status(discovery_status, monitor->second->topic_status_);
                 physical_listener_->on_topic_discovery(domain_id, entity_id, monitor->second->topic_status_);
                 monitor->second->topic_status_.on_status_read();
             }
@@ -231,16 +233,17 @@ void StatisticsBackendData::on_domain_entity_discovery(
         }
         case EntityKind::DATAWRITER:
         {
+            // The status must be recorded regardless of the callback
+            prepare_entity_discovery_status(discovery_status, monitor->second->datawriter_status_);
+
             if (should_call_domain_listener(monitor->second, CallbackKind::ON_DATAWRITER_DISCOVERY))
             {
-                prepare_entity_discovery_status(discovery_status, monitor->second->datawriter_status_);
                 monitor->second->domain_listener->on_datawriter_discovery(domain_id, entity_id,
                         monitor->second->datawriter_status_);
                 monitor->second->datawriter_status_.on_status_read();
             }
             else if (should_call_physical_listener(CallbackKind::ON_DATAWRITER_DISCOVERY))
             {
-                prepare_entity_discovery_status(discovery_status, monitor->second->datawriter_status_);
                 physical_listener_->on_datawriter_discovery(domain_id, entity_id, monitor->second->datawriter_status_);
                 monitor->second->datawriter_status_.on_status_read();
             }
@@ -248,16 +251,17 @@ void StatisticsBackendData::on_domain_entity_discovery(
         }
         case EntityKind::DATAREADER:
         {
+            // The status must be recorded regardless of the callback
+            prepare_entity_discovery_status(discovery_status, monitor->second->datareader_status_);
+
             if (should_call_domain_listener(monitor->second, CallbackKind::ON_DATAREADER_DISCOVERY))
             {
-                prepare_entity_discovery_status(discovery_status, monitor->second->datareader_status_);
                 monitor->second->domain_listener->on_datareader_discovery(domain_id, entity_id,
                         monitor->second->datareader_status_);
                 monitor->second->datareader_status_.on_status_read();
             }
             else if (should_call_physical_listener(CallbackKind::ON_DATAREADER_DISCOVERY))
             {
-                prepare_entity_discovery_status(discovery_status, monitor->second->datareader_status_);
                 physical_listener_->on_datareader_discovery(domain_id, entity_id, monitor->second->datareader_status_);
                 monitor->second->datareader_status_.on_status_read();
             }
@@ -279,9 +283,11 @@ void StatisticsBackendData::on_physical_entity_discovery(
     {
         case EntityKind::HOST:
         {
+            // The status must be recorded regardless of the callback
+            prepare_entity_discovery_status(DISCOVERY, host_status_);
+
             if (should_call_physical_listener(CallbackKind::ON_HOST_DISCOVERY))
             {
-                prepare_entity_discovery_status(DISCOVERY, host_status_);
                 physical_listener_->on_host_discovery(participant_id, entity_id, host_status_);
                 host_status_.on_status_read();
             }
@@ -289,9 +295,11 @@ void StatisticsBackendData::on_physical_entity_discovery(
         }
         case EntityKind::USER:
         {
+            // The status must be recorded regardless of the callback
+            prepare_entity_discovery_status(DISCOVERY, user_status_);
+
             if (should_call_physical_listener(CallbackKind::ON_USER_DISCOVERY))
             {
-                prepare_entity_discovery_status(DISCOVERY, user_status_);
                 physical_listener_->on_user_discovery(participant_id, entity_id, user_status_);
                 user_status_.on_status_read();
             }
@@ -299,9 +307,11 @@ void StatisticsBackendData::on_physical_entity_discovery(
         }
         case EntityKind::PROCESS:
         {
+            // The status must be recorded regardless of the callback
+            prepare_entity_discovery_status(DISCOVERY, process_status_);
+
             if (should_call_physical_listener(CallbackKind::ON_PROCESS_DISCOVERY))
             {
-                prepare_entity_discovery_status(DISCOVERY, process_status_);
                 physical_listener_->on_process_discovery(participant_id, entity_id, process_status_);
                 process_status_.on_status_read();
             }
@@ -309,9 +319,11 @@ void StatisticsBackendData::on_physical_entity_discovery(
         }
         case EntityKind::LOCATOR:
         {
+            // The status must be recorded regardless of the callback
+            prepare_entity_discovery_status(DISCOVERY, locator_status_);
+
             if (should_call_physical_listener(CallbackKind::ON_LOCATOR_DISCOVERY))
             {
-                prepare_entity_discovery_status(DISCOVERY, locator_status_);
                 physical_listener_->on_locator_discovery(participant_id, entity_id, locator_status_);
                 locator_status_.on_status_read();
             }

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -365,7 +365,7 @@ protected:
                     front().second.domain_id, id,
                     front().second.entity->kind);
             }
-            else
+            else if(EntityKind::DOMAIN != front().second.entity->kind)
             {
                 details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(front().second.domain_id, id,
                         front().second.entity->kind, details::StatisticsBackendData::DISCOVERY);

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -365,7 +365,7 @@ protected:
                     front().second.domain_id, id,
                     front().second.entity->kind);
             }
-            else if(EntityKind::DOMAIN != front().second.entity->kind)
+            else if (EntityKind::DOMAIN != front().second.entity->kind)
             {
                 details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(front().second.domain_id, id,
                         front().second.entity->kind, details::StatisticsBackendData::DISCOVERY);

--- a/test/unittest/Database/DatabaseGetEntitiesTest.cpp
+++ b/test/unittest/Database/DatabaseGetEntitiesTest.cpp
@@ -132,11 +132,11 @@ GTEST_INSTANTIATE_TEST_MACRO(
         // ALL - TOPIC
         std::make_tuple(EntityKind::TOPIC, 0, std::vector<size_t>{11, 12}),
         // ALL - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 0, std::vector<size_t>{13, 14}),
+        std::make_tuple(EntityKind::DATAREADER, 0, std::vector<size_t>{13, 15}),
         // ALL - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 0, std::vector<size_t>{15, 16}),
+        std::make_tuple(EntityKind::DATAWRITER, 0, std::vector<size_t>{17, 19}),
         // ALL - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 0, std::vector<size_t>{17, 18, 19, 20}),
+        std::make_tuple(EntityKind::LOCATOR, 0, std::vector<size_t>{14, 16, 18, 20}),
         // HOST - HOST
         std::make_tuple(EntityKind::HOST, 2, std::vector<size_t> { 2 }),
         std::make_tuple(EntityKind::HOST, 1, std::vector<size_t> { 1 }),
@@ -161,15 +161,15 @@ GTEST_INSTANTIATE_TEST_MACRO(
         // HOST - TOPIC: none
         std::make_tuple(EntityKind::TOPIC, 1, std::vector<size_t> { }),
         // HOST - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 2, std::vector<size_t> { 15, 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 2, std::vector<size_t> { 17, 19 }),
         // HOST - DATAWRITER: none
         std::make_tuple(EntityKind::DATAWRITER, 1, std::vector<size_t> { }),
         // HOST - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 2, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 2, std::vector<size_t> { 13, 15 }),
         // HOST - DATAREADER: none
         std::make_tuple(EntityKind::DATAREADER, 1, std::vector<size_t> { }),
         // HOST - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 2, std::vector<size_t> { 17, 18, 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 2, std::vector<size_t> { 14, 16, 18, 20 }),
         // HOST - LOCATOR: none
         std::make_tuple(EntityKind::LOCATOR, 1, std::vector<size_t> { }),
 
@@ -196,15 +196,15 @@ GTEST_INSTANTIATE_TEST_MACRO(
         // USER - TOPIC: none
         std::make_tuple(EntityKind::TOPIC, 3, std::vector<size_t> { }),
         // USER - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 4, std::vector<size_t> { 15, 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 4, std::vector<size_t> { 17, 19 }),
         // USER - DATAWRITER: none
         std::make_tuple(EntityKind::DATAWRITER, 3, std::vector<size_t> { }),
         // USER - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 4, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 4, std::vector<size_t> { 13, 15 }),
         // USER - DATAREADER: none
         std::make_tuple(EntityKind::DATAREADER, 3, std::vector<size_t> { }),
         // USER - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 4, std::vector<size_t> { 17, 18, 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 4, std::vector<size_t> { 14, 16, 18, 20 }),
         // USER - LOCATOR: none
         std::make_tuple(EntityKind::LOCATOR, 3, std::vector<size_t> { }),
 
@@ -230,15 +230,15 @@ GTEST_INSTANTIATE_TEST_MACRO(
         // PROCESS - TOPIC: none
         std::make_tuple(EntityKind::TOPIC, 5, std::vector<size_t> { }),
         // PROCESS - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 6, std::vector<size_t> { 15, 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 6, std::vector<size_t> { 17, 19 }),
         // PROCESS - DATAWRITER: none
         std::make_tuple(EntityKind::DATAWRITER, 5, std::vector<size_t> { }),
         // PROCESS - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 6, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 6, std::vector<size_t> { 13, 15 }),
         // PROCESS - DATAREADER: none
         std::make_tuple(EntityKind::DATAREADER, 5, std::vector<size_t> { }),
         // PROCESS - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 6, std::vector<size_t> { 17, 18, 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 6, std::vector<size_t> { 14, 16, 18, 20 }),
         // PROCESS - LOCATOR: none
         std::make_tuple(EntityKind::LOCATOR, 5, std::vector<size_t> { }),
 
@@ -266,15 +266,15 @@ GTEST_INSTANTIATE_TEST_MACRO(
         // DOMAIN - TOPIC: none
         std::make_tuple(EntityKind::TOPIC, 7, std::vector<size_t> { }),
         // DOMAIN - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 8, std::vector<size_t> { 15, 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 8, std::vector<size_t> { 17, 19 }),
         // DOMAIN - DATAWRITER: none
         std::make_tuple(EntityKind::DATAWRITER, 7, std::vector<size_t> { }),
         // DOMAIN - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 8, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 8, std::vector<size_t> { 13, 15 }),
         // DOMAIN - DATAREADER: none
         std::make_tuple(EntityKind::DATAREADER, 7, std::vector<size_t> { }),
         // DOMAIN - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 8, std::vector<size_t> { 17, 18, 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 8, std::vector<size_t> { 14, 16, 18, 20 }),
         // DOMAIN - LOCATOR: none
         std::make_tuple(EntityKind::LOCATOR, 7, std::vector<size_t> { }),
 
@@ -298,15 +298,15 @@ GTEST_INSTANTIATE_TEST_MACRO(
         // PARTICIPANT - TOPIC: none
         std::make_tuple(EntityKind::TOPIC, 9, std::vector<size_t> { }),
         // PARTICIPANT - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 10, std::vector<size_t> { 15, 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 10, std::vector<size_t> { 17, 19 }),
         // PARTICIPANT - DATAWRITER: none
         std::make_tuple(EntityKind::DATAWRITER, 9, std::vector<size_t> { }),
         // PARTICIPANT - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 10, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 10, std::vector<size_t> { 13, 15 }),
         // PARTICIPANT - DATAREADER: none
         std::make_tuple(EntityKind::DATAREADER, 9, std::vector<size_t> { }),
         // PARTICIPANT - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 10, std::vector<size_t> { 17, 18, 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 10, std::vector<size_t> { 14, 16, 18, 20 }),
         // PARTICIPANT - LOCATOR: none
         std::make_tuple(EntityKind::LOCATOR, 9, std::vector<size_t> { }),
 
@@ -333,120 +333,120 @@ GTEST_INSTANTIATE_TEST_MACRO(
         std::make_tuple(EntityKind::TOPIC, 12, std::vector<size_t> { 12 }),
         std::make_tuple(EntityKind::TOPIC, 11, std::vector<size_t> { 11 }),
         // TOPIC - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 12, std::vector<size_t> { 15, 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 12, std::vector<size_t> { 17, 19 }),
         // TOPIC - DATAWRITER: none
         std::make_tuple(EntityKind::DATAWRITER, 11, std::vector<size_t> { }),
         // TOPIC - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 12, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 12, std::vector<size_t> { 13, 15 }),
         // TOPIC - DATAREADER: none
         std::make_tuple(EntityKind::DATAREADER, 11, std::vector<size_t> { }),
         // TOPIC - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 12, std::vector<size_t> { 17, 18, 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 12, std::vector<size_t> { 14, 16, 18, 20 }),
         // TOPIC - LOCATOR: none
         std::make_tuple(EntityKind::LOCATOR, 11, std::vector<size_t> { }),
 
         // DATAREADER - HOST
-        std::make_tuple(EntityKind::HOST, 14, std::vector<size_t> { 2 }),
+        std::make_tuple(EntityKind::HOST, 15, std::vector<size_t> { 2 }),
         std::make_tuple(EntityKind::HOST, 13, std::vector<size_t> { 2 }),
         // DATAREADER - USER
-        std::make_tuple(EntityKind::USER, 14, std::vector<size_t> { 4 }),
+        std::make_tuple(EntityKind::USER, 15, std::vector<size_t> { 4 }),
         std::make_tuple(EntityKind::USER, 13, std::vector<size_t> { 4 }),
         // DATAREADER - PROCESS
-        std::make_tuple(EntityKind::PROCESS, 14, std::vector<size_t> { 6 }),
+        std::make_tuple(EntityKind::PROCESS, 15, std::vector<size_t> { 6 }),
         std::make_tuple(EntityKind::PROCESS, 13, std::vector<size_t> { 6 }),
         // DATAREADER - DOMAIN
-        std::make_tuple(EntityKind::DOMAIN, 14, std::vector<size_t> { 8 }),
+        std::make_tuple(EntityKind::DOMAIN, 15, std::vector<size_t> { 8 }),
         std::make_tuple(EntityKind::DOMAIN, 13, std::vector<size_t> { 8 }),
         // DATAREADER - PARTICIPANT
-        std::make_tuple(EntityKind::PARTICIPANT, 14, std::vector<size_t> { 10 }),
+        std::make_tuple(EntityKind::PARTICIPANT, 15, std::vector<size_t> { 10 }),
         std::make_tuple(EntityKind::PARTICIPANT, 13, std::vector<size_t> { 10 }),
         // DATAREADER - TOPIC
-        std::make_tuple(EntityKind::TOPIC, 14, std::vector<size_t> { 12 }),
+        std::make_tuple(EntityKind::TOPIC, 15, std::vector<size_t> { 12 }),
         std::make_tuple(EntityKind::TOPIC, 13, std::vector<size_t> { 12 }),
         // DATAREADER - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 14, std::vector<size_t> { 15, 16 }),
-        std::make_tuple(EntityKind::DATAWRITER, 13, std::vector<size_t> { 15, 16}),
+        std::make_tuple(EntityKind::DATAWRITER, 15, std::vector<size_t> { 17, 19 }),
+        std::make_tuple(EntityKind::DATAWRITER, 13, std::vector<size_t> { 17, 19}),
         // DATAREADER - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 14, std::vector<size_t> { 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 15, std::vector<size_t> { 15 }),
         std::make_tuple(EntityKind::DATAREADER, 13, std::vector<size_t> { 13 }),
         // DATAREADER - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 14, std::vector<size_t> { 17, 18 }),
+        std::make_tuple(EntityKind::LOCATOR, 15, std::vector<size_t> { 14, 16 }),
         // DATAREADER - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 13, std::vector<size_t> { 17 }),
+        std::make_tuple(EntityKind::LOCATOR, 13, std::vector<size_t> { 14 }),
 
         // DATAWRITER - HOST
-        std::make_tuple(EntityKind::HOST, 16, std::vector<size_t> { 2 }),
-        std::make_tuple(EntityKind::HOST, 15, std::vector<size_t> { 2 }),
+        std::make_tuple(EntityKind::HOST, 19, std::vector<size_t> { 2 }),
+        std::make_tuple(EntityKind::HOST, 17, std::vector<size_t> { 2 }),
         // DATAWRITER - USER
-        std::make_tuple(EntityKind::USER, 16, std::vector<size_t> { 4 }),
-        std::make_tuple(EntityKind::USER, 15, std::vector<size_t> { 4 }),
+        std::make_tuple(EntityKind::USER, 19, std::vector<size_t> { 4 }),
+        std::make_tuple(EntityKind::USER, 17, std::vector<size_t> { 4 }),
         // DATAWRITER - PROCESS
-        std::make_tuple(EntityKind::PROCESS, 16, std::vector<size_t> { 6 }),
-        std::make_tuple(EntityKind::PROCESS, 15, std::vector<size_t> { 6 }),
+        std::make_tuple(EntityKind::PROCESS, 19, std::vector<size_t> { 6 }),
+        std::make_tuple(EntityKind::PROCESS, 17, std::vector<size_t> { 6 }),
         // DATAWRITER - DOMAIN
-        std::make_tuple(EntityKind::DOMAIN, 16, std::vector<size_t> { 8 }),
-        std::make_tuple(EntityKind::DOMAIN, 15, std::vector<size_t> { 8 }),
+        std::make_tuple(EntityKind::DOMAIN, 19, std::vector<size_t> { 8 }),
+        std::make_tuple(EntityKind::DOMAIN, 17, std::vector<size_t> { 8 }),
         // DATAWRITER - PARTICIPANT
-        std::make_tuple(EntityKind::PARTICIPANT, 16, std::vector<size_t> { 10 }),
-        std::make_tuple(EntityKind::PARTICIPANT, 15, std::vector<size_t> { 10 }),
+        std::make_tuple(EntityKind::PARTICIPANT, 19, std::vector<size_t> { 10 }),
+        std::make_tuple(EntityKind::PARTICIPANT, 17, std::vector<size_t> { 10 }),
         // DATAWRITER - TOPIC
-        std::make_tuple(EntityKind::TOPIC, 16, std::vector<size_t> { 12 }),
-        std::make_tuple(EntityKind::TOPIC, 15, std::vector<size_t> { 12 }),
+        std::make_tuple(EntityKind::TOPIC, 19, std::vector<size_t> { 12 }),
+        std::make_tuple(EntityKind::TOPIC, 17, std::vector<size_t> { 12 }),
         // DATAWRITER - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 16, std::vector<size_t> { 16 }),
-        std::make_tuple(EntityKind::DATAWRITER, 15, std::vector<size_t> { 15}),
+        std::make_tuple(EntityKind::DATAWRITER, 19, std::vector<size_t> { 19 }),
+        std::make_tuple(EntityKind::DATAWRITER, 17, std::vector<size_t> { 17}),
         // DATAWRITER - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 16, std::vector<size_t> { 13, 14 }),
-        std::make_tuple(EntityKind::DATAREADER, 15, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 19, std::vector<size_t> { 13, 15 }),
+        std::make_tuple(EntityKind::DATAREADER, 17, std::vector<size_t> { 13, 15 }),
         // DATAWRITER - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 16, std::vector<size_t> { 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 19, std::vector<size_t> { 18, 20 }),
         // DATAWRITER - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 15, std::vector<size_t> { 19 }),
+        std::make_tuple(EntityKind::LOCATOR, 17, std::vector<size_t> { 18 }),
 
         // LOCATOR - HOST
-        std::make_tuple(EntityKind::HOST, 17, std::vector<size_t> { 2 }),
+        std::make_tuple(EntityKind::HOST, 14, std::vector<size_t> { 2 }),
+        std::make_tuple(EntityKind::HOST, 16, std::vector<size_t> { 2 }),
         std::make_tuple(EntityKind::HOST, 18, std::vector<size_t> { 2 }),
-        std::make_tuple(EntityKind::HOST, 19, std::vector<size_t> { 2 }),
         std::make_tuple(EntityKind::HOST, 20, std::vector<size_t> { 2 }),
         // LOCATOR - USER
-        std::make_tuple(EntityKind::USER, 17, std::vector<size_t> { 4 }),
+        std::make_tuple(EntityKind::USER, 14, std::vector<size_t> { 4 }),
+        std::make_tuple(EntityKind::USER, 16, std::vector<size_t> { 4 }),
         std::make_tuple(EntityKind::USER, 18, std::vector<size_t> { 4 }),
-        std::make_tuple(EntityKind::USER, 19, std::vector<size_t> { 4 }),
         std::make_tuple(EntityKind::USER, 20, std::vector<size_t> { 4 }),
         // LOCATOR - PROCESS
-        std::make_tuple(EntityKind::PROCESS, 17, std::vector<size_t> { 6 }),
+        std::make_tuple(EntityKind::PROCESS, 14, std::vector<size_t> { 6 }),
+        std::make_tuple(EntityKind::PROCESS, 16, std::vector<size_t> { 6 }),
         std::make_tuple(EntityKind::PROCESS, 18, std::vector<size_t> { 6 }),
-        std::make_tuple(EntityKind::PROCESS, 19, std::vector<size_t> { 6 }),
         std::make_tuple(EntityKind::PROCESS, 20, std::vector<size_t> { 6 }),
         // LOCATOR - DOMAIN
-        std::make_tuple(EntityKind::DOMAIN, 17, std::vector<size_t> { 8 }),
+        std::make_tuple(EntityKind::DOMAIN, 14, std::vector<size_t> { 8 }),
+        std::make_tuple(EntityKind::DOMAIN, 16, std::vector<size_t> { 8 }),
         std::make_tuple(EntityKind::DOMAIN, 18, std::vector<size_t> { 8 }),
-        std::make_tuple(EntityKind::DOMAIN, 19, std::vector<size_t> { 8 }),
         std::make_tuple(EntityKind::DOMAIN, 20, std::vector<size_t> { 8 }),
         // LOCATOR - PARTICIPANT
-        std::make_tuple(EntityKind::PARTICIPANT, 17, std::vector<size_t> { 10 }),
+        std::make_tuple(EntityKind::PARTICIPANT, 14, std::vector<size_t> { 10 }),
+        std::make_tuple(EntityKind::PARTICIPANT, 16, std::vector<size_t> { 10 }),
         std::make_tuple(EntityKind::PARTICIPANT, 18, std::vector<size_t> { 10 }),
-        std::make_tuple(EntityKind::PARTICIPANT, 19, std::vector<size_t> { 10 }),
         std::make_tuple(EntityKind::PARTICIPANT, 20, std::vector<size_t> { 10 }),
         // LOCATOR - TOPIC
-        std::make_tuple(EntityKind::TOPIC, 17, std::vector<size_t> { 12 }),
+        std::make_tuple(EntityKind::TOPIC, 14, std::vector<size_t> { 12 }),
+        std::make_tuple(EntityKind::TOPIC, 16, std::vector<size_t> { 12 }),
         std::make_tuple(EntityKind::TOPIC, 18, std::vector<size_t> { 12 }),
-        std::make_tuple(EntityKind::TOPIC, 19, std::vector<size_t> { 12 }),
         std::make_tuple(EntityKind::TOPIC, 20, std::vector<size_t> { 12 }),
         // LOCATOR - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 17, std::vector<size_t> { }),
-        std::make_tuple(EntityKind::DATAWRITER, 18, std::vector<size_t> { }),
-        std::make_tuple(EntityKind::DATAWRITER, 19, std::vector<size_t> { 15, 16 }),
-        std::make_tuple(EntityKind::DATAWRITER, 20, std::vector<size_t> { 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 14, std::vector<size_t> { }),
+        std::make_tuple(EntityKind::DATAWRITER, 16, std::vector<size_t> { }),
+        std::make_tuple(EntityKind::DATAWRITER, 18, std::vector<size_t> { 17, 19 }),
+        std::make_tuple(EntityKind::DATAWRITER, 20, std::vector<size_t> { 19 }),
         // LOCATOR - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 17, std::vector<size_t> { 13, 14 }),
-        std::make_tuple(EntityKind::DATAREADER, 18, std::vector<size_t> { 14 }),
-        std::make_tuple(EntityKind::DATAREADER, 19, std::vector<size_t> { }),
+        std::make_tuple(EntityKind::DATAREADER, 14, std::vector<size_t> { 13, 15 }),
+        std::make_tuple(EntityKind::DATAREADER, 16, std::vector<size_t> { 15 }),
+        std::make_tuple(EntityKind::DATAREADER, 18, std::vector<size_t> { }),
         std::make_tuple(EntityKind::DATAREADER, 20, std::vector<size_t> { }),
         // LOCATOR - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 17, std::vector<size_t> { 17 }),
+        std::make_tuple(EntityKind::LOCATOR, 14, std::vector<size_t> { 14 }),
+        std::make_tuple(EntityKind::LOCATOR, 16, std::vector<size_t> { 16 }),
         std::make_tuple(EntityKind::LOCATOR, 18, std::vector<size_t> { 18 }),
-        std::make_tuple(EntityKind::LOCATOR, 19, std::vector<size_t> { 19 }),
         std::make_tuple(EntityKind::LOCATOR, 20, std::vector<size_t> { 20 })
         ));
 

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -505,10 +505,11 @@ TEST_F(database_queue_tests, push_domain)
     EXPECT_CALL(database, insert(_)).Times(1)
             .WillOnce(Invoke(&insert_args, &InsertEntityArgs::insert));
 
-    // Expectations: Request the backend to notify user (if needed)
+    // Expectations: Domains are not discovered, they are created on monitor initialization
+    // Never try to inform the user
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
             on_domain_entity_discovery(EntityId(0), EntityId(
-                0), EntityKind::DOMAIN, details::StatisticsBackendData::DISCOVERY)).Times(1);
+                0), EntityKind::DOMAIN, details::StatisticsBackendData::DISCOVERY)).Times(0);
 
     // Add to the queue and wait to be processed
     entity_queue.push(timestamp, {domain, 0});

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -66,6 +66,7 @@ set(BACKEND_TEST_LIST
     get_type
     get_data_supported_entity_kinds
     set_alias
+    internal_callbacks_negative_cases
     )
 
 foreach(test_name ${BACKEND_TEST_LIST})

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -67,6 +67,7 @@ set(BACKEND_TEST_LIST
     get_data_supported_entity_kinds
     set_alias
     internal_callbacks_negative_cases
+    set_listener_non_existent_monitor
     )
 
 foreach(test_name ${BACKEND_TEST_LIST})

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -189,7 +189,45 @@ foreach(test_name ${USER_LISTENERS_DEATH_TEST_LIST})
     endif(TEST_FRIENDLY_PATH)
 endforeach()
 
-set(USER_DATA_LISTENERS_TEST_LIST
+set(USER_LISTENERS_TEST_LIST_PHYSICAL_ENTITIES
+    entity_discovered
+    entity_discovered_not_in_mask
+    entity_discovered_no_listener
+    entity_discovered_no_listener_not_in_mask
+    )
+
+foreach(test_name ${USER_LISTENERS_TEST_LIST_PHYSICAL_ENTITIES})
+
+    add_test(NAME calling_user_listeners_tests_physical_entities.${test_name}
+        COMMAND calling_user_listeners_tests
+        --gtest_filter=calling_user_listeners_tests_physical_entities.${test_name}:*/calling_user_listeners_tests_physical_entities.${test_name}/*)
+
+    if(TEST_FRIENDLY_PATH)
+        set_tests_properties(calling_user_listeners_tests_physical_entities.${test_name} PROPERTIES ENVIRONMENT "PATH=${TEST_FRIENDLY_PATH}")
+    endif(TEST_FRIENDLY_PATH)
+
+endforeach()
+
+    set(USER_LISTENERS_TEST_LIST_DOMAIN_ENTITIES
+    entity_discovered
+    entity_discovered_not_in_mask
+    entity_discovered_no_listener
+    entity_discovered_no_listener_not_in_mask
+    )
+
+foreach(test_name ${USER_LISTENERS_TEST_LIST_DOMAIN_ENTITIES})
+
+    add_test(NAME calling_user_listeners_tests_domain_entities.${test_name}
+        COMMAND calling_user_listeners_tests
+        --gtest_filter=calling_user_listeners_tests_domain_entities.${test_name}:*/calling_user_listeners_tests_domain_entities.${test_name}/*)
+
+    if(TEST_FRIENDLY_PATH)
+        set_tests_properties(calling_user_listeners_tests_domain_entities.${test_name} PROPERTIES ENVIRONMENT "PATH=${TEST_FRIENDLY_PATH}")
+    endif(TEST_FRIENDLY_PATH)
+
+endforeach()
+
+set(USER_LISTENERS_TEST_LIST_DATAS
     data_available
     data_available_callback_not_in_mask
     data_available_data_not_in_mask
@@ -198,14 +236,16 @@ set(USER_DATA_LISTENERS_TEST_LIST
     data_available_no_listener_data_not_in_mask
     )
 
-foreach(test_name ${USER_DATA_LISTENERS_TEST_LIST})
-    add_test(NAME calling_user_listeners_tests.${test_name}
+foreach(test_name ${USER_LISTENERS_TEST_LIST_DATAS})
+
+    add_test(NAME calling_user_listeners_tests_datas.${test_name}
             COMMAND calling_user_listeners_tests
-            --gtest_filter=calling_user_data_listeners_tests.${test_name}:*/calling_user_data_listeners_tests.${test_name}/*)
+            --gtest_filter=calling_user_listeners_tests_datas.${test_name}:*/calling_user_listeners_tests_datas.${test_name}/*)
 
     if(TEST_FRIENDLY_PATH)
-        set_tests_properties(calling_user_listeners_tests.${test_name} PROPERTIES ENVIRONMENT "PATH=${TEST_FRIENDLY_PATH}")
+        set_tests_properties(calling_user_listeners_tests_datas.${test_name} PROPERTIES ENVIRONMENT "PATH=${TEST_FRIENDLY_PATH}")
     endif(TEST_FRIENDLY_PATH)
+
 endforeach()
 
 

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -1154,7 +1154,7 @@ public:
         StatisticsBackend::stop_monitor(monitor_id_);
         details::StatisticsBackendData::reset_instance();
     }
-    
+
     DataKind data_kind_;
     CallbackKind callback_kind_;
     MockedPhysicalListener physical_listener_;

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -289,6 +289,56 @@ public:
 
         Mock::VerifyAndClearExpectations(&physical_listener);
     }
+
+        /*
+     * This method extends the tests for the testcases where there is no callback triggered
+     * in the starting configuration.
+     * 
+     * It sets the appropriate physical listener and retests.
+     */
+    void extend_no_callback_tests()
+    {
+        EntityKind entity_kind = std::get<0>(GetParam());
+        CallbackKind callback_kind = std::get<1>(GetParam());
+
+        // Set the physical listener and test
+        CallbackMask mask = CallbackMask::none();
+        mask.set(callback_kind);
+        StatisticsBackend::set_physical_listener(
+            &physical_listener,
+            mask,
+            DataKindMask::all());
+
+        // Expectation: Only the physical listener is called
+        test_entity_discovery(PHYSICAL, entity_kind,
+                [&](
+                    EntityId domain_id,
+                    EntityId entity_id,
+                    const DomainListener::Status& status)
+                {
+                    EXPECT_EQ(0, domain_id);
+                    EXPECT_EQ(1, entity_id);
+                    EXPECT_EQ(2, status.total_count);
+                    EXPECT_EQ(2, status.total_count_change);
+                    EXPECT_EQ(2, status.current_count);
+                    EXPECT_EQ(2, status.current_count_change);
+                });
+
+        // Expectation: Only the physical listener is called again
+        test_entity_discovery(PHYSICAL, entity_kind,
+                [&](
+                    EntityId domain_id,
+                    EntityId entity_id,
+                    const DomainListener::Status& status)
+                {
+                    EXPECT_EQ(0, domain_id);
+                    EXPECT_EQ(1, entity_id);
+                    EXPECT_EQ(3, status.total_count);
+                    EXPECT_EQ(1, status.total_count_change);
+                    EXPECT_EQ(3, status.current_count);
+                    EXPECT_EQ(1, status.current_count_change);
+                });
+    }
 };
 
 TEST_P(calling_user_listeners_tests_physical_entities, entity_discovered)
@@ -348,6 +398,8 @@ TEST_P(calling_user_listeners_tests_physical_entities, entity_discovered_not_in_
 
     // Expectation: The user listener is never called
     test_entity_discovery(NONE, entity_kind);
+
+    extend_no_callback_tests();
 }
 
 TEST_P(calling_user_listeners_tests_physical_entities, entity_discovered_no_listener)
@@ -364,6 +416,8 @@ TEST_P(calling_user_listeners_tests_physical_entities, entity_discovered_no_list
 
     // Expectation: The user listener is never called
     test_entity_discovery(NONE, entity_kind);
+
+    extend_no_callback_tests();
 }
 
 TEST_P(calling_user_listeners_tests_physical_entities, entity_discovered_no_listener_not_in_mask)
@@ -380,6 +434,8 @@ TEST_P(calling_user_listeners_tests_physical_entities, entity_discovered_no_list
 
     // Expectation: The user listener is never called
     test_entity_discovery(NONE, entity_kind);
+
+    extend_no_callback_tests();
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -588,8 +588,8 @@ public:
                 {
                     EXPECT_EQ(monitor_id, domain_id);
                     EXPECT_EQ(1, entity_id);
-                    EXPECT_EQ(1, status.total_count);
-                    EXPECT_EQ(1, status.total_count_change);
+                    EXPECT_EQ(2, status.total_count);
+                    EXPECT_EQ(2, status.total_count_change);
                     EXPECT_EQ(1, status.current_count);
                     EXPECT_EQ(1, status.current_count_change);
                 });
@@ -603,7 +603,7 @@ public:
                 {
                     EXPECT_EQ(monitor_id, domain_id);
                     EXPECT_EQ(1, entity_id);
-                    EXPECT_EQ(2, status.total_count);
+                    EXPECT_EQ(3, status.total_count);
                     EXPECT_EQ(1, status.total_count_change);
                     EXPECT_EQ(2, status.current_count);
                     EXPECT_EQ(1, status.current_count_change);
@@ -618,7 +618,7 @@ public:
                 {
                     EXPECT_EQ(monitor_id, domain_id);
                     EXPECT_EQ(1, entity_id);
-                    EXPECT_EQ(2, status.total_count);
+                    EXPECT_EQ(3, status.total_count);
                     EXPECT_EQ(0, status.total_count_change);
                     EXPECT_EQ(2, status.current_count);
                     EXPECT_EQ(0, status.current_count_change);
@@ -633,7 +633,7 @@ public:
                 {
                     EXPECT_EQ(monitor_id, domain_id);
                     EXPECT_EQ(1, entity_id);
-                    EXPECT_EQ(2, status.total_count);
+                    EXPECT_EQ(3, status.total_count);
                     EXPECT_EQ(0, status.total_count_change);
                     EXPECT_EQ(1, status.current_count);
                     EXPECT_EQ(-1, status.current_count_change);
@@ -655,7 +655,7 @@ public:
                 {
                     EXPECT_EQ(monitor_id, domain_id);
                     EXPECT_EQ(1, entity_id);
-                    EXPECT_EQ(3, status.total_count);
+                    EXPECT_EQ(4, status.total_count);
                     EXPECT_EQ(1, status.total_count_change);
                     EXPECT_EQ(2, status.current_count);
                     EXPECT_EQ(1, status.current_count_change);
@@ -670,7 +670,7 @@ public:
                 {
                     EXPECT_EQ(monitor_id, domain_id);
                     EXPECT_EQ(1, entity_id);
-                    EXPECT_EQ(4, status.total_count);
+                    EXPECT_EQ(5, status.total_count);
                     EXPECT_EQ(1, status.total_count_change);
                     EXPECT_EQ(3, status.current_count);
                     EXPECT_EQ(1, status.current_count_change);
@@ -685,7 +685,7 @@ public:
                 {
                     EXPECT_EQ(monitor_id, domain_id);
                     EXPECT_EQ(1, entity_id);
-                    EXPECT_EQ(4, status.total_count);
+                    EXPECT_EQ(5, status.total_count);
                     EXPECT_EQ(0, status.total_count_change);
                     EXPECT_EQ(3, status.current_count);
                     EXPECT_EQ(0, status.current_count_change);
@@ -700,7 +700,7 @@ public:
                 {
                     EXPECT_EQ(monitor_id, domain_id);
                     EXPECT_EQ(1, entity_id);
-                    EXPECT_EQ(4, status.total_count);
+                    EXPECT_EQ(5, status.total_count);
                     EXPECT_EQ(0, status.total_count_change);
                     EXPECT_EQ(2, status.current_count);
                     EXPECT_EQ(-1, status.current_count_change);

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -626,8 +626,8 @@ public:
      */
     void extend_no_callback_tests()
     {
-        EntityKind entity_kind = std::get<1>(GetParam());
-        CallbackKind callback_kind = std::get<2>(GetParam());
+        EntityKind entity_kind = std::get<0>(GetParam());
+        CallbackKind callback_kind = std::get<1>(GetParam());
 
         // Set the physical listener and test
         CallbackMask mask = CallbackMask::none();
@@ -1205,7 +1205,7 @@ public:
      */
     void extend_no_callback_tests()
     {
-        DataKind data_kind = std::get<1>(GetParam());
+        DataKind data_kind = std::get<0>(GetParam());
 
         // Set the physical listener and test
         CallbackMask callback_mask = CallbackMask::none();

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -36,10 +36,10 @@ using ::testing::Mock;
 using namespace eprosima::statistics_backend;
 
 using DiscoveryStatus = details::StatisticsBackendData::DiscoveryStatus;
-using ArgumentChecker = std::function<void(
-                EntityId,
-                EntityId,
-                const DomainListener::Status& status)>;
+using ArgumentChecker = std::function<void (
+                    EntityId,
+                    EntityId,
+                    const DomainListener::Status& status)>;
 
 struct EntityDiscoveryArgs
 {
@@ -155,7 +155,8 @@ public:
                 DataKind data_kind));
 };
 
-class calling_user_listeners_tests_physical_entities : public ::testing::TestWithParam<std::tuple<EntityKind, CallbackKind>>
+class calling_user_listeners_tests_physical_entities : public ::testing::TestWithParam<std::tuple<EntityKind,
+            CallbackKind>>
 {
 public:
 
@@ -188,12 +189,12 @@ public:
     void test_entity_discovery(
             ListenerKind listener_kind,
             EntityKind entity_kind,
-            ArgumentChecker checker = [](
+            ArgumentChecker checker = [] (
                 EntityId,
                 EntityId,
                 const DomainListener::Status&)
-            {
-            })
+    {
+    })
     {
         // Set the callback of the expectations
         discovery_args.callback_ = checker;
@@ -206,7 +207,7 @@ public:
                 if (listener_kind == PHYSICAL)
                 {
                     EXPECT_CALL(physical_listener, on_host_discovery(EntityId(0), EntityId(1), _)).Times(1)
-                        .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
+                            .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
                 }
                 else
                 {
@@ -215,9 +216,9 @@ public:
 
                 // Execution
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                        EntityId(0),
-                        EntityId(1),
-                        EntityKind::HOST);
+                    EntityId(0),
+                    EntityId(1),
+                    EntityKind::HOST);
 
                 break;
             }
@@ -226,7 +227,7 @@ public:
                 if (listener_kind == PHYSICAL)
                 {
                     EXPECT_CALL(physical_listener, on_user_discovery(EntityId(0), EntityId(1), _)).Times(1)
-                        .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
+                            .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
                 }
                 else
                 {
@@ -235,9 +236,9 @@ public:
 
                 // Execution
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                        EntityId(0),
-                        EntityId(1),
-                        EntityKind::USER);
+                    EntityId(0),
+                    EntityId(1),
+                    EntityKind::USER);
 
                 break;
             }
@@ -246,7 +247,7 @@ public:
                 if (listener_kind == PHYSICAL)
                 {
                     EXPECT_CALL(physical_listener, on_process_discovery(EntityId(0), EntityId(1), _)).Times(1)
-                        .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
+                            .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
                 }
                 else
                 {
@@ -255,9 +256,9 @@ public:
 
                 // Execution
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                        EntityId(0),
-                        EntityId(1),
-                        EntityKind::PROCESS);
+                    EntityId(0),
+                    EntityId(1),
+                    EntityKind::PROCESS);
 
                 break;
             }
@@ -266,7 +267,7 @@ public:
                 if (listener_kind == PHYSICAL)
                 {
                     EXPECT_CALL(physical_listener, on_locator_discovery(EntityId(0), EntityId(1), _)).Times(1)
-                        .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
+                            .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
                 }
                 else
                 {
@@ -275,9 +276,9 @@ public:
 
                 // Execution
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                        EntityId(0),
-                        EntityId(1),
-                        EntityKind::LOCATOR);
+                    EntityId(0),
+                    EntityId(1),
+                    EntityKind::LOCATOR);
 
                 break;
             }
@@ -290,10 +291,10 @@ public:
         Mock::VerifyAndClearExpectations(&physical_listener);
     }
 
-        /*
+    /*
      * This method extends the tests for the testcases where there is no callback triggered
      * in the starting configuration.
-     * 
+     *
      * It sets the appropriate physical listener and retests.
      */
     void extend_no_callback_tests()
@@ -339,6 +340,7 @@ public:
                     EXPECT_EQ(1, status.current_count_change);
                 });
     }
+
 };
 
 TEST_P(calling_user_listeners_tests_physical_entities, entity_discovered)
@@ -457,7 +459,7 @@ GTEST_INSTANTIATE_TEST_MACRO(
 
 
 class calling_user_listeners_tests_domain_entities
-        : public ::testing::TestWithParam<std::tuple<EntityKind, CallbackKind>>
+    : public ::testing::TestWithParam<std::tuple<EntityKind, CallbackKind>>
 {
 public:
 
@@ -477,12 +479,12 @@ public:
             ListenerKind listener_kind,
             EntityKind entity_kind,
             DiscoveryStatus discovery_status = DiscoveryStatus::DISCOVERY,
-            ArgumentChecker checker = [](
+            ArgumentChecker checker = [] (
                 EntityId,
                 EntityId,
                 const DomainListener::Status&)
-            {
-            })
+    {
+    })
     {
         // Set the callback of the expectations
         discovery_args.callback_ = checker;
@@ -494,14 +496,14 @@ public:
                 if (listener_kind == PHYSICAL)
                 {
                     EXPECT_CALL(physical_listener, on_participant_discovery(monitor_id, EntityId(1), _)).Times(1)
-                        .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
+                            .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
                     EXPECT_CALL(domain_listener, on_participant_discovery(_, _, _)).Times(0);
                 }
                 else if (listener_kind == DOMAIN)
                 {
                     EXPECT_CALL(physical_listener, on_participant_discovery(_, _, _)).Times(0);
                     EXPECT_CALL(domain_listener, on_participant_discovery(monitor_id, EntityId(1), _)).Times(1)
-                        .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
+                            .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
                 }
                 else
                 {
@@ -511,10 +513,10 @@ public:
 
                 // Execution
                 details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
-                        monitor_id,
-                        EntityId(1),
-                        EntityKind::PARTICIPANT,
-                        discovery_status);
+                    monitor_id,
+                    EntityId(1),
+                    EntityKind::PARTICIPANT,
+                    discovery_status);
 
                 break;
             }
@@ -523,14 +525,14 @@ public:
                 if (listener_kind == PHYSICAL)
                 {
                     EXPECT_CALL(physical_listener, on_topic_discovery(monitor_id, EntityId(1), _)).Times(1)
-                        .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
+                            .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
                     EXPECT_CALL(domain_listener, on_topic_discovery(_, _, _)).Times(0);
                 }
                 else if (listener_kind == DOMAIN)
                 {
                     EXPECT_CALL(physical_listener, on_topic_discovery(_, _, _)).Times(0);
                     EXPECT_CALL(domain_listener, on_topic_discovery(monitor_id, EntityId(1), _)).Times(1)
-                        .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
+                            .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
                 }
                 else
                 {
@@ -540,10 +542,10 @@ public:
 
                 // Execution
                 details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
-                        monitor_id,
-                        EntityId(1),
-                        EntityKind::TOPIC,
-                        discovery_status);
+                    monitor_id,
+                    EntityId(1),
+                    EntityKind::TOPIC,
+                    discovery_status);
 
                 break;
             }
@@ -552,14 +554,14 @@ public:
                 if (listener_kind == PHYSICAL)
                 {
                     EXPECT_CALL(physical_listener, on_datareader_discovery(monitor_id, EntityId(1), _)).Times(1)
-                        .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
+                            .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
                     EXPECT_CALL(domain_listener, on_datareader_discovery(_, _, _)).Times(0);
                 }
                 else if (listener_kind == DOMAIN)
                 {
                     EXPECT_CALL(physical_listener, on_datareader_discovery(_, _, _)).Times(0);
                     EXPECT_CALL(domain_listener, on_datareader_discovery(monitor_id, EntityId(1), _)).Times(1)
-                        .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
+                            .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
                 }
                 else
                 {
@@ -569,10 +571,10 @@ public:
 
                 // Execution
                 details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
-                        monitor_id,
-                        EntityId(1),
-                        EntityKind::DATAREADER,
-                        discovery_status);
+                    monitor_id,
+                    EntityId(1),
+                    EntityKind::DATAREADER,
+                    discovery_status);
 
                 break;
             }
@@ -581,14 +583,14 @@ public:
                 if (listener_kind == PHYSICAL)
                 {
                     EXPECT_CALL(physical_listener, on_datawriter_discovery(monitor_id, EntityId(1), _)).Times(1)
-                        .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
+                            .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
                     EXPECT_CALL(domain_listener, on_datawriter_discovery(_, _, _)).Times(0);
                 }
                 else if (listener_kind == DOMAIN)
                 {
                     EXPECT_CALL(physical_listener, on_datawriter_discovery(_, _, _)).Times(0);
                     EXPECT_CALL(domain_listener, on_datawriter_discovery(monitor_id, EntityId(1), _)).Times(1)
-                        .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
+                            .WillOnce(Invoke(&discovery_args, &EntityDiscoveryArgs::on_discovery));
                 }
                 else
                 {
@@ -598,10 +600,10 @@ public:
 
                 // Execution
                 details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
-                        monitor_id,
-                        EntityId(1),
-                        EntityKind::DATAWRITER,
-                        discovery_status);
+                    monitor_id,
+                    EntityId(1),
+                    EntityKind::DATAWRITER,
+                    discovery_status);
 
                 break;
             }
@@ -618,7 +620,7 @@ public:
     /*
      * This method extends the tests for the testcases where there is no callback triggered
      * in the starting configuration.
-     * 
+     *
      * First it sets the appropriate physical listener and retests with DISCOVERY, UPDATE and UNDISCOVERY.
      * Then sets the domain listener and retests with DISCOVERY, UPDATE and UNDISCOVERY.
      */
@@ -1157,8 +1159,8 @@ public:
     MockedPhysicalListener physical_listener;
     MockedDomainListener domain_listener;
     EntityId monitor_id;
-    
-        enum ListenerKind
+
+    enum ListenerKind
     {
         NONE,
         PHYSICAL,
@@ -1172,7 +1174,7 @@ public:
 
         if (listener_kind == PHYSICAL)
         {
-            EXPECT_CALL(physical_listener, on_data_available(monitor_id,EntityId(1), data_kind)).Times(1);
+            EXPECT_CALL(physical_listener, on_data_available(monitor_id, EntityId(1), data_kind)).Times(1);
             EXPECT_CALL(domain_listener, on_data_available(_, _, _)).Times(0);
 
         }
@@ -1189,15 +1191,15 @@ public:
 
         // Execution
         details::StatisticsBackendData::get_instance()->on_data_available(
-                monitor_id,
-                EntityId(1),
-                data_kind);
+            monitor_id,
+            EntityId(1),
+            data_kind);
     }
 
-   /*
+    /*
      * This method extends the tests for the testcases where there is no callback triggered
      * in the starting configuration.
-     * 
+     *
      * First it sets the appropriate physical listener and retests.
      * Then sets the domain listener and retests.
      */
@@ -1249,6 +1251,7 @@ public:
         StatisticsBackend::stop_monitor(monitor_id);
         details::StatisticsBackendData::reset_instance();
     }
+
 };
 
 TEST_P(calling_user_listeners_tests_datas, data_available)

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -768,7 +768,9 @@ public:
     calling_user_listeners_tests_domain_entities()
     {
         // Set the profile to ignore discovery data from other processes
+        // Set the profile to ignore discovery data from other processes
         eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->load_XML_profiles_file("profile.xml");
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->load_profiles();
 
         monitor_id = StatisticsBackend::init_monitor(0, nullptr, CallbackMask::none(), DataKindMask::none());
     }

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -394,6 +394,181 @@ TEST_F(statistics_backend_tests, set_alias)
     }
 }
 
+TEST_F(statistics_backend_tests, internal_callbacks_negative_cases)
+{
+    StatisticsBackendTest::set_database(db);
+
+    // Will be using entities that are on the database,
+    // to make sure the error is due to the intended reason
+
+    // Check that there is a monitor with EntityId(7)
+    // This will be used in all calls to on_domain_entity_discovery
+    auto result = StatisticsBackendTest::get_entities(EntityKind::DOMAIN, EntityId(7));
+    ASSERT_EQ(1, result.size());
+    EntityId monitor_id = EntityId(7);
+
+    result = StatisticsBackendTest::get_entities(EntityKind::HOST, EntityId(1));
+    ASSERT_EQ(1, result.size());
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                monitor_id,
+                EntityId(1),
+                EntityKind::HOST,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                monitor_id,
+                EntityId(1),
+                EntityKind::HOST,
+                details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                monitor_id,
+                EntityId(1),
+                EntityKind::HOST,
+                details::StatisticsBackendData::DiscoveryStatus::UPDATE),
+            ".*");
+
+    result = StatisticsBackendTest::get_entities(EntityKind::USER, EntityId(3));
+    ASSERT_EQ(1, result.size());
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                monitor_id,
+                EntityId(3),
+                EntityKind::USER,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                monitor_id,
+                EntityId(3),
+                EntityKind::USER,
+                details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                monitor_id,
+                EntityId(3),
+                EntityKind::USER,
+                details::StatisticsBackendData::DiscoveryStatus::UPDATE),
+            ".*");
+
+    result = StatisticsBackendTest::get_entities(EntityKind::PROCESS, EntityId(5));
+    ASSERT_EQ(1, result.size());
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                monitor_id,
+                EntityId(5),
+                EntityKind::PROCESS,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                monitor_id,
+                EntityId(5),
+                EntityKind::PROCESS,
+                details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                monitor_id,
+                EntityId(5),
+                EntityKind::PROCESS,
+                details::StatisticsBackendData::DiscoveryStatus::UPDATE),
+            ".*");
+
+    result = StatisticsBackendTest::get_entities(EntityKind::LOCATOR, EntityId(17));
+    ASSERT_EQ(1, result.size());
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                monitor_id,
+                EntityId(17),
+                EntityKind::LOCATOR,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                monitor_id,
+                EntityId(17),
+                EntityKind::LOCATOR,
+                details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                monitor_id,
+                EntityId(17),
+                EntityKind::LOCATOR,
+                details::StatisticsBackendData::DiscoveryStatus::UPDATE),
+            ".*");
+
+    // Check that there is a Participant with EntityId(9)
+    // This will be used in all calls to on_physical_entity_discovery
+    result = StatisticsBackendTest::get_entities(EntityKind::PARTICIPANT, EntityId(9));
+    ASSERT_EQ(1, result.size());
+    EntityId participant_id = EntityId(9);
+
+    // Avoid a participant discovering itself
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                participant_id,
+                EntityId(9),
+                EntityKind::PARTICIPANT),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                participant_id,
+                EntityId(10),
+                EntityKind::PARTICIPANT),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                participant_id,
+                EntityId(10),
+                EntityKind::PARTICIPANT),
+            ".*");
+
+    result = StatisticsBackendTest::get_entities(EntityKind::TOPIC, EntityId(11));
+    ASSERT_EQ(1, result.size());
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                participant_id,
+                EntityId(11),
+                EntityKind::TOPIC),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                participant_id,
+                EntityId(11),
+                EntityKind::TOPIC),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                participant_id,
+                EntityId(11),
+                EntityKind::TOPIC),
+            ".*");
+
+    result = StatisticsBackendTest::get_entities(EntityKind::DATAREADER, EntityId(13));
+    ASSERT_EQ(1, result.size());
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                participant_id,
+                EntityId(13),
+                EntityKind::DATAREADER),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                participant_id,
+                EntityId(13),
+                EntityKind::DATAREADER),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                participant_id,
+                EntityId(13),
+                EntityKind::DATAREADER),
+            ".*");
+
+    result = StatisticsBackendTest::get_entities(EntityKind::DATAWRITER, EntityId(15));
+    ASSERT_EQ(1, result.size());
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                participant_id,
+                EntityId(15),
+                EntityKind::DATAWRITER),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                participant_id,
+                EntityId(15),
+                EntityKind::DATAWRITER),
+            ".*");
+    ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                participant_id,
+                EntityId(15),
+                EntityKind::DATAWRITER),
+            ".*");
+}
+
 #ifdef INSTANTIATE_TEST_SUITE_P
 #define GTEST_INSTANTIATE_TEST_MACRO(x, y, z) INSTANTIATE_TEST_SUITE_P(x, y, z)
 #else

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -603,22 +603,22 @@ TEST_F(statistics_backend_tests, set_listener_non_existent_monitor)
 
     // Try to set the listener for some monitor when there is none
     EXPECT_THROW(StatisticsBackend::set_domain_listener(
-        EntityId(1000),
-        nullptr,
-        CallbackMask::all(),
-        DataKindMask::all()),
-        BadParameter);
+                EntityId(1000),
+                nullptr,
+                CallbackMask::all(),
+                DataKindMask::all()),
+            BadParameter);
 
     // Start a monitor
     EntityId monitor_id_ = StatisticsBackend::init_monitor(0, nullptr, CallbackMask::none(), DataKindMask::none());
 
     // Try to set the listener for another monitor
     EXPECT_THROW(StatisticsBackend::set_domain_listener(
-        EntityId(monitor_id_.value() + 100),
-        nullptr,
-        CallbackMask::all(),
-        DataKindMask::all()),
-        BadParameter);
+                EntityId(monitor_id_.value() + 100),
+                nullptr,
+                CallbackMask::all(),
+                DataKindMask::all()),
+            BadParameter);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -550,21 +550,21 @@ TEST_F(statistics_backend_tests, internal_callbacks_negative_cases)
                 EntityKind::DATAREADER),
             ".*");
 
-    result = StatisticsBackendTest::get_entities(EntityKind::DATAWRITER, EntityId(15));
+    result = StatisticsBackendTest::get_entities(EntityKind::DATAWRITER, EntityId(17));
     ASSERT_EQ(1, result.size());
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
-                EntityId(15),
+                EntityId(17),
                 EntityKind::DATAWRITER),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
-                EntityId(15),
+                EntityId(17),
                 EntityKind::DATAWRITER),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
-                EntityId(15),
+                EntityId(17),
                 EntityKind::DATAWRITER),
             ".*");
 }
@@ -592,11 +592,11 @@ GTEST_INSTANTIATE_TEST_MACRO(
         // ALL - TOPIC
         std::make_tuple(EntityKind::TOPIC, 0, std::vector<size_t>{11, 12}),
         // ALL - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 0, std::vector<size_t>{13, 14}),
+        std::make_tuple(EntityKind::DATAREADER, 0, std::vector<size_t>{13, 15}),
         // ALL - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 0, std::vector<size_t>{15, 16}),
+        std::make_tuple(EntityKind::DATAWRITER, 0, std::vector<size_t>{17, 19}),
         // ALL - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 0, std::vector<size_t>{17, 18, 19, 20}),
+        std::make_tuple(EntityKind::LOCATOR, 0, std::vector<size_t>{14, 16, 18, 20}),
         // HOST - HOST
         std::make_tuple(EntityKind::HOST, 2, std::vector<size_t> { 2 }),
         std::make_tuple(EntityKind::HOST, 1, std::vector<size_t> { 1 }),
@@ -621,15 +621,15 @@ GTEST_INSTANTIATE_TEST_MACRO(
         // HOST - TOPIC: none
         std::make_tuple(EntityKind::TOPIC, 1, std::vector<size_t> { }),
         // HOST - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 2, std::vector<size_t> { 15, 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 2, std::vector<size_t> { 17, 19 }),
         // HOST - DATAWRITER: none
         std::make_tuple(EntityKind::DATAWRITER, 1, std::vector<size_t> { }),
         // HOST - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 2, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 2, std::vector<size_t> { 13, 15 }),
         // HOST - DATAREADER: none
         std::make_tuple(EntityKind::DATAREADER, 1, std::vector<size_t> { }),
         // HOST - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 2, std::vector<size_t> { 17, 18, 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 2, std::vector<size_t> { 14, 16, 18, 20 }),
         // HOST - LOCATOR: none
         std::make_tuple(EntityKind::LOCATOR, 1, std::vector<size_t> { }),
 
@@ -656,15 +656,15 @@ GTEST_INSTANTIATE_TEST_MACRO(
         // USER - TOPIC: none
         std::make_tuple(EntityKind::TOPIC, 3, std::vector<size_t> { }),
         // USER - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 4, std::vector<size_t> { 15, 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 4, std::vector<size_t> { 17, 19 }),
         // USER - DATAWRITER: none
         std::make_tuple(EntityKind::DATAWRITER, 3, std::vector<size_t> { }),
         // USER - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 4, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 4, std::vector<size_t> { 13, 15 }),
         // USER - DATAREADER: none
         std::make_tuple(EntityKind::DATAREADER, 3, std::vector<size_t> { }),
         // USER - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 4, std::vector<size_t> { 17, 18, 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 4, std::vector<size_t> { 14, 16, 18, 20 }),
         // USER - LOCATOR: none
         std::make_tuple(EntityKind::LOCATOR, 3, std::vector<size_t> { }),
 
@@ -690,15 +690,15 @@ GTEST_INSTANTIATE_TEST_MACRO(
         // PROCESS - TOPIC: none
         std::make_tuple(EntityKind::TOPIC, 5, std::vector<size_t> { }),
         // PROCESS - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 6, std::vector<size_t> { 15, 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 6, std::vector<size_t> { 17, 19 }),
         // PROCESS - DATAWRITER: none
         std::make_tuple(EntityKind::DATAWRITER, 5, std::vector<size_t> { }),
         // PROCESS - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 6, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 6, std::vector<size_t> { 13, 15 }),
         // PROCESS - DATAREADER: none
         std::make_tuple(EntityKind::DATAREADER, 5, std::vector<size_t> { }),
         // PROCESS - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 6, std::vector<size_t> { 17, 18, 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 6, std::vector<size_t> { 14, 16, 18, 20 }),
         // PROCESS - LOCATOR: none
         std::make_tuple(EntityKind::LOCATOR, 5, std::vector<size_t> { }),
 
@@ -726,15 +726,15 @@ GTEST_INSTANTIATE_TEST_MACRO(
         // DOMAIN - TOPIC: none
         std::make_tuple(EntityKind::TOPIC, 7, std::vector<size_t> { }),
         // DOMAIN - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 8, std::vector<size_t> { 15, 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 8, std::vector<size_t> { 17, 19 }),
         // DOMAIN - DATAWRITER: none
         std::make_tuple(EntityKind::DATAWRITER, 7, std::vector<size_t> { }),
         // DOMAIN - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 8, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 8, std::vector<size_t> { 13, 15 }),
         // DOMAIN - DATAREADER: none
         std::make_tuple(EntityKind::DATAREADER, 7, std::vector<size_t> { }),
         // DOMAIN - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 8, std::vector<size_t> { 17, 18, 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 8, std::vector<size_t> { 14, 16, 18, 20 }),
         // DOMAIN - LOCATOR: none
         std::make_tuple(EntityKind::LOCATOR, 7, std::vector<size_t> { }),
 
@@ -758,15 +758,15 @@ GTEST_INSTANTIATE_TEST_MACRO(
         // PARTICIPANT - TOPIC: none
         std::make_tuple(EntityKind::TOPIC, 9, std::vector<size_t> { }),
         // PARTICIPANT - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 10, std::vector<size_t> { 15, 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 10, std::vector<size_t> { 17, 19 }),
         // PARTICIPANT - DATAWRITER: none
         std::make_tuple(EntityKind::DATAWRITER, 9, std::vector<size_t> { }),
         // PARTICIPANT - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 10, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 10, std::vector<size_t> { 13, 15 }),
         // PARTICIPANT - DATAREADER: none
         std::make_tuple(EntityKind::DATAREADER, 9, std::vector<size_t> { }),
         // PARTICIPANT - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 10, std::vector<size_t> { 17, 18, 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 10, std::vector<size_t> { 14, 16, 18, 20 }),
         // PARTICIPANT - LOCATOR: none
         std::make_tuple(EntityKind::LOCATOR, 9, std::vector<size_t> { }),
 
@@ -793,120 +793,120 @@ GTEST_INSTANTIATE_TEST_MACRO(
         std::make_tuple(EntityKind::TOPIC, 12, std::vector<size_t> { 12 }),
         std::make_tuple(EntityKind::TOPIC, 11, std::vector<size_t> { 11 }),
         // TOPIC - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 12, std::vector<size_t> { 15, 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 12, std::vector<size_t> { 17, 19 }),
         // TOPIC - DATAWRITER: none
         std::make_tuple(EntityKind::DATAWRITER, 11, std::vector<size_t> { }),
         // TOPIC - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 12, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 12, std::vector<size_t> { 13, 15 }),
         // TOPIC - DATAREADER: none
         std::make_tuple(EntityKind::DATAREADER, 11, std::vector<size_t> { }),
         // TOPIC - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 12, std::vector<size_t> { 17, 18, 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 12, std::vector<size_t> { 14, 16, 18, 20 }),
         // TOPIC - LOCATOR: none
         std::make_tuple(EntityKind::LOCATOR, 11, std::vector<size_t> { }),
 
         // DATAREADER - HOST
-        std::make_tuple(EntityKind::HOST, 14, std::vector<size_t> { 2 }),
+        std::make_tuple(EntityKind::HOST, 15, std::vector<size_t> { 2 }),
         std::make_tuple(EntityKind::HOST, 13, std::vector<size_t> { 2 }),
         // DATAREADER - USER
-        std::make_tuple(EntityKind::USER, 14, std::vector<size_t> { 4 }),
+        std::make_tuple(EntityKind::USER, 15, std::vector<size_t> { 4 }),
         std::make_tuple(EntityKind::USER, 13, std::vector<size_t> { 4 }),
         // DATAREADER - PROCESS
-        std::make_tuple(EntityKind::PROCESS, 14, std::vector<size_t> { 6 }),
+        std::make_tuple(EntityKind::PROCESS, 15, std::vector<size_t> { 6 }),
         std::make_tuple(EntityKind::PROCESS, 13, std::vector<size_t> { 6 }),
         // DATAREADER - DOMAIN
-        std::make_tuple(EntityKind::DOMAIN, 14, std::vector<size_t> { 8 }),
+        std::make_tuple(EntityKind::DOMAIN, 15, std::vector<size_t> { 8 }),
         std::make_tuple(EntityKind::DOMAIN, 13, std::vector<size_t> { 8 }),
         // DATAREADER - PARTICIPANT
-        std::make_tuple(EntityKind::PARTICIPANT, 14, std::vector<size_t> { 10 }),
+        std::make_tuple(EntityKind::PARTICIPANT, 15, std::vector<size_t> { 10 }),
         std::make_tuple(EntityKind::PARTICIPANT, 13, std::vector<size_t> { 10 }),
         // DATAREADER - TOPIC
-        std::make_tuple(EntityKind::TOPIC, 14, std::vector<size_t> { 12 }),
+        std::make_tuple(EntityKind::TOPIC, 15, std::vector<size_t> { 12 }),
         std::make_tuple(EntityKind::TOPIC, 13, std::vector<size_t> { 12 }),
         // DATAREADER - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 14, std::vector<size_t> { 15, 16 }),
-        std::make_tuple(EntityKind::DATAWRITER, 13, std::vector<size_t> { 15, 16}),
+        std::make_tuple(EntityKind::DATAWRITER, 15, std::vector<size_t> { 17, 19 }),
+        std::make_tuple(EntityKind::DATAWRITER, 13, std::vector<size_t> { 17, 19}),
         // DATAREADER - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 14, std::vector<size_t> { 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 15, std::vector<size_t> { 15 }),
         std::make_tuple(EntityKind::DATAREADER, 13, std::vector<size_t> { 13 }),
         // DATAREADER - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 14, std::vector<size_t> { 17, 18 }),
+        std::make_tuple(EntityKind::LOCATOR, 15, std::vector<size_t> { 14, 16 }),
         // DATAREADER - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 13, std::vector<size_t> { 17 }),
+        std::make_tuple(EntityKind::LOCATOR, 13, std::vector<size_t> { 14 }),
 
         // DATAWRITER - HOST
-        std::make_tuple(EntityKind::HOST, 16, std::vector<size_t> { 2 }),
-        std::make_tuple(EntityKind::HOST, 15, std::vector<size_t> { 2 }),
+        std::make_tuple(EntityKind::HOST, 19, std::vector<size_t> { 2 }),
+        std::make_tuple(EntityKind::HOST, 17, std::vector<size_t> { 2 }),
         // DATAWRITER - USER
-        std::make_tuple(EntityKind::USER, 16, std::vector<size_t> { 4 }),
-        std::make_tuple(EntityKind::USER, 15, std::vector<size_t> { 4 }),
+        std::make_tuple(EntityKind::USER, 19, std::vector<size_t> { 4 }),
+        std::make_tuple(EntityKind::USER, 17, std::vector<size_t> { 4 }),
         // DATAWRITER - PROCESS
-        std::make_tuple(EntityKind::PROCESS, 16, std::vector<size_t> { 6 }),
-        std::make_tuple(EntityKind::PROCESS, 15, std::vector<size_t> { 6 }),
+        std::make_tuple(EntityKind::PROCESS, 19, std::vector<size_t> { 6 }),
+        std::make_tuple(EntityKind::PROCESS, 17, std::vector<size_t> { 6 }),
         // DATAWRITER - DOMAIN
-        std::make_tuple(EntityKind::DOMAIN, 16, std::vector<size_t> { 8 }),
-        std::make_tuple(EntityKind::DOMAIN, 15, std::vector<size_t> { 8 }),
+        std::make_tuple(EntityKind::DOMAIN, 19, std::vector<size_t> { 8 }),
+        std::make_tuple(EntityKind::DOMAIN, 17, std::vector<size_t> { 8 }),
         // DATAWRITER - PARTICIPANT
-        std::make_tuple(EntityKind::PARTICIPANT, 16, std::vector<size_t> { 10 }),
-        std::make_tuple(EntityKind::PARTICIPANT, 15, std::vector<size_t> { 10 }),
+        std::make_tuple(EntityKind::PARTICIPANT, 19, std::vector<size_t> { 10 }),
+        std::make_tuple(EntityKind::PARTICIPANT, 17, std::vector<size_t> { 10 }),
         // DATAWRITER - TOPIC
-        std::make_tuple(EntityKind::TOPIC, 16, std::vector<size_t> { 12 }),
-        std::make_tuple(EntityKind::TOPIC, 15, std::vector<size_t> { 12 }),
+        std::make_tuple(EntityKind::TOPIC, 19, std::vector<size_t> { 12 }),
+        std::make_tuple(EntityKind::TOPIC, 17, std::vector<size_t> { 12 }),
         // DATAWRITER - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 16, std::vector<size_t> { 16 }),
-        std::make_tuple(EntityKind::DATAWRITER, 15, std::vector<size_t> { 15}),
+        std::make_tuple(EntityKind::DATAWRITER, 19, std::vector<size_t> { 19 }),
+        std::make_tuple(EntityKind::DATAWRITER, 17, std::vector<size_t> { 17}),
         // DATAWRITER - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 16, std::vector<size_t> { 13, 14 }),
-        std::make_tuple(EntityKind::DATAREADER, 15, std::vector<size_t> { 13, 14 }),
+        std::make_tuple(EntityKind::DATAREADER, 19, std::vector<size_t> { 13, 15 }),
+        std::make_tuple(EntityKind::DATAREADER, 17, std::vector<size_t> { 13, 15 }),
         // DATAWRITER - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 16, std::vector<size_t> { 19, 20 }),
+        std::make_tuple(EntityKind::LOCATOR, 19, std::vector<size_t> { 18, 20 }),
         // DATAWRITER - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 15, std::vector<size_t> { 19 }),
+        std::make_tuple(EntityKind::LOCATOR, 17, std::vector<size_t> { 18 }),
 
         // LOCATOR - HOST
-        std::make_tuple(EntityKind::HOST, 17, std::vector<size_t> { 2 }),
+        std::make_tuple(EntityKind::HOST, 14, std::vector<size_t> { 2 }),
+        std::make_tuple(EntityKind::HOST, 16, std::vector<size_t> { 2 }),
         std::make_tuple(EntityKind::HOST, 18, std::vector<size_t> { 2 }),
-        std::make_tuple(EntityKind::HOST, 19, std::vector<size_t> { 2 }),
         std::make_tuple(EntityKind::HOST, 20, std::vector<size_t> { 2 }),
         // LOCATOR - USER
-        std::make_tuple(EntityKind::USER, 17, std::vector<size_t> { 4 }),
+        std::make_tuple(EntityKind::USER, 14, std::vector<size_t> { 4 }),
+        std::make_tuple(EntityKind::USER, 16, std::vector<size_t> { 4 }),
         std::make_tuple(EntityKind::USER, 18, std::vector<size_t> { 4 }),
-        std::make_tuple(EntityKind::USER, 19, std::vector<size_t> { 4 }),
         std::make_tuple(EntityKind::USER, 20, std::vector<size_t> { 4 }),
         // LOCATOR - PROCESS
-        std::make_tuple(EntityKind::PROCESS, 17, std::vector<size_t> { 6 }),
+        std::make_tuple(EntityKind::PROCESS, 14, std::vector<size_t> { 6 }),
+        std::make_tuple(EntityKind::PROCESS, 16, std::vector<size_t> { 6 }),
         std::make_tuple(EntityKind::PROCESS, 18, std::vector<size_t> { 6 }),
-        std::make_tuple(EntityKind::PROCESS, 19, std::vector<size_t> { 6 }),
         std::make_tuple(EntityKind::PROCESS, 20, std::vector<size_t> { 6 }),
         // LOCATOR - DOMAIN
-        std::make_tuple(EntityKind::DOMAIN, 17, std::vector<size_t> { 8 }),
+        std::make_tuple(EntityKind::DOMAIN, 14, std::vector<size_t> { 8 }),
+        std::make_tuple(EntityKind::DOMAIN, 16, std::vector<size_t> { 8 }),
         std::make_tuple(EntityKind::DOMAIN, 18, std::vector<size_t> { 8 }),
-        std::make_tuple(EntityKind::DOMAIN, 19, std::vector<size_t> { 8 }),
         std::make_tuple(EntityKind::DOMAIN, 20, std::vector<size_t> { 8 }),
         // LOCATOR - PARTICIPANT
-        std::make_tuple(EntityKind::PARTICIPANT, 17, std::vector<size_t> { 10 }),
+        std::make_tuple(EntityKind::PARTICIPANT, 14, std::vector<size_t> { 10 }),
+        std::make_tuple(EntityKind::PARTICIPANT, 16, std::vector<size_t> { 10 }),
         std::make_tuple(EntityKind::PARTICIPANT, 18, std::vector<size_t> { 10 }),
-        std::make_tuple(EntityKind::PARTICIPANT, 19, std::vector<size_t> { 10 }),
         std::make_tuple(EntityKind::PARTICIPANT, 20, std::vector<size_t> { 10 }),
         // LOCATOR - TOPIC
-        std::make_tuple(EntityKind::TOPIC, 17, std::vector<size_t> { 12 }),
+        std::make_tuple(EntityKind::TOPIC, 14, std::vector<size_t> { 12 }),
+        std::make_tuple(EntityKind::TOPIC, 16, std::vector<size_t> { 12 }),
         std::make_tuple(EntityKind::TOPIC, 18, std::vector<size_t> { 12 }),
-        std::make_tuple(EntityKind::TOPIC, 19, std::vector<size_t> { 12 }),
         std::make_tuple(EntityKind::TOPIC, 20, std::vector<size_t> { 12 }),
         // LOCATOR - DATAWRITER
-        std::make_tuple(EntityKind::DATAWRITER, 17, std::vector<size_t> { }),
-        std::make_tuple(EntityKind::DATAWRITER, 18, std::vector<size_t> { }),
-        std::make_tuple(EntityKind::DATAWRITER, 19, std::vector<size_t> { 15, 16 }),
-        std::make_tuple(EntityKind::DATAWRITER, 20, std::vector<size_t> { 16 }),
+        std::make_tuple(EntityKind::DATAWRITER, 14, std::vector<size_t> { }),
+        std::make_tuple(EntityKind::DATAWRITER, 16, std::vector<size_t> { }),
+        std::make_tuple(EntityKind::DATAWRITER, 18, std::vector<size_t> { 17, 19 }),
+        std::make_tuple(EntityKind::DATAWRITER, 20, std::vector<size_t> { 19 }),
         // LOCATOR - DATAREADER
-        std::make_tuple(EntityKind::DATAREADER, 17, std::vector<size_t> { 13, 14 }),
-        std::make_tuple(EntityKind::DATAREADER, 18, std::vector<size_t> { 14 }),
-        std::make_tuple(EntityKind::DATAREADER, 19, std::vector<size_t> { }),
+        std::make_tuple(EntityKind::DATAREADER, 14, std::vector<size_t> { 13, 15 }),
+        std::make_tuple(EntityKind::DATAREADER, 16, std::vector<size_t> { 15 }),
+        std::make_tuple(EntityKind::DATAREADER, 18, std::vector<size_t> { }),
         std::make_tuple(EntityKind::DATAREADER, 20, std::vector<size_t> { }),
         // LOCATOR - LOCATOR
-        std::make_tuple(EntityKind::LOCATOR, 17, std::vector<size_t> { 17 }),
+        std::make_tuple(EntityKind::LOCATOR, 14, std::vector<size_t> { 14 }),
+        std::make_tuple(EntityKind::LOCATOR, 16, std::vector<size_t> { 16 }),
         std::make_tuple(EntityKind::LOCATOR, 18, std::vector<size_t> { 18 }),
-        std::make_tuple(EntityKind::LOCATOR, 19, std::vector<size_t> { 19 }),
         std::make_tuple(EntityKind::LOCATOR, 20, std::vector<size_t> { 20 })
         ));
 

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -22,6 +22,7 @@
 
 #include <StatisticsBackend.hpp>
 #include <StatisticsBackendData.hpp>
+#include <Monitor.hpp>
 #include <types/JSONTags.h>
 #include <types/types.hpp>
 #include <database/database.hpp>

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -400,6 +400,8 @@ TEST_F(statistics_backend_tests, set_alias)
 
 TEST_F(statistics_backend_tests, internal_callbacks_negative_cases)
 {
+#ifndef NDEBUG
+
     StatisticsBackendTest::set_database(db);
 
     // Will be using entities that are on the database,
@@ -593,6 +595,8 @@ TEST_F(statistics_backend_tests, internal_callbacks_negative_cases)
                 EntityId(17),
                 EntityKind::DATAWRITER),
             ".*");
+
+#endif // ifndef NDEBUG
 }
 
 TEST_F(statistics_backend_tests, set_listener_non_existent_monitor)

--- a/test/unittest/TestUtils/DatabaseUtils.hpp
+++ b/test/unittest/TestUtils/DatabaseUtils.hpp
@@ -105,25 +105,25 @@ using namespace eprosima::statistics_backend::database;
  *     "locators": ["reader_locator1"]
  *   }
  *   "datareader2": {
- *     "ID": 14,
+ *     "ID": 15,
  *     "locators": ["reader_locator1", "reader_locator2"]
  *   }
  *   "datawriter1": {
- *     "ID": 15,
+ *     "ID": 17,
  *     "locators": ["writer_locator1"]
  *   }
  *   "datawriter2": {
- *     "ID": 16,
+ *     "ID": 19,
  *     "locators": ["writer_locator1", "writer_locator2"]
  *   }
  *   "reader_locator1": {
- *     "ID": 17
+ *     "ID": 14
  *   }
  *   "reader_locator2": {
- *     "ID": 18
+ *     "ID": 16
  *   }
  *   "writer_locator1": {
- *     "ID": 19
+ *     "ID": 18
  *   }
  *   "writer_locator2": {
  *     "ID": 20
@@ -208,7 +208,7 @@ public:
         datareader1->locators[reader_locator1->id] = reader_locator1;
         db.insert(datareader1);
         entities[13] = datareader1;
-        entities[17] = reader_locator1;
+        entities[14] = reader_locator1;
 
         auto datareader2 = std::make_shared<DataReader>("datareader2", "qos", "15.16.17.18", participant2, topic2);
         auto reader_locator2 = std::make_shared<Locator>("reader_locator2");
@@ -216,16 +216,16 @@ public:
         datareader2->locators[reader_locator1->id] = reader_locator1;
         datareader2->locators[reader_locator2->id] = reader_locator2;
         db.insert(datareader2);
-        entities[14] = datareader2;
-        entities[18] = reader_locator2;
+        entities[15] = datareader2;
+        entities[16] = reader_locator2;
 
         auto datawriter1 = std::make_shared<DataWriter>("datawriter1", "qos", "21.22.23.24", participant2, topic2);
         auto writer_locator1 = std::make_shared<Locator>("writer_locator1");
         writer_locator1->id = db.generate_entity_id();
         datawriter1->locators[writer_locator1->id] = writer_locator1;
         db.insert(datawriter1);
-        entities[15] = datawriter1;
-        entities[19] = writer_locator1;
+        entities[17] = datawriter1;
+        entities[18] = writer_locator1;
 
         auto datawriter2 = std::make_shared<DataWriter>("datawriter2", "qos", "25.26.27.28", participant2, topic2);
         auto writer_locator2 = std::make_shared<Locator>("writer_locator2");
@@ -233,7 +233,7 @@ public:
         datawriter2->locators[writer_locator1->id] = writer_locator1;
         datawriter2->locators[writer_locator2->id] = writer_locator2;
         db.insert(datawriter2);
-        entities[16] = datawriter2;
+        entities[19] = datawriter2;
         entities[20] = writer_locator2;
 
         // Insert datas on domain2

--- a/test/unittest/TestUtils/DatabaseUtils.hpp
+++ b/test/unittest/TestUtils/DatabaseUtils.hpp
@@ -607,6 +607,21 @@ public:
             Database* db)
     {
         details::StatisticsBackendData::get_instance()->database_.reset(db);
+
+        details::StatisticsBackendData::get_instance()->monitors_by_entity_.clear();
+
+        // Need to reconstruct the monitors
+        auto domains = details::StatisticsBackendData::get_instance()->database_->get_entities(
+            EntityKind::DOMAIN, EntityId::all());
+        for (auto domain : domains)
+        {
+            std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
+            std::stringstream domain_name;
+            domain_name << domain->name;
+            monitor->id = domain->id;
+            monitor->domain_listener = nullptr;
+            details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
+        }
     }
 
 };


### PR DESCRIPTION
**This PR must be merged after #72**

Start reviewing from the commit with description " Rework listener tests assuming set_domain_listener is implemented "

It has some other improvements and bugfixes that were found during this development and/or testing for coverage:
* Statuses must be updated even if no listener is called
* Parameterize the test for listener calls
* Some bugfixes in other tests

