### PR TITLE
Add locators in the participant's info [11863]

### DIFF
--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -390,6 +390,38 @@ Info StatisticsBackend::get_info(
             break;
         }
         case EntityKind::PARTICIPANT:
+        {
+            std::shared_ptr<const database::DomainParticipant> participant =
+                    std::dynamic_pointer_cast<const database::DomainParticipant>(entity);
+            info[GUID_INFO_TAG] = participant->guid;
+            info[QOS_INFO_TAG] = participant->qos;
+
+            // Locators associated to endpoints
+            DatabaseDump locators = DatabaseDump::array();
+
+            // Writers registered in the participant
+            for (auto writer : participant->data_writers)
+            {
+                // Locators associated to each writer
+                for (auto locator : writer.second.get()->locators)
+                {
+                    locators.push_back(locator.second.get()->name);
+                }
+            }
+
+            // Readers registered in the participant
+            for (auto reader : participant->data_readers)
+            {
+                // Locators associated to each reader
+                for (auto locator : reader.second.get()->locators)
+                {
+                    locators.push_back(locator.second.get()->name);
+                }
+            }
+
+            info[LOCATOR_CONTAINER_TAG] = locators;
+            break;
+        }
         case EntityKind::DATAWRITER:
         case EntityKind::DATAREADER:
         {

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -422,11 +422,11 @@ Info StatisticsBackend::get_info(
 
             // Remove duplicates
             auto last = std::unique(locators.begin(), locators.end(), [](
-                    const std::string& first,
-                    const std::string& second)
-                {
-                    return first.compare(second) == 0;
-                });
+                                const std::string& first,
+                                const std::string& second)
+                            {
+                                return first.compare(second) == 0;
+                            });
             locators.erase(last, locators.end());
             info[LOCATOR_CONTAINER_TAG] = locators;
             break;

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -16,6 +16,7 @@
  * @file StatisticsBackend.cpp
  */
 
+#include <algorithm>
 #include <fstream>
 
 #include <fastdds/dds/core/status/StatusMask.hpp>
@@ -419,6 +420,14 @@ Info StatisticsBackend::get_info(
                 }
             }
 
+            // Remove duplicates
+            auto last = std::unique(locators.begin(), locators.end(), [](
+                    const std::string& first,
+                    const std::string& second)
+                {
+                    return first.compare(second) == 0;
+                });
+            locators.erase(last, locators.end());
             info[LOCATOR_CONTAINER_TAG] = locators;
             break;
         }

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -67,13 +67,15 @@ public:
 
 void check_dds_entity(
         std::shared_ptr<const DDSEntity> const& entity,
-        Info const& info)
+        Info& info)
 {
     ASSERT_EQ(entity->guid, info[GUID_INFO_TAG]);
+    info.erase(GUID_INFO_TAG);
     ASSERT_EQ(entity->qos, info[QOS_INFO_TAG]);
+    info.erase(QOS_INFO_TAG);
 }
 
-// Check the get_type StatisticsBackend method
+// Check the get_info StatisticsBackend method
 TEST_F(statistics_backend_tests, get_info)
 {
     StatisticsBackendTest::set_database(db);
@@ -89,9 +91,14 @@ TEST_F(statistics_backend_tests, get_info)
         Info info = StatisticsBackendTest::get_info(entity->id);
 
         // Check generic info
+        // Once the info is checked, it is erased so the final check is confirm that the info is empty (there is no
+        // more information than the expected)
         ASSERT_EQ(entity->id, EntityId(info[ID_INFO_TAG]));
+        info.erase(ID_INFO_TAG);
         ASSERT_EQ(entity_kind_str[(int)entity->kind], info[KIND_INFO_TAG]);
+        info.erase(KIND_INFO_TAG);
         ASSERT_EQ(entity->name, info[NAME_INFO_TAG]);
+        info.erase(NAME_INFO_TAG);
 
         // Check specific info
         switch (entity->kind)
@@ -101,6 +108,7 @@ TEST_F(statistics_backend_tests, get_info)
                 std::shared_ptr<const Process> process =
                         std::dynamic_pointer_cast<const Process>(entity);
                 ASSERT_EQ(process->pid, info[PID_INFO_TAG]);
+                info.erase(PID_INFO_TAG);
                 break;
             }
             case EntityKind::TOPIC:
@@ -108,6 +116,7 @@ TEST_F(statistics_backend_tests, get_info)
                 std::shared_ptr<const Topic> topic =
                         std::dynamic_pointer_cast<const Topic>(entity);
                 ASSERT_EQ(topic->data_type, info[DATA_TYPE_INFO_TAG]);
+                info.erase(DATA_TYPE_INFO_TAG);
                 break;
             }
             case EntityKind::PARTICIPANT:
@@ -124,6 +133,7 @@ TEST_F(statistics_backend_tests, get_info)
                 break;
             }
         }
+        EXPECT_TRUE(info.empty());
     }
 }
 

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -140,18 +140,18 @@ TEST_F(statistics_backend_tests, get_info)
                 }
                 // Remove duplicates
                 auto last = std::unique(locators.begin(), locators.end(), [](
-                        const std::string& first,
-                        const std::string& second)
-                    {
-                        return first.compare(second) == 0;
-                    });
+                                    const std::string& first,
+                                    const std::string& second)
+                                {
+                                    return first.compare(second) == 0;
+                                });
                 locators.erase(last, locators.end());
 
                 // Check that every locator is included in the Info object
                 for (auto locator_name : locators)
                 {
                     auto locator_it = std::find(info[LOCATOR_CONTAINER_TAG].begin(),
-                        info[LOCATOR_CONTAINER_TAG].end(), locator_name);
+                                    info[LOCATOR_CONTAINER_TAG].end(), locator_name);
                     ASSERT_NE(locator_it, info[LOCATOR_CONTAINER_TAG].end());
                     info[LOCATOR_CONTAINER_TAG].erase(locator_it);
                 }

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <list>
+#include <string>
+#include <vector>
 
 #include <gtest_aux.hpp>
 #include <gtest/gtest.h>
@@ -65,15 +68,6 @@ public:
 
 };
 
-void check_dds_entity(
-        std::shared_ptr<const DDSEntity> const& entity,
-        Info& info)
-{
-    ASSERT_EQ(entity->guid, info[GUID_INFO_TAG]);
-    info.erase(GUID_INFO_TAG);
-    ASSERT_EQ(entity->qos, info[QOS_INFO_TAG]);
-    info.erase(QOS_INFO_TAG);
-}
 
 // Check the get_info StatisticsBackend method
 TEST_F(statistics_backend_tests, get_info)
@@ -93,11 +87,11 @@ TEST_F(statistics_backend_tests, get_info)
         // Check generic info
         // Once the info is checked, it is erased so the final check is confirm that the info is empty (there is no
         // more information than the expected)
-        ASSERT_EQ(entity->id, EntityId(info[ID_INFO_TAG]));
+        EXPECT_EQ(entity->id, EntityId(info[ID_INFO_TAG]));
         info.erase(ID_INFO_TAG);
-        ASSERT_EQ(entity_kind_str[(int)entity->kind], info[KIND_INFO_TAG]);
+        EXPECT_EQ(entity_kind_str[(int)entity->kind], info[KIND_INFO_TAG]);
         info.erase(KIND_INFO_TAG);
-        ASSERT_EQ(entity->name, info[NAME_INFO_TAG]);
+        EXPECT_EQ(entity->name, info[NAME_INFO_TAG]);
         info.erase(NAME_INFO_TAG);
 
         // Check specific info
@@ -107,7 +101,7 @@ TEST_F(statistics_backend_tests, get_info)
             {
                 std::shared_ptr<const Process> process =
                         std::dynamic_pointer_cast<const Process>(entity);
-                ASSERT_EQ(process->pid, info[PID_INFO_TAG]);
+                EXPECT_EQ(process->pid, info[PID_INFO_TAG]);
                 info.erase(PID_INFO_TAG);
                 break;
             }
@@ -115,17 +109,65 @@ TEST_F(statistics_backend_tests, get_info)
             {
                 std::shared_ptr<const Topic> topic =
                         std::dynamic_pointer_cast<const Topic>(entity);
-                ASSERT_EQ(topic->data_type, info[DATA_TYPE_INFO_TAG]);
+                EXPECT_EQ(topic->data_type, info[DATA_TYPE_INFO_TAG]);
                 info.erase(DATA_TYPE_INFO_TAG);
                 break;
             }
             case EntityKind::PARTICIPANT:
+            {
+                std::shared_ptr<const DomainParticipant> participant =
+                        std::dynamic_pointer_cast<const DomainParticipant>(entity);
+                EXPECT_EQ(participant->guid, info[GUID_INFO_TAG]);
+                info.erase(GUID_INFO_TAG);
+                EXPECT_EQ(participant->qos, info[QOS_INFO_TAG]);
+                info.erase(QOS_INFO_TAG);
+
+                // Obtain the locators list associated to the participant's endpoints
+                std::vector<std::string> locators;
+                for (auto reader : participant->data_readers)
+                {
+                    for (auto locator : reader.second.get()->locators)
+                    {
+                        locators.push_back(locator.second.get()->name);
+                    }
+                }
+                for (auto writer : participant->data_writers)
+                {
+                    for (auto locator : writer.second.get()->locators)
+                    {
+                        locators.push_back(locator.second.get()->name);
+                    }
+                }
+                // Remove duplicates
+                auto last = std::unique(locators.begin(), locators.end(), [](
+                        const std::string& first,
+                        const std::string& second)
+                    {
+                        return first.compare(second) == 0;
+                    });
+                locators.erase(last, locators.end());
+
+                // Check that every locator is included in the Info object
+                for (auto locator_name : locators)
+                {
+                    auto locator_it = std::find(info[LOCATOR_CONTAINER_TAG].begin(),
+                        info[LOCATOR_CONTAINER_TAG].end(), locator_name);
+                    ASSERT_NE(locator_it, info[LOCATOR_CONTAINER_TAG].end());
+                    info[LOCATOR_CONTAINER_TAG].erase(locator_it);
+                }
+                EXPECT_TRUE(info[LOCATOR_CONTAINER_TAG].empty());
+                info.erase(LOCATOR_CONTAINER_TAG);
+                break;
+            }
             case EntityKind::DATAWRITER:
             case EntityKind::DATAREADER:
             {
                 std::shared_ptr<const DDSEntity> dds_entity =
                         std::dynamic_pointer_cast<const DDSEntity>(entity);
-                check_dds_entity(dds_entity, info);
+                EXPECT_EQ(dds_entity->guid, info[GUID_INFO_TAG]);
+                info.erase(GUID_INFO_TAG);
+                EXPECT_EQ(dds_entity->qos, info[QOS_INFO_TAG]);
+                info.erase(QOS_INFO_TAG);
                 break;
             }
             default:


### PR DESCRIPTION
`get_info` should also provide the locators names when the DomainParticipant Info is required.

This PR also improves the `get_info` test to ensure that there is no extra information in the Info object. The returned Info is only the information being required and no more.