### PR TITLE
Call user callbacks when entities are undiscovered [11856]

### DIFF
--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -277,14 +277,17 @@ void StatisticsBackendData::on_domain_entity_discovery(
 void StatisticsBackendData::on_physical_entity_discovery(
         EntityId participant_id,
         EntityId entity_id,
-        EntityKind entity_kind)
+        EntityKind entity_kind,
+        DiscoveryStatus discovery_status)
 {
+    assert(discovery_status != DiscoveryStatus::UPDATE);
+
     switch (entity_kind)
     {
         case EntityKind::HOST:
         {
             // The status must be recorded regardless of the callback
-            prepare_entity_discovery_status(DISCOVERY, host_status_);
+            prepare_entity_discovery_status(discovery_status, host_status_);
 
             if (should_call_physical_listener(CallbackKind::ON_HOST_DISCOVERY))
             {
@@ -296,7 +299,7 @@ void StatisticsBackendData::on_physical_entity_discovery(
         case EntityKind::USER:
         {
             // The status must be recorded regardless of the callback
-            prepare_entity_discovery_status(DISCOVERY, user_status_);
+            prepare_entity_discovery_status(discovery_status, user_status_);
 
             if (should_call_physical_listener(CallbackKind::ON_USER_DISCOVERY))
             {
@@ -308,7 +311,7 @@ void StatisticsBackendData::on_physical_entity_discovery(
         case EntityKind::PROCESS:
         {
             // The status must be recorded regardless of the callback
-            prepare_entity_discovery_status(DISCOVERY, process_status_);
+            prepare_entity_discovery_status(discovery_status, process_status_);
 
             if (should_call_physical_listener(CallbackKind::ON_PROCESS_DISCOVERY))
             {
@@ -320,7 +323,7 @@ void StatisticsBackendData::on_physical_entity_discovery(
         case EntityKind::LOCATOR:
         {
             // The status must be recorded regardless of the callback
-            prepare_entity_discovery_status(DISCOVERY, locator_status_);
+            prepare_entity_discovery_status(discovery_status, locator_status_);
 
             if (should_call_physical_listener(CallbackKind::ON_LOCATOR_DISCOVERY))
             {

--- a/src/cpp/StatisticsBackendData.hpp
+++ b/src/cpp/StatisticsBackendData.hpp
@@ -148,13 +148,13 @@ public:
      * @param participant_id Entity ID of the participant that discovered the entity.
      * @param entity_id The entity_id of the discovered entity
      * @param entity_kind EntityKind of the discovery event
-	 * @param discovery_status The reason why the method is being called
+     * @param discovery_status The reason why the method is being called
      */
     void on_physical_entity_discovery(
             EntityId participant_id,
             EntityId entity_id,
             EntityKind entity_kind,
-        	DiscoveryStatus discovery_status);
+            DiscoveryStatus discovery_status);
 
     /**
      * @brief Notify the user about a new available data

--- a/src/cpp/StatisticsBackendData.hpp
+++ b/src/cpp/StatisticsBackendData.hpp
@@ -143,16 +143,18 @@ public:
     /**
      * @brief Notify the user about a new discovered entity
      *
-     * There is no DiscoveryStatus parameter because physical entities are never undiscovered nor updated
+     * Physical entities can be discovered or undiscovered, never updated
      *
      * @param participant_id Entity ID of the participant that discovered the entity.
      * @param entity_id The entity_id of the discovered entity
      * @param entity_kind EntityKind of the discovery event
+	 * @param discovery_status The reason why the method is being called
      */
     void on_physical_entity_discovery(
             EntityId participant_id,
             EntityId entity_id,
-            EntityKind entity_kind);
+            EntityKind entity_kind,
+        	DiscoveryStatus discovery_status);
 
     /**
      * @brief Notify the user about a new available data

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -26,7 +26,9 @@
 #include <fastdds_statistics_backend/exception/Exception.hpp>
 #include <fastdds_statistics_backend/types/types.hpp>
 #include <fastdds_statistics_backend/types/JSONTags.h>
+#include <StatisticsBackendData.hpp>
 
+#include "database_queue.hpp"
 #include "samples.hpp"
 
 namespace eprosima {
@@ -4204,10 +4206,25 @@ void Database::load_data(
     }
 }
 
+// Conversion from bool to DiscoveryStatus
+details::StatisticsBackendData::DiscoveryStatus get_status(
+    bool active)
+{
+    if (active)
+    {
+        return details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
+    }
+    else
+    {
+        return details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY;
+    }
+}
+
 void Database::change_entity_status_of_kind(
         const EntityId& entity_id,
         bool active,
-        EntityKind entity_kind) noexcept
+        const EntityKind& entity_kind,
+        const EntityId& domain_id) noexcept
 {
     std::shared_lock<std::shared_timed_mutex> lock(mutex_);
 
@@ -4228,6 +4245,8 @@ void Database::change_entity_status_of_kind(
             if (host != nullptr && host->active != active)
             {
                 host->active = active;
+                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain_id, entity_id,
+                        entity_kind,get_status(active));
             }
             break;
         }
@@ -4246,6 +4265,8 @@ void Database::change_entity_status_of_kind(
             if (user != nullptr && user->active != active)
             {
                 user->active = active;
+                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain_id, entity_id,
+                        entity_kind,get_status(active));
 
                 // host
                 {
@@ -4261,7 +4282,7 @@ void Database::change_entity_status_of_kind(
 
                     if (change_status)
                     {
-                        change_entity_status_of_kind(user->host->id, active, user->host->kind);
+                        change_entity_status_of_kind(user->host->id, active, user->host->kind, domain_id);
                     }
                 }
             }
@@ -4282,6 +4303,8 @@ void Database::change_entity_status_of_kind(
             if (process != nullptr && process->active != active)
             {
                 process->active = active;
+                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain_id, entity_id,
+                        entity_kind,get_status(active));
 
                 // user
                 {
@@ -4297,7 +4320,7 @@ void Database::change_entity_status_of_kind(
 
                     if (change_status)
                     {
-                        change_entity_status_of_kind(process->user->id, active, process->user->kind);
+                        change_entity_status_of_kind(process->user->id, active, process->user->kind, domain_id);
                     }
                 }
             }
@@ -4339,6 +4362,9 @@ void Database::change_entity_status_of_kind(
             if (topic != nullptr && topic->active != active)
             {
                 topic->active = active;
+                
+                details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain_id, entity_id,
+                        entity_kind,get_status(active));
             }
             break;
         }
@@ -4377,7 +4403,7 @@ void Database::change_entity_status_of_kind(
 
                     if (change_status)
                     {
-                        change_entity_status_of_kind(participant->process->id, active, participant->process->kind);
+                        change_entity_status_of_kind(participant->process->id, active, participant->process->kind, participant->domain->id);
                     }
                 }
             }
@@ -4426,7 +4452,7 @@ void Database::change_entity_status_of_kind(
                         }
                         if (change_status)
                         {
-                            change_entity_status_of_kind(datawriter->topic->id, active, datawriter->topic->kind);
+                            change_entity_status_of_kind(datawriter->topic->id, active, datawriter->topic->kind, datawriter->participant->domain->id);
                         }
                     }
                 }
@@ -4475,7 +4501,7 @@ void Database::change_entity_status_of_kind(
                         }
                         if (change_status)
                         {
-                            change_entity_status_of_kind(datareader->topic->id, active, datareader->topic->kind);
+                            change_entity_status_of_kind(datareader->topic->id, active, datareader->topic->kind, datareader->participant->domain->id);
                         }
                     }
                 }

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -4208,7 +4208,7 @@ void Database::load_data(
 
 // Conversion from bool to DiscoveryStatus
 details::StatisticsBackendData::DiscoveryStatus get_status(
-    bool active)
+        bool active)
 {
     if (active)
     {
@@ -4246,7 +4246,7 @@ void Database::change_entity_status_of_kind(
             {
                 host->active = active;
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain_id, entity_id,
-                        entity_kind,get_status(active));
+                        entity_kind, get_status(active));
             }
             break;
         }
@@ -4266,7 +4266,7 @@ void Database::change_entity_status_of_kind(
             {
                 user->active = active;
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain_id, entity_id,
-                        entity_kind,get_status(active));
+                        entity_kind, get_status(active));
 
                 // host
                 {
@@ -4304,7 +4304,7 @@ void Database::change_entity_status_of_kind(
             {
                 process->active = active;
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain_id, entity_id,
-                        entity_kind,get_status(active));
+                        entity_kind, get_status(active));
 
                 // user
                 {
@@ -4362,9 +4362,9 @@ void Database::change_entity_status_of_kind(
             if (topic != nullptr && topic->active != active)
             {
                 topic->active = active;
-                
+
                 details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain_id, entity_id,
-                        entity_kind,get_status(active));
+                        entity_kind, get_status(active));
             }
             break;
         }
@@ -4403,7 +4403,8 @@ void Database::change_entity_status_of_kind(
 
                     if (change_status)
                     {
-                        change_entity_status_of_kind(participant->process->id, active, participant->process->kind, participant->domain->id);
+                        change_entity_status_of_kind(participant->process->id, active, participant->process->kind,
+                                participant->domain->id);
                     }
                 }
             }
@@ -4452,7 +4453,8 @@ void Database::change_entity_status_of_kind(
                         }
                         if (change_status)
                         {
-                            change_entity_status_of_kind(datawriter->topic->id, active, datawriter->topic->kind, datawriter->participant->domain->id);
+                            change_entity_status_of_kind(datawriter->topic->id, active, datawriter->topic->kind,
+                                    datawriter->participant->domain->id);
                         }
                     }
                 }
@@ -4501,7 +4503,8 @@ void Database::change_entity_status_of_kind(
                         }
                         if (change_status)
                         {
-                            change_entity_status_of_kind(datareader->topic->id, active, datareader->topic->kind, datareader->participant->domain->id);
+                            change_entity_status_of_kind(datareader->topic->id, active, datareader->topic->kind,
+                                    datareader->participant->domain->id);
                         }
                     }
                 }

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -317,6 +317,7 @@ public:
     /**
      * Change the status (active/inactive) of an entity given an EntityId.
      * Also check if the references of the entity must also be changed and change the status in that case.
+	 * A call to the user listener will be performed if the status of the entity change.
      * @param entity_id The EntityId of the entity
      * @param active The entity status value to set
      * @throws eprosima::statistics_backend::BadParameter if entity_kind is not valid.
@@ -681,14 +682,17 @@ protected:
     /**
      * Change the status (active/inactive) of an entity given an EntityId.
      * Also check if the references of the entity must also be changed and change the status in that case.
+	 * A call to the user listeners will be performed if the status of the entity change.
      * @param entity_id The EntityId of the entity
      * @param active The entity status value to set
      * @param entity_kind The EntityKind of the entity
+     * @param domain_id The entityId of the domain
      */
     void change_entity_status_of_kind(
             const EntityId& entity_id,
             bool active,
-            EntityKind entity_kind) noexcept;
+            const EntityKind& entity_kind,
+            const EntityId& domain_id = EntityId::invalid()) noexcept;
 
     //! Collection of Hosts sorted by EntityId
     std::map<EntityId, std::shared_ptr<Host>> hosts_;

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -317,7 +317,7 @@ public:
     /**
      * Change the status (active/inactive) of an entity given an EntityId.
      * Also check if the references of the entity must also be changed and change the status in that case.
-     * A call to the user listener will be performed if the status of the entity change.
+     * A call to the user listener will be performed if the status of the entity changes.
      * @param entity_id The EntityId of the entity
      * @param active The entity status value to set
      * @throws eprosima::statistics_backend::BadParameter if entity_kind is not valid.
@@ -682,7 +682,7 @@ protected:
     /**
      * Change the status (active/inactive) of an entity given an EntityId.
      * Also check if the references of the entity must also be changed and change the status in that case.
-     * A call to the user listeners will be performed if the status of the entity change.
+     * A call to the user listeners will be performed if the status of the entity changes.
      * @param entity_id The EntityId of the entity
      * @param active The entity status value to set
      * @param entity_kind The EntityKind of the entity

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -317,7 +317,7 @@ public:
     /**
      * Change the status (active/inactive) of an entity given an EntityId.
      * Also check if the references of the entity must also be changed and change the status in that case.
-	 * A call to the user listener will be performed if the status of the entity change.
+     * A call to the user listener will be performed if the status of the entity change.
      * @param entity_id The EntityId of the entity
      * @param active The entity status value to set
      * @throws eprosima::statistics_backend::BadParameter if entity_kind is not valid.
@@ -682,7 +682,7 @@ protected:
     /**
      * Change the status (active/inactive) of an entity given an EntityId.
      * Also check if the references of the entity must also be changed and change the status in that case.
-	 * A call to the user listeners will be performed if the status of the entity change.
+     * A call to the user listeners will be performed if the status of the entity change.
      * @param entity_id The EntityId of the entity
      * @param active The entity status value to set
      * @param entity_kind The EntityKind of the entity

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -696,7 +696,7 @@ void DatabaseDataQueue::process_sample()
                     host->id = database_->insert(std::static_pointer_cast<Entity>(host));
                     details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(participant_id,
                             host->id,
-                            EntityKind::HOST);
+                            EntityKind::HOST,details::StatisticsBackendData::DISCOVERY);
                 }
                 else
                 {
@@ -727,7 +727,7 @@ void DatabaseDataQueue::process_sample()
                     user->id = database_->insert(std::static_pointer_cast<Entity>(user));
                     details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(participant_id,
                             user->id,
-                            EntityKind::USER);
+                            EntityKind::USER,details::StatisticsBackendData::DISCOVERY);
                 }
 
                 // Check the existence of the process in that user
@@ -753,7 +753,7 @@ void DatabaseDataQueue::process_sample()
                     process_id = database_->insert(std::static_pointer_cast<Entity>(process));
                     details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(participant_id,
                             process_id,
-                            EntityKind::PROCESS);
+                            EntityKind::PROCESS,details::StatisticsBackendData::DISCOVERY);
                 }
 
                 database_->link_participant_with_process(participant_id, process_id);

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -696,7 +696,7 @@ void DatabaseDataQueue::process_sample()
                     host->id = database_->insert(std::static_pointer_cast<Entity>(host));
                     details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(participant_id,
                             host->id,
-                            EntityKind::HOST,details::StatisticsBackendData::DISCOVERY);
+                            EntityKind::HOST, details::StatisticsBackendData::DISCOVERY);
                 }
                 else
                 {
@@ -727,7 +727,7 @@ void DatabaseDataQueue::process_sample()
                     user->id = database_->insert(std::static_pointer_cast<Entity>(user));
                     details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(participant_id,
                             user->id,
-                            EntityKind::USER,details::StatisticsBackendData::DISCOVERY);
+                            EntityKind::USER, details::StatisticsBackendData::DISCOVERY);
                 }
 
                 // Check the existence of the process in that user
@@ -753,7 +753,7 @@ void DatabaseDataQueue::process_sample()
                     process_id = database_->insert(std::static_pointer_cast<Entity>(process));
                     details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(participant_id,
                             process_id,
-                            EntityKind::PROCESS,details::StatisticsBackendData::DISCOVERY);
+                            EntityKind::PROCESS, details::StatisticsBackendData::DISCOVERY);
                 }
 
                 database_->link_participant_with_process(participant_id, process_id);

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -370,8 +370,13 @@ protected:
                         info.entity->id,
                         info.entity->kind, info.discovery_status);
             }
+            // Domains are not discovered, they are created on monitor initialization
+            else if (EntityKind::DOMAIN == info.entity->kind)
+            {
+                info.entity->id = database_->insert(info.entity);
+            }
             // Domain entities
-            else if (EntityKind::DOMAIN != info.entity->kind)
+            else
             {
                 // The topic is never updated/undiscovered, is only discovered. So the status is not changed.
                 // It status will only be updated if its endpoints are discovered/undiscovered.

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -359,8 +359,9 @@ protected:
             EntityDiscoveryInfo info = front().second;
             EntityId id;
 
-            // Insert the entity only if is discovered
-            if (info.discovery_status == details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)
+            // Insert the entity only if is discovered and is not yet inserted in the database
+            if (info.discovery_status == details::StatisticsBackendData::DiscoveryStatus::DISCOVERY &&
+                    !info.entity->id.is_valid_and_unique())
             {
                 id = database_->insert(info.entity);
             }
@@ -369,7 +370,7 @@ protected:
                 id = info.entity->id;
             }
 
-            // Update the entity status
+            // Update the entity status and check if its references must also change it status
             database_->change_entity_status(id,
                     info.discovery_status !=
                     details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY);

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -356,7 +356,7 @@ protected:
     {
         try
         {
-            EntityDiscoveryInfo info = front().second;
+            const EntityDiscoveryInfo& info = front().second;
 
             // Physical entities
             if (EntityKind::HOST  == info.entity->kind ||
@@ -364,6 +364,7 @@ protected:
                     EntityKind::PROCESS == info.entity->kind ||
                     EntityKind::LOCATOR == info.entity->kind)
             {
+                assert(info.discovery_status == details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
                 info.entity->id = database_->insert(info.entity);
 
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(info.domain_id,
@@ -373,6 +374,7 @@ protected:
             // Domains are not discovered, they are created on monitor initialization
             else if (EntityKind::DOMAIN == info.entity->kind)
             {
+                assert(info.discovery_status == details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
                 info.entity->id = database_->insert(info.entity);
             }
             // Domain entities
@@ -382,6 +384,9 @@ protected:
                 // It status will only be updated if its endpoints are discovered/undiscovered.
                 if (info.entity->kind == EntityKind::TOPIC)
                 {
+                    assert(
+                        info.discovery_status == details::StatisticsBackendData::DiscoveryStatus::DISCOVERY &&
+                        !info.entity->id.is_valid_and_unique());
                     info.entity->id = database_->insert(info.entity);
                 }
                 else

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -371,19 +371,22 @@ protected:
 
             // Update the entity status
             database_->change_entity_status(id,
-                                            info.discovery_status !=
-                                                details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY);
+                    info.discovery_status !=
+                    details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY);
 
             if (EntityKind::HOST  == info.entity->kind ||
                     EntityKind::USER == info.entity->kind ||
                     EntityKind::PROCESS == info.entity->kind ||
                     EntityKind::LOCATOR == info.entity->kind)
             {
-                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(info.domain_id, id,info.entity->kind);
+                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(info.domain_id, id,
+                        info.entity->kind);
             }
             else if (EntityKind::DOMAIN != front().second.entity->kind)
             {
-                details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(info.domain_id, id,info.entity->kind, info.discovery_status);
+                details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(info.domain_id, id,
+                        info.entity->kind,
+                        info.discovery_status);
             }
         }
         catch (const eprosima::statistics_backend::Exception& e)

--- a/src/cpp/subscriber/StatisticsParticipantListener.cpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.cpp
@@ -263,7 +263,7 @@ void StatisticsParticipantListener::on_participant_discovery(
         {
             case ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT:
             {
-                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UPDATE;
+                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
                 break;
             }
             case ParticipantDiscoveryInfo::CHANGED_QOS_PARTICIPANT:
@@ -351,7 +351,7 @@ void StatisticsParticipantListener::on_subscriber_discovery(
         {
             case ReaderDiscoveryInfo::DISCOVERED_READER:
             {
-                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UPDATE;
+                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
                 break;
             }
             case ReaderDiscoveryInfo::CHANGED_QOS_READER:
@@ -419,7 +419,7 @@ void StatisticsParticipantListener::on_publisher_discovery(
         {
             case WriterDiscoveryInfo::DISCOVERED_WRITER:
             {
-                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UPDATE;
+                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
                 break;
             }
             case WriterDiscoveryInfo::CHANGED_QOS_WRITER:

--- a/src/cpp/subscriber/StatisticsParticipantListener.hpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.hpp
@@ -35,7 +35,6 @@ namespace database {
 class Database;
 class DatabaseDataQueue;
 class DatabaseEntityQueue;
-class EntityDiscoveryInfo;
 
 } // namespace database
 

--- a/src/cpp/subscriber/StatisticsParticipantListener.hpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.hpp
@@ -35,6 +35,7 @@ namespace database {
 class Database;
 class DatabaseDataQueue;
 class DatabaseEntityQueue;
+class EntityDiscoveryInfo;
 
 } // namespace database
 

--- a/test/mock/StatisticsBackend/StatisticsBackendData.hpp
+++ b/test/mock/StatisticsBackend/StatisticsBackendData.hpp
@@ -48,10 +48,11 @@ public:
                 EntityKind entity_kind,
                 DiscoveryStatus discovery_status));
 
-    MOCK_METHOD3(on_physical_entity_discovery, void(
+    MOCK_METHOD4(on_physical_entity_discovery, void(
                 EntityId participant_id,
                 EntityId entity_id,
-                EntityKind entity_kind));
+                EntityKind entity_kind,
+                DiscoveryStatus discovery_status));
 
     MOCK_METHOD3(on_data_available, void(
                 EntityId domain_id,

--- a/test/unittest/Database/DatabaseDumpTests.cpp
+++ b/test/unittest/Database/DatabaseDumpTests.cpp
@@ -48,7 +48,7 @@ constexpr const int16_t MAGNITUDE_DEFAULT = 0;
 #define HOST_DEFAULT_NAME(x) "host_" + std::to_string(x)
 #define USER_DEFAULT_NAME(x) "user_" + std::to_string(x)
 #define PROCESS_DEFAULT_NAME(x) "process_" + std::to_string(x)
-#define DOMAIN_DEFAULT_NAME(x) "domain_" + std::to_string(x)
+#define DOMAIN_DEFAULT_NAME(x) "12" + std::to_string(x)
 #define TOPIC_DEFAULT_NAME(x) "topic_" + std::to_string(x)
 #define PARTICIPANT_DEFAULT_NAME(x) "participant_" + std::to_string(x)
 #define DATAWRITER_DEFAULT_NAME(x) "datawriter_" + std::to_string(x)

--- a/test/unittest/Database/DatabaseDumpTests.cpp
+++ b/test/unittest/Database/DatabaseDumpTests.cpp
@@ -49,6 +49,7 @@ constexpr const int16_t MAGNITUDE_DEFAULT = 0;
 #define USER_DEFAULT_NAME(x) "user_" + std::to_string(x)
 #define PROCESS_DEFAULT_NAME(x) "process_" + std::to_string(x)
 #define DOMAIN_DEFAULT_NAME(x) "12" + std::to_string(x)
+#define ALIAS_DEFAULT_NAME(x) "domain_" + std::to_string(x)
 #define TOPIC_DEFAULT_NAME(x) "topic_" + std::to_string(x)
 #define PARTICIPANT_DEFAULT_NAME(x) "participant_" + std::to_string(x)
 #define DATAWRITER_DEFAULT_NAME(x) "datawriter_" + std::to_string(x)
@@ -78,6 +79,7 @@ void initialize_empty_entities(
     std::shared_ptr<Process> process = std::make_shared<Process>(std::string(PROCESS_DEFAULT_NAME(
                         index)), PID_DEFAULT, user);
     std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(index)));
+    domain->alias = ALIAS_DEFAULT_NAME(index);
     std::shared_ptr<Topic> topic = std::make_shared<Topic>(std::string(TOPIC_DEFAULT_NAME(
                         index)), DATA_TYPE_DEFAULT, domain);
     std::shared_ptr<DomainParticipant> participant = std::make_shared<DomainParticipant>(std::string(
@@ -377,6 +379,7 @@ void initialize_empty_entities_unlinked(
     std::shared_ptr<Process> process = std::make_shared<Process>(std::string(PROCESS_DEFAULT_NAME(
                         index)), PID_DEFAULT, user);
     std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(index)));
+    domain->alias = ALIAS_DEFAULT_NAME(index);
     std::shared_ptr<Topic> topic = std::make_shared<Topic>(std::string(TOPIC_DEFAULT_NAME(
                         index)), DATA_TYPE_DEFAULT, domain);
     std::shared_ptr<DomainParticipant> participant = std::make_shared<DomainParticipant>(std::string(

--- a/test/unittest/Database/DatabaseStatusTests.cpp
+++ b/test/unittest/Database/DatabaseStatusTests.cpp
@@ -73,7 +73,7 @@ TEST_F(database_status_tests, host)
     ASSERT_DEATH(db.change_entity_status(host->id, false), "");
 #endif // ifndef NDEBUG
 
-    db.change_entity_status_test(host->id, false);
+    db.change_entity_status_test(host->id, false,domain->id);
 
     ASSERT_FALSE(host->active);
     ASSERT_TRUE(user->active);
@@ -85,7 +85,7 @@ TEST_F(database_status_tests, host)
     ASSERT_TRUE(datareader->active);
     ASSERT_TRUE(locator->active);
 
-    db.change_entity_status_test(host->id, true);
+    db.change_entity_status_test(host->id, true,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -101,7 +101,7 @@ TEST_F(database_status_tests, host)
     db.insert(host1);
     ASSERT_TRUE(host1->active);
 
-    db.change_entity_status_test(host->id, false);
+    db.change_entity_status_test(host->id, false,domain->id);
 
     ASSERT_FALSE(host->active);
     ASSERT_TRUE(user->active);
@@ -114,7 +114,7 @@ TEST_F(database_status_tests, host)
     ASSERT_TRUE(locator->active);
     ASSERT_TRUE(host1->active);
 
-    db.change_entity_status_test(host->id, true);
+    db.change_entity_status_test(host->id, true,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -134,7 +134,7 @@ TEST_F(database_status_tests, user)
     ASSERT_DEATH(db.change_entity_status(user->id, false), "");
 #endif // ifndef NDEBUG
 
-    db.change_entity_status_test(user->id, false);
+    db.change_entity_status_test(user->id, false,domain->id);
 
     ASSERT_FALSE(host->active);
     ASSERT_FALSE(user->active);
@@ -146,7 +146,7 @@ TEST_F(database_status_tests, user)
     ASSERT_TRUE(datareader->active);
     ASSERT_TRUE(locator->active);
 
-    db.change_entity_status_test(user->id, true);
+    db.change_entity_status_test(user->id, true,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -162,7 +162,7 @@ TEST_F(database_status_tests, user)
     db.insert(user1);
     ASSERT_TRUE(user1->active);
 
-    db.change_entity_status_test(user->id, false);
+    db.change_entity_status_test(user->id, false,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_FALSE(user->active);
@@ -175,7 +175,7 @@ TEST_F(database_status_tests, user)
     ASSERT_TRUE(locator->active);
     ASSERT_TRUE(user1->active);
 
-    db.change_entity_status_test(user->id, true);
+    db.change_entity_status_test(user->id, true,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -195,7 +195,7 @@ TEST_F(database_status_tests, process)
     ASSERT_DEATH(db.change_entity_status(process->id, false), "");
 #endif // ifndef NDEBUG
 
-    db.change_entity_status_test(process->id, false);
+    db.change_entity_status_test(process->id, false,domain->id);
 
     ASSERT_FALSE(host->active);
     ASSERT_FALSE(user->active);
@@ -207,7 +207,7 @@ TEST_F(database_status_tests, process)
     ASSERT_TRUE(datareader->active);
     ASSERT_TRUE(locator->active);
 
-    db.change_entity_status_test(process->id, true);
+    db.change_entity_status_test(process->id, true,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -223,7 +223,7 @@ TEST_F(database_status_tests, process)
     db.insert(process1);
     ASSERT_TRUE(process1->active);
 
-    db.change_entity_status_test(process->id, false);
+    db.change_entity_status_test(process->id, false,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -236,7 +236,7 @@ TEST_F(database_status_tests, process)
     ASSERT_TRUE(locator->active);
     ASSERT_TRUE(process1->active);
 
-    db.change_entity_status_test(process->id, true);
+    db.change_entity_status_test(process->id, true,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -309,11 +309,15 @@ TEST_F(database_status_tests, domain)
 
 TEST_F(database_status_tests, topic)
 {
+    // Simulate that the backend is monitorizing the domain
+    std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
+    details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
+
 #ifndef NDEBUG
     ASSERT_DEATH(db.change_entity_status(topic->id, false), "");
 #endif // ifndef NDEBUG
 
-    db.change_entity_status_test(topic->id, false);
+    db.change_entity_status_test(topic->id, false,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -325,7 +329,7 @@ TEST_F(database_status_tests, topic)
     ASSERT_TRUE(datareader->active);
     ASSERT_TRUE(locator->active);
 
-    db.change_entity_status_test(topic->id, true);
+    db.change_entity_status_test(topic->id, true,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -341,7 +345,7 @@ TEST_F(database_status_tests, topic)
     db.insert(topic1);
     ASSERT_TRUE(topic1->active);
 
-    db.change_entity_status_test(topic->id, false);
+    db.change_entity_status_test(topic->id, false,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -354,7 +358,7 @@ TEST_F(database_status_tests, topic)
     ASSERT_TRUE(locator->active);
     ASSERT_TRUE(topic1->active);
 
-    db.change_entity_status_test(topic->id, true);
+    db.change_entity_status_test(topic->id, true,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -583,6 +587,10 @@ TEST_F(database_status_tests, datareader)
 
 TEST_F(database_status_tests, endpoints)
 {
+    // Simulate that the backend is monitorizing the domain
+    std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
+    details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
+    
     db.change_entity_status(datawriter->id, false);
     db.change_entity_status(datareader->id, false);
 
@@ -666,7 +674,7 @@ TEST_F(database_status_tests, locator)
     ASSERT_DEATH(db.change_entity_status(locator->id, false), "");
 #endif // ifndef NDEBUG
 
-    db.change_entity_status_test(locator->id, false);
+    db.change_entity_status_test(locator->id, false,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -678,7 +686,7 @@ TEST_F(database_status_tests, locator)
     ASSERT_TRUE(datareader->active);
     ASSERT_TRUE(locator->active);
 
-    db.change_entity_status_test(locator->id, true);
+    db.change_entity_status_test(locator->id, true,domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);

--- a/test/unittest/Database/DatabaseStatusTests.cpp
+++ b/test/unittest/Database/DatabaseStatusTests.cpp
@@ -73,7 +73,7 @@ TEST_F(database_status_tests, host)
     ASSERT_DEATH(db.change_entity_status(host->id, false), "");
 #endif // ifndef NDEBUG
 
-    db.change_entity_status_test(host->id, false,domain->id);
+    db.change_entity_status_test(host->id, false, domain->id);
 
     ASSERT_FALSE(host->active);
     ASSERT_TRUE(user->active);
@@ -85,7 +85,7 @@ TEST_F(database_status_tests, host)
     ASSERT_TRUE(datareader->active);
     ASSERT_TRUE(locator->active);
 
-    db.change_entity_status_test(host->id, true,domain->id);
+    db.change_entity_status_test(host->id, true, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -101,7 +101,7 @@ TEST_F(database_status_tests, host)
     db.insert(host1);
     ASSERT_TRUE(host1->active);
 
-    db.change_entity_status_test(host->id, false,domain->id);
+    db.change_entity_status_test(host->id, false, domain->id);
 
     ASSERT_FALSE(host->active);
     ASSERT_TRUE(user->active);
@@ -114,7 +114,7 @@ TEST_F(database_status_tests, host)
     ASSERT_TRUE(locator->active);
     ASSERT_TRUE(host1->active);
 
-    db.change_entity_status_test(host->id, true,domain->id);
+    db.change_entity_status_test(host->id, true, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -134,7 +134,7 @@ TEST_F(database_status_tests, user)
     ASSERT_DEATH(db.change_entity_status(user->id, false), "");
 #endif // ifndef NDEBUG
 
-    db.change_entity_status_test(user->id, false,domain->id);
+    db.change_entity_status_test(user->id, false, domain->id);
 
     ASSERT_FALSE(host->active);
     ASSERT_FALSE(user->active);
@@ -146,7 +146,7 @@ TEST_F(database_status_tests, user)
     ASSERT_TRUE(datareader->active);
     ASSERT_TRUE(locator->active);
 
-    db.change_entity_status_test(user->id, true,domain->id);
+    db.change_entity_status_test(user->id, true, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -162,7 +162,7 @@ TEST_F(database_status_tests, user)
     db.insert(user1);
     ASSERT_TRUE(user1->active);
 
-    db.change_entity_status_test(user->id, false,domain->id);
+    db.change_entity_status_test(user->id, false, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_FALSE(user->active);
@@ -175,7 +175,7 @@ TEST_F(database_status_tests, user)
     ASSERT_TRUE(locator->active);
     ASSERT_TRUE(user1->active);
 
-    db.change_entity_status_test(user->id, true,domain->id);
+    db.change_entity_status_test(user->id, true, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -195,7 +195,7 @@ TEST_F(database_status_tests, process)
     ASSERT_DEATH(db.change_entity_status(process->id, false), "");
 #endif // ifndef NDEBUG
 
-    db.change_entity_status_test(process->id, false,domain->id);
+    db.change_entity_status_test(process->id, false, domain->id);
 
     ASSERT_FALSE(host->active);
     ASSERT_FALSE(user->active);
@@ -207,7 +207,7 @@ TEST_F(database_status_tests, process)
     ASSERT_TRUE(datareader->active);
     ASSERT_TRUE(locator->active);
 
-    db.change_entity_status_test(process->id, true,domain->id);
+    db.change_entity_status_test(process->id, true, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -223,7 +223,7 @@ TEST_F(database_status_tests, process)
     db.insert(process1);
     ASSERT_TRUE(process1->active);
 
-    db.change_entity_status_test(process->id, false,domain->id);
+    db.change_entity_status_test(process->id, false, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -236,7 +236,7 @@ TEST_F(database_status_tests, process)
     ASSERT_TRUE(locator->active);
     ASSERT_TRUE(process1->active);
 
-    db.change_entity_status_test(process->id, true,domain->id);
+    db.change_entity_status_test(process->id, true, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -317,7 +317,7 @@ TEST_F(database_status_tests, topic)
     ASSERT_DEATH(db.change_entity_status(topic->id, false), "");
 #endif // ifndef NDEBUG
 
-    db.change_entity_status_test(topic->id, false,domain->id);
+    db.change_entity_status_test(topic->id, false, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -329,7 +329,7 @@ TEST_F(database_status_tests, topic)
     ASSERT_TRUE(datareader->active);
     ASSERT_TRUE(locator->active);
 
-    db.change_entity_status_test(topic->id, true,domain->id);
+    db.change_entity_status_test(topic->id, true, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -345,7 +345,7 @@ TEST_F(database_status_tests, topic)
     db.insert(topic1);
     ASSERT_TRUE(topic1->active);
 
-    db.change_entity_status_test(topic->id, false,domain->id);
+    db.change_entity_status_test(topic->id, false, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -358,7 +358,7 @@ TEST_F(database_status_tests, topic)
     ASSERT_TRUE(locator->active);
     ASSERT_TRUE(topic1->active);
 
-    db.change_entity_status_test(topic->id, true,domain->id);
+    db.change_entity_status_test(topic->id, true, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -590,7 +590,7 @@ TEST_F(database_status_tests, endpoints)
     // Simulate that the backend is monitorizing the domain
     std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
     details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
-    
+
     db.change_entity_status(datawriter->id, false);
     db.change_entity_status(datareader->id, false);
 
@@ -674,7 +674,7 @@ TEST_F(database_status_tests, locator)
     ASSERT_DEATH(db.change_entity_status(locator->id, false), "");
 #endif // ifndef NDEBUG
 
-    db.change_entity_status_test(locator->id, false,domain->id);
+    db.change_entity_status_test(locator->id, false, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);
@@ -686,7 +686,7 @@ TEST_F(database_status_tests, locator)
     ASSERT_TRUE(datareader->active);
     ASSERT_TRUE(locator->active);
 
-    db.change_entity_status_test(locator->id, true,domain->id);
+    db.change_entity_status_test(locator->id, true, domain->id);
 
     ASSERT_TRUE(host->active);
     ASSERT_TRUE(user->active);

--- a/test/unittest/Database/DatabaseStatusTests.cpp
+++ b/test/unittest/Database/DatabaseStatusTests.cpp
@@ -39,6 +39,37 @@ public:
         datawriter = db.get_dds_endpoints<DataWriter>().begin()->second.begin()->second;
         datareader = db.get_dds_endpoints<DataReader>().begin()->second.begin()->second;
         locator = db.locators().begin()->second;
+
+        // Simulate that the backend is monitorizing the domain
+        std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
+        details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
+
+        // Simulate the discover of the entities
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain->id,
+                host->id,
+                host->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain->id,
+                user->id,
+                user->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain->id,
+                process->id,
+                process->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain->id,
+                topic->id,
+                topic->kind,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain->id,
+                participant->id,
+                participant->kind,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain->id,
+                datawriter->id,
+                datawriter->kind,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain->id,
+                datareader->id,
+                datareader->kind,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
     }
 
     std::shared_ptr<Host> host;
@@ -309,10 +340,6 @@ TEST_F(database_status_tests, domain)
 
 TEST_F(database_status_tests, topic)
 {
-    // Simulate that the backend is monitorizing the domain
-    std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
-    details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
-
 #ifndef NDEBUG
     ASSERT_DEATH(db.change_entity_status(topic->id, false), "");
 #endif // ifndef NDEBUG
@@ -587,10 +614,6 @@ TEST_F(database_status_tests, datareader)
 
 TEST_F(database_status_tests, endpoints)
 {
-    // Simulate that the backend is monitorizing the domain
-    std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
-    details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
-
     db.change_entity_status(datawriter->id, false);
     db.change_entity_status(datareader->id, false);
 

--- a/test/unittest/DatabaseQueue/CMakeLists.txt
+++ b/test/unittest/DatabaseQueue/CMakeLists.txt
@@ -59,6 +59,7 @@ if(GTEST_FOUND AND GMOCK_FOUND)
         push_domain_throws
         push_participant_process_exists
         push_participant_no_process_exists
+        push_participant_throws
         push_topic
         push_topic_throws
         push_datawriter

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -216,9 +216,9 @@ TEST_F(database_queue_tests, start_stop_flush)
     // Add something to the stopped queue
     EXPECT_CALL(database, insert(_)).Times(0);
     EXPECT_TRUE(entity_queue.stop_consumer());
-    entity_queue.push(timestamp, {host, 0});
-    entity_queue.push(timestamp, {user, 0});
-    entity_queue.push(timestamp, {process, 0});
+    entity_queue.push(timestamp, {host, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {user, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {process, 0,details::StatisticsBackendData::DISCOVERY});
 
     EXPECT_TRUE(entity_queue.get_foreground_queue().empty());
     EXPECT_EQ(3, entity_queue.get_background_queue().size());
@@ -296,7 +296,7 @@ TEST_F(database_queue_tests, push_host)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {host, 0});
+    entity_queue.push(timestamp, {host, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -327,7 +327,7 @@ TEST_F(database_queue_tests, push_host_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {host, DomainId(0)});
+    entity_queue.push(timestamp, {host, DomainId(0),details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -364,7 +364,7 @@ TEST_F(database_queue_tests, push_user)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {user, 0});
+    entity_queue.push(timestamp, {user, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -398,7 +398,7 @@ TEST_F(database_queue_tests, push_user_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {user, 0});
+    entity_queue.push(timestamp, {user, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -439,7 +439,7 @@ TEST_F(database_queue_tests, push_process)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {process, 0});
+    entity_queue.push(timestamp, {process, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -477,7 +477,7 @@ TEST_F(database_queue_tests, push_process_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {process, 0});
+    entity_queue.push(timestamp, {process, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -512,7 +512,7 @@ TEST_F(database_queue_tests, push_domain)
                 0), EntityKind::DOMAIN, details::StatisticsBackendData::DISCOVERY)).Times(0);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {domain, 0});
+    entity_queue.push(timestamp, {domain, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -543,7 +543,7 @@ TEST_F(database_queue_tests, push_domain_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {domain, 0});
+    entity_queue.push(timestamp, {domain, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -591,7 +591,7 @@ TEST_F(database_queue_tests, push_participant_process_exists)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {participant, 0});
+    entity_queue.push(timestamp, {participant, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -632,7 +632,7 @@ TEST_F(database_queue_tests, push_participant_no_process_exists)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {participant, 0});
+    entity_queue.push(timestamp, {participant, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -669,7 +669,7 @@ TEST_F(database_queue_tests, push_topic)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {topic, 0});
+    entity_queue.push(timestamp, {topic, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -705,7 +705,7 @@ TEST_F(database_queue_tests, push_topic_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {topic, 0});
+    entity_queue.push(timestamp, {topic, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -748,7 +748,7 @@ TEST_F(database_queue_tests, push_datawriter)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {datawriter, 0});
+    entity_queue.push(timestamp, {datawriter, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -788,7 +788,7 @@ TEST_F(database_queue_tests, push_datawriter_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {datawriter, 0});
+    entity_queue.push(timestamp, {datawriter, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -831,7 +831,7 @@ TEST_F(database_queue_tests, push_datareader)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {datareader, 0});
+    entity_queue.push(timestamp, {datareader, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -871,7 +871,7 @@ TEST_F(database_queue_tests, push_datareader_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {datareader, 0});
+    entity_queue.push(timestamp, {datareader, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -905,7 +905,7 @@ TEST_F(database_queue_tests, push_locator)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {locator, 0});
+    entity_queue.push(timestamp, {locator, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -937,7 +937,7 @@ TEST_F(database_queue_tests, push_locator_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {locator, 0});
+    entity_queue.push(timestamp, {locator, 0,details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -576,6 +576,9 @@ TEST_F(database_queue_tests, push_participant_process_exists)
         EXPECT_CALL(database, change_entity_status(_, false)).Times(AnyNumber())
                 .WillRepeatedly(Throw(BadParameter("Error")));
 
+        // Expectations: No notification to user
+        EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_domain_entity_discovery(_, _, _, _)).Times(0);
+
         // Add to the queue and wait to be processed
         entity_queue.push(timestamp, {participant, 0, details::StatisticsBackendData::UNDISCOVERY});
         entity_queue.flush();
@@ -587,6 +590,9 @@ TEST_F(database_queue_tests, push_participant_process_exists)
         // Expectations: The status will throw an exception because the participant is not in the database
         EXPECT_CALL(database, change_entity_status(_, true)).Times(AnyNumber())
                 .WillRepeatedly(Throw(BadParameter("Error")));
+
+        // Expectations: No notification to user
+        EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_domain_entity_discovery(_, _, _, _)).Times(0);
 
         // Add to the queue and wait to be processed
         entity_queue.push(timestamp, {participant, 0, details::StatisticsBackendData::UPDATE});
@@ -678,6 +684,9 @@ TEST_F(database_queue_tests, push_participant_no_process_exists)
         EXPECT_CALL(database, change_entity_status(_, false)).Times(AnyNumber())
                 .WillRepeatedly(Throw(BadParameter("Error")));
 
+        // Expectations: No notification to user
+        EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_domain_entity_discovery(_, _, _, _)).Times(0);
+
         // Add to the queue and wait to be processed
         entity_queue.push(timestamp, {participant, 0, details::StatisticsBackendData::UNDISCOVERY});
         entity_queue.flush();
@@ -689,6 +698,9 @@ TEST_F(database_queue_tests, push_participant_no_process_exists)
         // Expectations: The status will throw an exception because the participant is not in the database
         EXPECT_CALL(database, change_entity_status(_, true)).Times(AnyNumber())
                 .WillRepeatedly(Throw(BadParameter("Error")));
+
+        // Expectations: No notification to user
+        EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_domain_entity_discovery(_, _, _, _)).Times(0);
 
         // Add to the queue and wait to be processed
         entity_queue.push(timestamp, {participant, 0, details::StatisticsBackendData::UPDATE});
@@ -896,6 +908,9 @@ TEST_F(database_queue_tests, push_datawriter)
         EXPECT_CALL(database, change_entity_status(_, false)).Times(AnyNumber())
                 .WillRepeatedly(Throw(BadParameter("Error")));
 
+        // Expectations: No notification to user
+        EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_domain_entity_discovery(_, _, _, _)).Times(0);
+
         // Add to the queue and wait to be processed
         entity_queue.push(timestamp, {datawriter, 0, details::StatisticsBackendData::UNDISCOVERY});
         entity_queue.flush();
@@ -907,6 +922,9 @@ TEST_F(database_queue_tests, push_datawriter)
         // Expectations: The status will throw an exception because the datawriter is not in the database
         EXPECT_CALL(database, change_entity_status(_, true)).Times(AnyNumber())
                 .WillRepeatedly(Throw(BadParameter("Error")));
+
+        // Expectations: No notification to user
+        EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_domain_entity_discovery(_, _, _, _)).Times(0);
 
         // Add to the queue and wait to be processed
         entity_queue.push(timestamp, {datawriter, 0, details::StatisticsBackendData::UPDATE});
@@ -1041,6 +1059,9 @@ TEST_F(database_queue_tests, push_datareader)
         EXPECT_CALL(database,
                 change_entity_status(_, false)).Times(AnyNumber()).WillRepeatedly(Throw(BadParameter("Error")));
 
+        // Expectations: No notification to user
+        EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_domain_entity_discovery(_, _, _, _)).Times(0);
+
         // Add to the queue and wait to be processed
         entity_queue.push(timestamp, {datareader, 0, details::StatisticsBackendData::UNDISCOVERY});
         entity_queue.flush();
@@ -1052,6 +1073,9 @@ TEST_F(database_queue_tests, push_datareader)
         // Expectations: The status will throw an exception because the datareader is not in the database
         EXPECT_CALL(database,
                 change_entity_status(_, true)).Times(AnyNumber()).WillRepeatedly(Throw(BadParameter("Error")));
+
+        // Expectations: No notification to user
+        EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_domain_entity_discovery(_, _, _, _)).Times(0);
 
         // Add to the queue and wait to be processed
         entity_queue.push(timestamp, {datareader, 0, details::StatisticsBackendData::UPDATE});

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -216,9 +216,9 @@ TEST_F(database_queue_tests, start_stop_flush)
     // Add something to the stopped queue
     EXPECT_CALL(database, insert(_)).Times(0);
     EXPECT_TRUE(entity_queue.stop_consumer());
-    entity_queue.push(timestamp, {host, 0,details::StatisticsBackendData::DISCOVERY});
-    entity_queue.push(timestamp, {user, 0,details::StatisticsBackendData::DISCOVERY});
-    entity_queue.push(timestamp, {process, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {host, 0, details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {user, 0, details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {process, 0, details::StatisticsBackendData::DISCOVERY});
 
     EXPECT_TRUE(entity_queue.get_foreground_queue().empty());
     EXPECT_EQ(3, entity_queue.get_background_queue().size());
@@ -296,7 +296,7 @@ TEST_F(database_queue_tests, push_host)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {host, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {host, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -327,7 +327,7 @@ TEST_F(database_queue_tests, push_host_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {host, DomainId(0),details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {host, DomainId(0), details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -364,7 +364,7 @@ TEST_F(database_queue_tests, push_user)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {user, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {user, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -398,7 +398,7 @@ TEST_F(database_queue_tests, push_user_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {user, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {user, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -439,7 +439,7 @@ TEST_F(database_queue_tests, push_process)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {process, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {process, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -477,7 +477,7 @@ TEST_F(database_queue_tests, push_process_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {process, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {process, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -512,7 +512,7 @@ TEST_F(database_queue_tests, push_domain)
                 0), EntityKind::DOMAIN, details::StatisticsBackendData::DISCOVERY)).Times(0);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {domain, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {domain, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -543,7 +543,7 @@ TEST_F(database_queue_tests, push_domain_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {domain, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {domain, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -591,7 +591,7 @@ TEST_F(database_queue_tests, push_participant_process_exists)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {participant, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {participant, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -632,7 +632,7 @@ TEST_F(database_queue_tests, push_participant_no_process_exists)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {participant, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {participant, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -669,7 +669,7 @@ TEST_F(database_queue_tests, push_topic)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {topic, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {topic, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -705,7 +705,7 @@ TEST_F(database_queue_tests, push_topic_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {topic, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {topic, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -748,7 +748,7 @@ TEST_F(database_queue_tests, push_datawriter)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {datawriter, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {datawriter, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -788,7 +788,7 @@ TEST_F(database_queue_tests, push_datawriter_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {datawriter, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {datawriter, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -831,7 +831,7 @@ TEST_F(database_queue_tests, push_datareader)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {datareader, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {datareader, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -871,7 +871,7 @@ TEST_F(database_queue_tests, push_datareader_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {datareader, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {datareader, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());
@@ -905,7 +905,7 @@ TEST_F(database_queue_tests, push_locator)
             details::StatisticsBackendData::DISCOVERY)).Times(1);
 
     // Add to the queue and wait to be processed
-    entity_queue.push(timestamp, {locator, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {locator, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.flush();
 }
 
@@ -937,7 +937,7 @@ TEST_F(database_queue_tests, push_locator_throws)
 
     // Add to the queue and wait to be processed
     entity_queue.stop_consumer();
-    entity_queue.push(timestamp, {locator, 0,details::StatisticsBackendData::DISCOVERY});
+    entity_queue.push(timestamp, {locator, 0, details::StatisticsBackendData::DISCOVERY});
     entity_queue.do_swap();
 
     EXPECT_NO_THROW(entity_queue.consume_sample());

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -3466,7 +3466,7 @@ TEST_F(database_queue_tests, push_physical_data_process_exists)
     EXPECT_CALL(database, link_participant_with_process(EntityId(1), EntityId(4))).Times(1);
 
     // Expectation: The user is not notified
-    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _)).Times(0);
+    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _, _)).Times(0);
 
     // Add to the queue and wait to be processed
     data_queue.push(timestamp, data);
@@ -3541,7 +3541,7 @@ TEST_F(database_queue_tests, push_physical_data_no_participant_exists)
             .WillOnce(Return(process));
 
     // Expectation: The user is not notified
-    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _)).Times(0);
+    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _, _)).Times(0);
 
     // Add to the queue and wait to be processed
     // The processing should not progress the exception.
@@ -3631,7 +3631,8 @@ TEST_F(database_queue_tests, push_physical_data_no_process_exists)
 
     // Expectation: The user is notified of the new process
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(4), EntityKind::PROCESS)).Times(1);
+            on_physical_entity_discovery(EntityId(1), EntityId(4), EntityKind::PROCESS,
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     // Expectation: The link method is called with appropriate arguments
     EXPECT_CALL(database, link_participant_with_process(EntityId(1), EntityId(4))).Times(1);
@@ -3722,7 +3723,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_exists_process_insert
             .WillOnce(Invoke(&insert_args_process, &InsertEntityArgs::insert));
 
     // Expectation: The user is not notified
-    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _)).Times(0);
+    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _, _)).Times(0);
 
 
     // Expectation: The link method is not called
@@ -3807,7 +3808,8 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_exists)
 
     // Expectation: The user is notified of the new process
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(3), EntityKind::USER)).Times(1);
+            on_physical_entity_discovery(EntityId(1), EntityId(3), EntityKind::USER,
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     // Expectation: The process is created and given ID 4
     InsertEntityArgs insert_args_process([&](
@@ -3824,7 +3826,8 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_exists)
 
     // Expectation: The user is notified of the new process
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(4), EntityKind::PROCESS)).Times(1);
+            on_physical_entity_discovery(EntityId(1), EntityId(4), EntityKind::PROCESS,
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     EXPECT_CALL(database, insert(_)).Times(2)
             .WillOnce(Invoke(&insert_args_user, &InsertEntityArgs::insert))
@@ -3912,7 +3915,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_exists_user_i
             .WillOnce(Invoke(&insert_args_user, &InsertEntityArgs::insert));
 
     // Expectation: The user is not notified of the new user
-    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _)).Times(0);
+    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _, _)).Times(0);
 
     // Expectation: The link method is not called
     EXPECT_CALL(database, link_participant_with_process(EntityId(1), EntityId(4))).Times(0);
@@ -3990,7 +3993,8 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_no_host_exist
 
     // Expectation: The user is notified of the new host
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(3), EntityKind::HOST)).Times(1);
+            on_physical_entity_discovery(EntityId(1), EntityId(3), EntityKind::HOST,
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     // Expectation: The user is created and given ID 4
     InsertEntityArgs insert_args_user([&](
@@ -4006,7 +4010,8 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_no_host_exist
 
     // Expectation: The user is notified of the new user
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(4), EntityKind::USER)).Times(1);
+            on_physical_entity_discovery(EntityId(1), EntityId(4), EntityKind::USER,
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     // Expectation: The process is created and given ID 5
     InsertEntityArgs insert_args_process([&](
@@ -4023,7 +4028,8 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_no_host_exist
 
     // Expectation: The user is notified of the new process
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(5), EntityKind::PROCESS)).Times(1);
+            on_physical_entity_discovery(EntityId(1), EntityId(5), EntityKind::PROCESS,
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     EXPECT_CALL(database, insert(_)).Times(3)
             .WillOnce(Invoke(&insert_args_host, &InsertEntityArgs::insert))
@@ -4105,7 +4111,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_no_host_exist
             .WillOnce(Invoke(&insert_args_host, &InsertEntityArgs::insert));
 
     // Expectation: The user is not notified
-    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _)).Times(0);
+    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _, _)).Times(0);
 
     // Expectation: The link method is not called
     EXPECT_CALL(database, link_participant_with_process(EntityId(1), EntityId(5))).Times(0);
@@ -4198,7 +4204,8 @@ TEST_F(database_queue_tests, push_physical_data_wrong_processname_format)
 
     // Expectation: The user is notified of the new process
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(4), EntityKind::PROCESS)).Times(1);
+            on_physical_entity_discovery(EntityId(1), EntityId(4), EntityKind::PROCESS,
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     // Expectation: The link method is called with appropriate arguments
     EXPECT_CALL(database, link_participant_with_process(EntityId(1), EntityId(4))).Times(1);

--- a/test/unittest/Resources/complex_dump.json
+++ b/test/unittest/Resources/complex_dump.json
@@ -580,7 +580,7 @@
     },
     "domains":{
         "13":{
-            "name":"domain_1",
+            "name":"121",
             "alias":"domain_1",
             "participants":[
                 "15"
@@ -590,7 +590,7 @@
             ]
         },
         "22":{
-            "name":"domain_2",
+            "name":"122",
             "alias":"domain_2",
             "participants":[
                 "24"
@@ -600,7 +600,7 @@
             ]
         },
         "4":{
-            "name":"domain_0",
+            "name":"120",
             "alias":"domain_0",
             "participants":[
                 "6"

--- a/test/unittest/Resources/empty_entities_dump.json
+++ b/test/unittest/Resources/empty_entities_dump.json
@@ -40,7 +40,7 @@
     {
         "4":
         {
-            "name": "domain_0",
+            "name": "120",
             "alias": "domain_0",
             "participants": ["6"],
             "topics": ["5"]

--- a/test/unittest/Resources/old_complex_dump.json
+++ b/test/unittest/Resources/old_complex_dump.json
@@ -604,7 +604,7 @@
     },
     "domains":{
         "13":{
-            "name":"domain_1",
+            "name":"121",
             "alias":"domain_1",
             "participants":[
                 "15"
@@ -614,7 +614,7 @@
             ]
         },
         "22":{
-            "name":"domain_2",
+            "name":"122",
             "alias":"domain_2",
             "participants":[
                 "24"
@@ -624,7 +624,7 @@
             ]
         },
         "4":{
-            "name":"domain_0",
+            "name":"120",
             "alias":"domain_0",
             "participants":[
                 "6"

--- a/test/unittest/Resources/simple_dump.json
+++ b/test/unittest/Resources/simple_dump.json
@@ -40,7 +40,7 @@
     {
         "4":
         {
-            "name": "domain_0",
+            "name": "120",
             "alias": "domain_0",
             "participants": ["6"],
             "topics": ["5"]

--- a/test/unittest/Resources/simple_dump_no_process_participant_link.json
+++ b/test/unittest/Resources/simple_dump_no_process_participant_link.json
@@ -40,7 +40,7 @@
     {
         "4":
         {
-            "name": "domain_0",
+            "name": "120",
             "alias": "domain_0",
             "participants": ["6"],
             "topics": ["5"]

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -490,6 +490,7 @@ if(GTEST_FOUND AND GMOCK_FOUND)
 
     target_include_directories(is_active_tests PRIVATE
         ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS}
+        ${PROJECT_SOURCE_DIR}/test/unittest/TestUtils
         ${PROJECT_SOURCE_DIR}/test/mock/dds/DomainParticipant
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -988,42 +988,48 @@ TEST_F(calling_user_listeners_DeathTest, wrong_entity_kind)
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 EntityId(0),
                 EntityId(1),
-                EntityKind::DOMAIN),
+                EntityKind::DOMAIN,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY),
             ".*");
 
     // Expectation: The call asserts
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 EntityId(0),
                 EntityId(1),
-                EntityKind::PARTICIPANT),
+                EntityKind::PARTICIPANT,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY),
             ".*");
 
     // Expectation: The call asserts
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 EntityId(0),
                 EntityId(1),
-                EntityKind::TOPIC),
+                EntityKind::TOPIC,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY),
             ".*");
 
     // Expectation: The call asserts
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 EntityId(0),
                 EntityId(1),
-                EntityKind::DATAREADER),
+                EntityKind::DATAREADER,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY),
             ".*");
 
     // Expectation: The call asserts
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 EntityId(0),
                 EntityId(1),
-                EntityKind::DATAWRITER),
+                EntityKind::DATAWRITER,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY),
             ".*");
 
     // Expectation: The call asserts
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 EntityId(0),
                 EntityId(1),
-                EntityKind::INVALID),
+                EntityKind::INVALID,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY),
             ".*");
 
     // Expectation: The call asserts

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -197,8 +197,9 @@ public:
                 EntityId,
                 EntityId,
                 const DomainListener::Status&)
-    {
-    })
+            {
+            },
+            details::StatisticsBackendData::DiscoveryStatus const& discovery_status = details::StatisticsBackendData::DISCOVERY)
     {
         // Set the callback of the expectations
         discovery_args_.callback_ = checker;
@@ -222,7 +223,8 @@ public:
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                     EntityId(0),
                     EntityId(1),
-                    EntityKind::HOST);
+                    EntityKind::HOST,
+                    discovery_status);
 
                 break;
             }
@@ -242,7 +244,8 @@ public:
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                     EntityId(0),
                     EntityId(1),
-                    EntityKind::USER);
+                    EntityKind::USER,
+                    discovery_status);
 
                 break;
             }
@@ -262,7 +265,8 @@ public:
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                     EntityId(0),
                     EntityId(1),
-                    EntityKind::PROCESS);
+                    EntityKind::PROCESS,
+                    discovery_status);
 
                 break;
             }
@@ -282,7 +286,8 @@ public:
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                     EntityId(0),
                     EntityId(1),
-                    EntityKind::LOCATOR);
+                    EntityKind::LOCATOR,
+                    discovery_status);
 
                 break;
             }
@@ -382,6 +387,34 @@ TEST_P(calling_user_listeners_tests_physical_entities, entity_discovered)
                 EXPECT_EQ(2, status.current_count);
                 EXPECT_EQ(1, status.current_count_change);
             });
+
+#ifndef NDEBUG
+    // Expectation: The user listener will fail assert with update
+    ASSERT_DEATH(test_entity_discovery(PHYSICAL,
+            [&](
+                EntityId,
+                EntityId,
+                const DomainListener::Status&)
+            {
+            },
+            details::StatisticsBackendData::DiscoveryStatus::UPDATE), "");
+#endif // ifndef NDEBUG
+
+    // Expectation: The user listener is called with removel
+    test_entity_discovery(PHYSICAL,
+            [&](
+                EntityId participant_id,
+                EntityId entity_id,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(0, participant_id);
+                EXPECT_EQ(1, entity_id);
+                EXPECT_EQ(2, status.total_count);
+                EXPECT_EQ(0, status.total_count_change);
+                EXPECT_EQ(1, status.current_count);
+                EXPECT_EQ(-1, status.current_count_change);
+            },
+            details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY);
 }
 
 TEST_P(calling_user_listeners_tests_physical_entities, entity_discovered_not_in_mask)
@@ -496,8 +529,8 @@ public:
                 EntityId,
                 EntityId,
                 const DomainListener::Status&)
-    {
-    })
+            {
+            })
     {
         // Set the callback of the expectations
         discovery_args_.callback_ = checker;

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -197,9 +197,10 @@ public:
                 EntityId,
                 EntityId,
                 const DomainListener::Status&)
-            {
-            },
-            details::StatisticsBackendData::DiscoveryStatus const& discovery_status = details::StatisticsBackendData::DISCOVERY)
+    {
+    },
+            details::StatisticsBackendData::DiscoveryStatus const& discovery_status
+            = details::StatisticsBackendData::DISCOVERY)
     {
         // Set the callback of the expectations
         discovery_args_.callback_ = checker;
@@ -529,8 +530,8 @@ public:
                 EntityId,
                 EntityId,
                 const DomainListener::Status&)
-            {
-            })
+    {
+    })
     {
         // Set the callback of the expectations
         discovery_args_.callback_ = checker;

--- a/test/unittest/StatisticsBackend/IsActiveTests.cpp
+++ b/test/unittest/StatisticsBackend/IsActiveTests.cpp
@@ -56,6 +56,47 @@ public:
         entity_queue = new DatabaseEntityQueue(db);
         data_queue = new DatabaseDataQueue(db);
         participant_listener = new StatisticsParticipantListener(domain->id, db, entity_queue, data_queue);
+
+        // Simulate that the backend is monitorizing the domain
+        std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
+        details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
+
+        // Simulate the discover of the entitiy
+        host->active = false;
+        db->change_entity_status_test(host->id, true, domain->id);
+        user->active = false;
+        db->change_entity_status_test(user->id, true, domain->id);
+        process->active = false;
+        db->change_entity_status_test(process->id, true, domain->id);
+        topic->active = false;
+        db->change_entity_status_test(topic->id, true, domain->id);
+
+        // Simulate the discover of the entities
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain->id,
+                host->id,
+                host->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain->id,
+                user->id,
+                user->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain->id,
+                process->id,
+                process->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain->id,
+                topic->id,
+                topic->kind,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain->id,
+                participant->id,
+                participant->kind,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain->id,
+                datawriter->id,
+                datawriter->kind,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain->id,
+                datareader->id,
+                datareader->kind,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
     }
 
     void TearDown()
@@ -93,10 +134,6 @@ public:
 // Check the is_active StatisticsBackend method when a participant is undiscovered
 TEST_F(is_active_tests, participant)
 {
-    // Simulate that the backend is monitorizing the domain
-    std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
-    details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
-
     ASSERT_TRUE(StatisticsBackendTest::is_active(host->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(user->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(process->id));
@@ -156,10 +193,6 @@ TEST_F(is_active_tests, participant)
 // Check the is_active StatisticsBackend method when a datawriter is undiscovered
 TEST_F(is_active_tests, datawriter)
 {
-    // Simulate that the backend is monitorizing the domain
-    std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
-    details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
-
     ASSERT_TRUE(StatisticsBackendTest::is_active(host->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(user->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(process->id));
@@ -226,10 +259,6 @@ TEST_F(is_active_tests, datawriter)
 // Check the is_active StatisticsBackend method when a datareader is undiscovered
 TEST_F(is_active_tests, datareader)
 {
-    // Simulate that the backend is monitorizing the domain
-    std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
-    details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
-
     ASSERT_TRUE(StatisticsBackendTest::is_active(host->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(user->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(process->id));
@@ -296,10 +325,6 @@ TEST_F(is_active_tests, datareader)
 // Check the is_active StatisticsBackend method when the endpoints are undiscovered
 TEST_F(is_active_tests, endpoints)
 {
-    // Simulate that the backend is monitorizing the domain
-    std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
-    details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
-
     ASSERT_TRUE(StatisticsBackendTest::is_active(host->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(user->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(process->id));

--- a/test/unittest/StatisticsBackend/IsActiveTests.cpp
+++ b/test/unittest/StatisticsBackend/IsActiveTests.cpp
@@ -156,6 +156,10 @@ TEST_F(is_active_tests, participant)
 // Check the is_active StatisticsBackend method when a datawriter is undiscovered
 TEST_F(is_active_tests, datawriter)
 {
+    // Simulate that the backend is monitorizing the domain
+    std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
+    details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
+
     ASSERT_TRUE(StatisticsBackendTest::is_active(host->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(user->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(process->id));
@@ -222,6 +226,10 @@ TEST_F(is_active_tests, datawriter)
 // Check the is_active StatisticsBackend method when a datareader is undiscovered
 TEST_F(is_active_tests, datareader)
 {
+    // Simulate that the backend is monitorizing the domain
+    std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
+    details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
+
     ASSERT_TRUE(StatisticsBackendTest::is_active(host->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(user->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(process->id));
@@ -288,6 +296,10 @@ TEST_F(is_active_tests, datareader)
 // Check the is_active StatisticsBackend method when the endpoints are undiscovered
 TEST_F(is_active_tests, endpoints)
 {
+    // Simulate that the backend is monitorizing the domain
+    std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
+    details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
+
     ASSERT_TRUE(StatisticsBackendTest::is_active(host->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(user->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(process->id));

--- a/test/unittest/StatisticsBackend/IsActiveTests.cpp
+++ b/test/unittest/StatisticsBackend/IsActiveTests.cpp
@@ -25,6 +25,17 @@
 
 using namespace eprosima::statistics_backend::subscriber;
 
+class DomainParticipantTest : public eprosima::fastdds::dds::DomainParticipant
+{
+public:
+
+    DomainParticipantTest()
+        : DomainParticipant()
+    {
+    }
+
+};
+
 /**
  * @brief Fixture for the is_active_tests
  * - Create a database loading it from a file.
@@ -82,7 +93,7 @@ public:
     // Data queue, attached to the database
     DatabaseDataQueue* data_queue;
     // Statistics participant_, that is supposed to receive the callbacks
-    eprosima::fastdds::dds::DomainParticipant statistics_participant;
+    DomainParticipantTest statistics_participant;
     // Listener under tests. Will receive a pointer to statistics_participant
     StatisticsParticipantListener* participant_listener;
 };
@@ -93,6 +104,10 @@ public:
 // Check the is_active StatisticsBackend method when a participant is undiscovered
 TEST_F(is_active_tests, participant)
 {
+    // Simulate that the backend is monitorizing the domain
+    std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
+    details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
+
     ASSERT_TRUE(StatisticsBackendTest::is_active(host->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(user->id));
     ASSERT_TRUE(StatisticsBackendTest::is_active(process->id));

--- a/test/unittest/StatisticsBackend/IsActiveTests.cpp
+++ b/test/unittest/StatisticsBackend/IsActiveTests.cpp
@@ -25,17 +25,6 @@
 
 using namespace eprosima::statistics_backend::subscriber;
 
-class DomainParticipantTest : public eprosima::fastdds::dds::DomainParticipant
-{
-public:
-
-    DomainParticipantTest()
-        : DomainParticipant()
-    {
-    }
-
-};
-
 /**
  * @brief Fixture for the is_active_tests
  * - Create a database loading it from a file.
@@ -93,7 +82,7 @@ public:
     // Data queue, attached to the database
     DatabaseDataQueue* data_queue;
     // Statistics participant_, that is supposed to receive the callbacks
-    DomainParticipantTest statistics_participant;
+    eprosima::fastdds::dds::DomainParticipant statistics_participant;
     // Listener under tests. Will receive a pointer to statistics_participant
     StatisticsParticipantListener* participant_listener;
 };

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -522,17 +522,20 @@ TEST_F(statistics_backend_tests, internal_callbacks_negative_cases)
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
                 EntityId(9),
-                EntityKind::PARTICIPANT),
+                EntityKind::PARTICIPANT,
+                details::StatisticsBackendData::DISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
                 EntityId(10),
-                EntityKind::PARTICIPANT),
+                EntityKind::PARTICIPANT,
+                details::StatisticsBackendData::DISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
                 EntityId(10),
-                EntityKind::PARTICIPANT),
+                EntityKind::PARTICIPANT,
+                details::StatisticsBackendData::DISCOVERY),
             ".*");
 
     // Check that there is a topic with EntityId(11)
@@ -543,17 +546,20 @@ TEST_F(statistics_backend_tests, internal_callbacks_negative_cases)
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
                 EntityId(11),
-                EntityKind::TOPIC),
+                EntityKind::TOPIC,
+                details::StatisticsBackendData::DISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
                 EntityId(11),
-                EntityKind::TOPIC),
+                EntityKind::TOPIC,
+                details::StatisticsBackendData::DISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
                 EntityId(11),
-                EntityKind::TOPIC),
+                EntityKind::TOPIC,
+                details::StatisticsBackendData::DISCOVERY),
             ".*");
 
     // Check that there is a datareader with EntityId(13)
@@ -564,17 +570,20 @@ TEST_F(statistics_backend_tests, internal_callbacks_negative_cases)
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
                 EntityId(13),
-                EntityKind::DATAREADER),
+                EntityKind::DATAREADER,
+                details::StatisticsBackendData::DISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
                 EntityId(13),
-                EntityKind::DATAREADER),
+                EntityKind::DATAREADER,
+                details::StatisticsBackendData::DISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
                 EntityId(13),
-                EntityKind::DATAREADER),
+                EntityKind::DATAREADER,
+                details::StatisticsBackendData::DISCOVERY),
             ".*");
 
     // Check that there is a datawriter with EntityId(17)
@@ -585,17 +594,20 @@ TEST_F(statistics_backend_tests, internal_callbacks_negative_cases)
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
                 EntityId(17),
-                EntityKind::DATAWRITER),
+                EntityKind::DATAWRITER,
+                details::StatisticsBackendData::DISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
                 EntityId(17),
-                EntityKind::DATAWRITER),
+                EntityKind::DATAWRITER,
+                details::StatisticsBackendData::DISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 participant_id,
                 EntityId(17),
-                EntityKind::DATAWRITER),
+                EntityKind::DATAWRITER,
+                details::StatisticsBackendData::DISCOVERY),
             ".*");
 
 #endif // ifndef NDEBUG

--- a/test/unittest/StatisticsParticipantListener/CMakeLists.txt
+++ b/test/unittest/StatisticsParticipantListener/CMakeLists.txt
@@ -53,8 +53,10 @@ if(GTEST_FOUND AND GMOCK_FOUND)
 
     set(STATISTICSPARTICIPANTLISTENER_TEST_LIST
         new_participant_discovered
-        new_participant_discovered_no_domain
         new_participant_discovered_participant_already_exists
+        new_participant_no_domain
+        new_participant_undiscovered
+        new_participant_undiscovered_participant_already_exists
         new_reader_discovered
         new_reader_discovered_no_topic
         new_reader_discovered_several_topics

--- a/test/unittest/StatisticsParticipantListener/CMakeLists.txt
+++ b/test/unittest/StatisticsParticipantListener/CMakeLists.txt
@@ -58,21 +58,25 @@ if(GTEST_FOUND AND GMOCK_FOUND)
         new_participant_undiscovered
         new_participant_undiscovered_participant_already_exists
         new_reader_discovered
-        new_reader_discovered_no_topic
-        new_reader_discovered_several_topics
-        new_reader_discovered_several_locators
-        new_reader_discovered_several_locators_no_host
-        new_reader_discovered_no_participant
-        new_reader_discovered_no_domain
         new_reader_discovered_reader_already_exists
+        new_reader_no_domain
+        new_reader_no_participant
+        new_reader_no_topic
+        new_reader_several_locators
+        new_reader_several_locators_no_host
+        new_reader_several_topics
+        new_reader_undiscovered
+        new_reader_undiscovered_reader_already_exists
         new_writer_discovered
-        new_writer_discovered_no_topic
-        new_writer_discovered_several_locators
-        new_writer_discovered_several_locators_no_host
-        new_writer_discovered_no_participant
-        new_writer_discovered_no_domain
         new_writer_discovered_writer_already_exists
-        new_writer_discovered_statistics_writer
+        new_writer_no_domain
+        new_writer_no_participant
+        new_writer_no_topic
+        new_writer_several_locators
+        new_writer_several_locators_no_host
+        new_writer_statistics_writer
+        new_writer_undiscovered
+        new_writer_undiscovered_writer_already_exists
         )
 
     foreach(test_name ${STATISTICSPARTICIPANTLISTENER_TEST_LIST})

--- a/test/unittest/StatisticsParticipantListener/StatisticsParticipantListenerTests.cpp
+++ b/test/unittest/StatisticsParticipantListener/StatisticsParticipantListenerTests.cpp
@@ -207,6 +207,9 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered)
     EXPECT_CALL(database, insert(_)).Times(1)
             .WillOnce(Invoke(&insert_args, &InsertEntityArgs::insert));
 
+    // Precondition: The Participant change it status
+    EXPECT_CALL(database, change_entity_status(EntityId(10), true)).Times(1);
+
     // Execution: Call the listener
     participant_listener.on_participant_discovery(&statistics_participant, std::move(info));
 }
@@ -256,6 +259,7 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_partici
             .WillRepeatedly(Return(domain_));
 
     // Precondition: The Participant exists and has ID 1
+    participant_->id = EntityId(1);
     EXPECT_CALL(database, get_entity_by_guid(EntityKind::PARTICIPANT, participant_guid_str_)).Times(AnyNumber())
             .WillRepeatedly(Return(std::make_pair(EntityId(0), EntityId(1))));
     EXPECT_CALL(database, get_entity(EntityId(1))).Times(AnyNumber())
@@ -380,6 +384,9 @@ TEST_F(statistics_participant_listener_tests, new_reader_discovered)
     EXPECT_CALL(database, insert(_)).Times(1)
             .WillOnce(Invoke(&insert_args, &InsertEntityArgs::insert));
 
+    // Precondition: The reader change it status
+    EXPECT_CALL(database, change_entity_status(EntityId(10), true)).Times(1);
+
     // Execution: Call the listener
     participant_listener.on_subscriber_discovery(&statistics_participant, std::move(info));
 }
@@ -496,9 +503,13 @@ TEST_F(statistics_participant_listener_tests, new_reader_discovered_no_topic)
             .WillOnce(Invoke(&insert_topic_args, &InsertEntityArgs::insert))
             .WillOnce(Invoke(&insert_reader_args, &InsertEntityArgs::insert));
 
+    // Precondition: The topic change it status
+    EXPECT_CALL(database, change_entity_status(EntityId(10), true)).Times(1);
+    // Precondition: The reader change it status
+    EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
+
     // Execution: Call the listener
     participant_listener.on_subscriber_discovery(&statistics_participant, std::move(info));
-
 }
 
 TEST_F(statistics_participant_listener_tests, new_reader_discovered_several_topics)
@@ -622,6 +633,9 @@ TEST_F(statistics_participant_listener_tests, new_reader_discovered_several_topi
 
     EXPECT_CALL(database, insert(_)).Times(1)
             .WillOnce(Invoke(&insert_args, &InsertEntityArgs::insert));
+
+    // Precondition: The reader change it status
+    EXPECT_CALL(database, change_entity_status(EntityId(10), true)).Times(1);
 
     // Execution: Call the listener
     participant_listener.on_subscriber_discovery(&statistics_participant, std::move(info));
@@ -789,6 +803,9 @@ TEST_F(statistics_participant_listener_tests, new_reader_discovered_several_loca
     EXPECT_CALL(database, insert(_)).Times(1)
             .WillOnce(Invoke(&insert_reader_args, &InsertEntityArgs::insert));
 
+    // Precondition: The reader change it status
+    EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
+
     // Execution: Call the listener
     participant_listener.on_subscriber_discovery(&statistics_participant, std::move(info));
     entity_queue.flush();
@@ -948,6 +965,9 @@ TEST_F(statistics_participant_listener_tests, new_reader_discovered_several_loca
 
     EXPECT_CALL(database, insert(_)).Times(1)
             .WillOnce(Invoke(&insert_reader_args, &InsertEntityArgs::insert));
+
+    // Precondition: The reader change it status
+    EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
 
     // Execution: Call the listener
     participant_listener.on_subscriber_discovery(&statistics_participant, std::move(info));
@@ -1263,6 +1283,9 @@ TEST_F(statistics_participant_listener_tests, new_writer_discovered)
     EXPECT_CALL(database, insert(_)).Times(1)
             .WillOnce(Invoke(&insert_args, &InsertEntityArgs::insert));
 
+    // Precondition: The writer change it status
+    EXPECT_CALL(database, change_entity_status(EntityId(10), true)).Times(1);
+
     // Execution: Call the listener
     participant_listener.on_publisher_discovery(&statistics_participant, std::move(info));
 }
@@ -1379,9 +1402,13 @@ TEST_F(statistics_participant_listener_tests, new_writer_discovered_no_topic)
             .WillOnce(Invoke(&insert_topic_args, &InsertEntityArgs::insert))
             .WillOnce(Invoke(&insert_writer_args, &InsertEntityArgs::insert));
 
+    // Precondition: The topic change it status
+    EXPECT_CALL(database, change_entity_status(EntityId(10), true)).Times(1);
+    // Precondition: The writer change it status
+    EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
+
     // Execution: Call the listener
     participant_listener.on_publisher_discovery(&statistics_participant, std::move(info));
-
 }
 
 TEST_F(statistics_participant_listener_tests, new_writer_discovered_several_locators
@@ -1546,6 +1573,9 @@ TEST_F(statistics_participant_listener_tests, new_writer_discovered_several_loca
     EXPECT_CALL(database, insert(_)).Times(1)
             .WillOnce(Invoke(&insert_writer_args, &InsertEntityArgs::insert));
 
+    // Precondition: The writer change it status
+    EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
+
     // Execution: Call the listener
     participant_listener.on_publisher_discovery(&statistics_participant, std::move(info));
     entity_queue.flush();
@@ -1705,6 +1735,9 @@ TEST_F(statistics_participant_listener_tests, new_writer_discovered_several_loca
 
     EXPECT_CALL(database, insert(_)).Times(1)
             .WillOnce(Invoke(&insert_writer_args, &InsertEntityArgs::insert));
+
+    // Precondition: The writer change it status
+    EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
 
     // Execution: Call the listener
     participant_listener.on_publisher_discovery(&statistics_participant, std::move(info));

--- a/test/unittest/StatisticsParticipantListener/StatisticsParticipantListenerTests.cpp
+++ b/test/unittest/StatisticsParticipantListener/StatisticsParticipantListenerTests.cpp
@@ -673,8 +673,6 @@ TEST_F(statistics_participant_listener_tests, new_reader_no_topic)
             .WillOnce(Invoke(&insert_topic_args, &InsertEntityArgs::insert))
             .WillOnce(Invoke(&insert_reader_args, &InsertEntityArgs::insert));
 
-    // Precondition: The topic change it status
-    EXPECT_CALL(database, change_entity_status(EntityId(10), true)).Times(1);
     // Precondition: The reader change it status
     EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
 
@@ -1741,8 +1739,6 @@ TEST_F(statistics_participant_listener_tests, new_writer_no_topic)
             .WillOnce(Invoke(&insert_topic_args, &InsertEntityArgs::insert))
             .WillOnce(Invoke(&insert_writer_args, &InsertEntityArgs::insert));
 
-    // Precondition: The topic change it status
-    EXPECT_CALL(database, change_entity_status(EntityId(10), true)).Times(1);
     // Precondition: The writer change it status
     EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
 

--- a/test/unittest/TestUtils/DatabaseUtils.hpp
+++ b/test/unittest/TestUtils/DatabaseUtils.hpp
@@ -588,10 +588,11 @@ public:
 
     void change_entity_status_test(
             const EntityId& entity_id,
-            bool active)
+            bool active,
+            const EntityId domain_id)
     {
         EntityKind entity_kind = get_entity_kind(entity_id);
-        change_entity_status_of_kind(entity_id, active, entity_kind);
+        change_entity_status_of_kind(entity_id, active, entity_kind,domain_id);
     }
 
 };

--- a/test/unittest/TestUtils/DatabaseUtils.hpp
+++ b/test/unittest/TestUtils/DatabaseUtils.hpp
@@ -592,7 +592,7 @@ public:
             const EntityId domain_id)
     {
         EntityKind entity_kind = get_entity_kind(entity_id);
-        change_entity_status_of_kind(entity_id, active, entity_kind,domain_id);
+        change_entity_status_of_kind(entity_id, active, entity_kind, domain_id);
     }
 
 };


### PR DESCRIPTION
For the implementation, modified:
-`DatabaseQueue.hpp`
-`StatisticsParticipantListener.cpp`

Modified several tests and added new tests in:
-`StatisticsParticipantListenerTests.cpp`
-`DatabaseQueueTests.cpp`

Modified domain name in .json file for be able to init a monitor on that domain.
Added `push_participant_throws` test in `StatisticsParticipantListenerTests.cpp`, we forgot it in some previous PR. 

Is better to check all changes at once instead of commit by commit.