### PR TITLE
init_monitor for eProsima Fast DDS Discovery Server networks

### DIFF
--- a/docs/code/StatisticsBackendTests.cpp
+++ b/docs/code/StatisticsBackendTests.cpp
@@ -81,7 +81,7 @@ void init_monitor_examples()
         // The monitor uses a custom listener.
         EntityId disc_server_prefix_monitor_id =
                 StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "127.0.0.1:11811",
-                    &domain_listener);
+                        &domain_listener);
         //!--
         static_cast<void>(domain_monitor_id);
         static_cast<void>(disc_server_monitor_id);
@@ -114,7 +114,7 @@ void init_monitor_examples()
         // The monitor uses a custom listener, a CallbackMask, and a DataKindMask.
         EntityId disc_server_prefix_monitor_id =
                 StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "127.0.0.1:11811",
-                    &domain_listener, callback_mask, datakind_mask);
+                        &domain_listener, callback_mask, datakind_mask);
         //!--
         static_cast<void>(domain_monitor_id);
         static_cast<void>(disc_server_monitor_id);

--- a/docs/code/StatisticsBackendTests.cpp
+++ b/docs/code/StatisticsBackendTests.cpp
@@ -38,23 +38,54 @@ void init_monitor_examples()
 {
     {
         //CONF-INIT-MONITOR-EXAMPLE
-        // Init a monitor in DDS domain 0 with no listener associated
-        EntityId domain_monitor_id = StatisticsBackend::init_monitor(0);
+        // Init a monitor in DDS domain 0 with no listener associated.
+        EntityId domain_monitor_id =
+                StatisticsBackend::init_monitor(0);
 
         // Init a monitor for a Fast DDS Discovery Server network which server is located in IPv4
-        // address 127.0.0.1 and port 11811. The monitor has no listener associated
-        EntityId disc_server_monitor_id = StatisticsBackend::init_monitor("127.0.0.1:11811");
+        // address 127.0.0.1 and port 11811, and that uses the default GUID prefix
+        // eprosima::fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX.
+        // The monitor has no listener associated.
+        EntityId disc_server_monitor_id =
+                StatisticsBackend::init_monitor("127.0.0.1:11811");
+
+        // Init a monitor for a Fast DDS Discovery Server network which serveris located in IPv4
+        // address 127.0.0.1 and port 11811, and that uses the GUID prefix
+        // "44.53.01.5f.45.50.52.4f.53.49.4d.41".
+        // The monitor has no listener associated.
+        EntityId disc_server_prefix_monitor_id =
+                StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "127.0.0.1:11811");
         //!--
         static_cast<void>(domain_monitor_id);
         static_cast<void>(disc_server_monitor_id);
+        static_cast<void>(disc_server_prefix_monitor_id);
     }
     {
         //CONF-INIT-MONITOR-LISTENER-EXAMPLE
-        // Init a monitor in DDS domain 0 with a custom listener
         CustomDomainListener domain_listener;
-        EntityId domain_monitor_id = StatisticsBackend::init_monitor(0, &domain_listener);
+
+        // Init a monitor in DDS domain 0 with a custom listener.
+        EntityId domain_monitor_id =
+                StatisticsBackend::init_monitor(0, &domain_listener);
+
+        // Init a monitor for a Fast DDS Discovery Server network which server is located in IPv4
+        // address 127.0.0.1 and port 11811, and that uses the default GUID prefix
+        // eprosima::fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX.
+        // The monitor uses a custom listener.
+        EntityId disc_server_monitor_id =
+                StatisticsBackend::init_monitor("127.0.0.1:11811", &domain_listener);
+
+        // Init a monitor for a Fast DDS Discovery Server network which serveris located in IPv4
+        // address 127.0.0.1 and port 11811, and that uses the GUID prefix
+        // "44.53.01.5f.45.50.52.4f.53.49.4d.41".
+        // The monitor uses a custom listener.
+        EntityId disc_server_prefix_monitor_id =
+                StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "127.0.0.1:11811",
+                    &domain_listener);
         //!--
         static_cast<void>(domain_monitor_id);
+        static_cast<void>(disc_server_monitor_id);
+        static_cast<void>(disc_server_prefix_monitor_id);
     }
     {
         //CONF-INIT-MONITOR-MASKS-EXAMPLE
@@ -64,11 +95,30 @@ void init_monitor_examples()
         // Only get notificiations about network latency or subscription throughput
         DataKindMask datakind_mask = DataKind::NETWORK_LATENCY | DataKind::SUBSCRIPTION_THROUGHPUT;
 
-        // Init a monitor in DDS domain 0 with a custom listener, a CallbackMask, and a DataKindMask
         CustomDomainListener domain_listener;
-        EntityId domain_monitor_id = StatisticsBackend::init_monitor(0, &domain_listener, callback_mask, datakind_mask);
+
+        // Init a monitor in DDS domain 0 with a custom listener, a CallbackMask, and a DataKindMask
+        EntityId domain_monitor_id =
+                StatisticsBackend::init_monitor(0, &domain_listener, callback_mask, datakind_mask);
+
+        // Init a monitor for a Fast DDS Discovery Server network which server is located in IPv4
+        // address 127.0.0.1 and port 11811, and that uses the default GUID prefix
+        // eprosima::fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX.
+        // The monitor uses a custom listener, a CallbackMask, and a DataKindMask.
+        EntityId disc_server_monitor_id =
+                StatisticsBackend::init_monitor("127.0.0.1:11811", &domain_listener, callback_mask, datakind_mask);
+
+        // Init a monitor for a Fast DDS Discovery Server network which serveris located in IPv4
+        // address 127.0.0.1 and port 11811, and that uses the GUID prefix
+        // "44.53.01.5f.45.50.52.4f.53.49.4d.41".
+        // The monitor uses a custom listener, a CallbackMask, and a DataKindMask.
+        EntityId disc_server_prefix_monitor_id =
+                StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "127.0.0.1:11811",
+                    &domain_listener, callback_mask, datakind_mask);
         //!--
         static_cast<void>(domain_monitor_id);
+        static_cast<void>(disc_server_monitor_id);
+        static_cast<void>(disc_server_prefix_monitor_id);
     }
 }
 

--- a/docs/rst/spelling_wordlist.txt
+++ b/docs/rst/spelling_wordlist.txt
@@ -12,6 +12,7 @@ datawriter
 destructor
 eProsima
 Gtest
+IPaddress
 monitorization
 monitorizations
 ostream

--- a/docs/rst/spelling_wordlist.txt
+++ b/docs/rst/spelling_wordlist.txt
@@ -12,7 +12,6 @@ datawriter
 destructor
 eProsima
 Gtest
-IPaddress
 monitorization
 monitorizations
 ostream

--- a/docs/rst/statistics_backend/init_monitor.rst
+++ b/docs/rst/statistics_backend/init_monitor.rst
@@ -9,7 +9,7 @@ Initializing a monitor on a certain Domain ID makes *eProsima Fast DDS Statistic
 start monitoring the statistics data and entity discoveries on that domain.
 No statistics data will be gathered unless there is a monitor initialized in the required domain.
 
-|StatisticsBackend-api| provides two overloads of |init_monitor-api| that can be used to start a monitorization on a
+|StatisticsBackend-api| provides three overloads of |init_monitor-api| that can be used to start a monitorization on a
 DDS domain or a *Fast DDS* Discovery Server network.
 
 .. literalinclude:: /code/StatisticsBackendTests.cpp
@@ -17,10 +17,6 @@ DDS domain or a *Fast DDS* Discovery Server network.
    :start-after: //CONF-INIT-MONITOR-EXAMPLE
    :end-before: //!
    :dedent: 8
-
-.. warning::
-    Initializing a monitor for a discovery server configuration is currently not supported.
-    It will be implemented on a future release of *Fast DDS Statistics Backend*.
 
 Furthermore, it is possible to initialize a monitor with a custom |DomainListener-api|.
 Please refer to :ref:`listeners_domain_listener` for more information about the ``DomainListener`` and its

--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -85,7 +85,7 @@ public:
      * the network of the server with the given locators.
      * The server \c GuidPrefix_t is set to the default one: \c eprosima::fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX.
      * If any other server is to be used, call the overload method that receives the \c GuidPrefix_t as parameter.
-     * 
+     *
      * The format to specify a locator is: <tt>kind:[IPaddress]:port</tt>, where:
      *  * \b kind is one of { \c UDPv4, \c TCPv4, \c UDPv6, \c TCPv4 }
      *  * \b IPaddress is the IP address
@@ -111,7 +111,7 @@ public:
      *
      * This function creates a new statistics DomainParticipant that starts monitoring
      * the network of the server with the given \c GuidPrefix_t and with the given locators.
-     * 
+     *
      * The format to specify a locator is: <tt>kind:[IPaddress]:port</tt>, where:
      *  * \b kind is one of { \c UDPv4, \c TCPv4, \c UDPv6, \c TCPv4 }
      *  * \b IPaddress is the IP address

--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -87,7 +87,7 @@ public:
      * If any other server is to be used, call the overload method that receives the \c GuidPrefix_t as parameter.
      *
      * @param discovery_server_locators The locator list of the server whose network is to be monitored,
-     *                                  formatted as a semicolon separated list of locators "IPaddress:port".
+     *                                  formatted as a semicolon separated list of locators "kind:[IPaddress]:port".
      * @param domain_listener Listener with the callback to use to inform of events.
      * @param callback_mask Mask of the callbacks. Only the events that have the mask bit set will be informed.
      * @param data_mask Mask of the data types that will be monitored.
@@ -107,7 +107,7 @@ public:
      *
      * @param discovery_server_guid_prefix Server \c GuidPrefix_t to be monitored.
      * @param discovery_server_locators The locator list of the server whose network is to be monitored,
-     *                                  formatted as a semicolon separated list of locators "IPaddress:port".
+     *                                  formatted as a semicolon separated list of locators "kind:[IPaddress]:port".
      * @param domain_listener Listener with the callback to use to inform of events.
      * @param callback_mask Mask of the callbacks. Only the events that have the mask bit set will be informed.
      * @param data_mask Mask of the data types that will be monitored.

--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -86,9 +86,9 @@ public:
      * The server \c GuidPrefix_t is set to the default one: \c eprosima::fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX.
      * If any other server is to be used, call the overload method that receives the \c GuidPrefix_t as parameter.
      *
-     * The format to specify a locator is: <tt>kind:[IPaddress]:port</tt>, where:
+     * The format to specify a locator is: <tt>kind:[IP]:port</tt>, where:
      *  * \b kind is one of { \c UDPv4, \c TCPv4, \c UDPv6, \c TCPv4 }
-     *  * \b IPaddress is the IP address
+     *  * \b IP is the IP address
      *  * \b port is the IP port
      * Note that \c SHM locators are not supported. For any server configured with shared memory locators,
      * initialize the monitor using only the non shared memory locators.
@@ -112,9 +112,9 @@ public:
      * This function creates a new statistics DomainParticipant that starts monitoring
      * the network of the server with the given \c GuidPrefix_t and with the given locators.
      *
-     * The format to specify a locator is: <tt>kind:[IPaddress]:port</tt>, where:
+     * The format to specify a locator is: <tt>kind:[IP]:port</tt>, where:
      *  * \b kind is one of { \c UDPv4, \c TCPv4, \c UDPv6, \c TCPv4 }
-     *  * \b IPaddress is the IP address
+     *  * \b IP is the IP address
      *  * \b port is the IP port
      * Note that \c SHM locators are not supported. For any server configured with shared memory locators,
      * initialize the monitor using only the non shared memory locators.

--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -85,9 +85,16 @@ public:
      * the network of the server with the given locators.
      * The server \c GuidPrefix_t is set to the default one: \c eprosima::fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX.
      * If any other server is to be used, call the overload method that receives the \c GuidPrefix_t as parameter.
+     * 
+     * The format to specify a locator is: <tt>kind:[IPaddress]:port</tt>, where:
+     *  * \b kind is one of { \c UDPv4, \c TCPv4, \c UDPv6, \c TCPv4 }
+     *  * \b IPaddress is the IP address
+     *  * \b port is the IP port
+     * Note that \c SHM locators are not supported. For any server configured with shared memory locators,
+     * initialize the monitor using only the non shared memory locators.
      *
      * @param discovery_server_locators The locator list of the server whose network is to be monitored,
-     *                                  formatted as a semicolon separated list of locators "kind:[IPaddress]:port".
+     *                                  formatted as a semicolon separated list of locators.
      * @param domain_listener Listener with the callback to use to inform of events.
      * @param callback_mask Mask of the callbacks. Only the events that have the mask bit set will be informed.
      * @param data_mask Mask of the data types that will be monitored.
@@ -104,10 +111,17 @@ public:
      *
      * This function creates a new statistics DomainParticipant that starts monitoring
      * the network of the server with the given \c GuidPrefix_t and with the given locators.
+     * 
+     * The format to specify a locator is: <tt>kind:[IPaddress]:port</tt>, where:
+     *  * \b kind is one of { \c UDPv4, \c TCPv4, \c UDPv6, \c TCPv4 }
+     *  * \b IPaddress is the IP address
+     *  * \b port is the IP port
+     * Note that \c SHM locators are not supported. For any server configured with shared memory locators,
+     * initialize the monitor using only the non shared memory locators.
      *
      * @param discovery_server_guid_prefix Server \c GuidPrefix_t to be monitored.
      * @param discovery_server_locators The locator list of the server whose network is to be monitored,
-     *                                  formatted as a semicolon separated list of locators "kind:[IPaddress]:port".
+     *                                  formatted as a semicolon separated list of locators.
      * @param domain_listener Listener with the callback to use to inform of events.
      * @param callback_mask Mask of the callbacks. Only the events that have the mask bit set will be informed.
      * @param data_mask Mask of the data types that will be monitored.

--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -79,19 +79,42 @@ public:
             DataKindMask data_mask = DataKindMask::none());
 
     /**
-     * @brief Starts monitoring the domain corresponding to a server.
+     * @brief Starts monitoring the network corresponding to a server.
      *
      * This function creates a new statistics DomainParticipant that starts monitoring
-     * the domain of the server with the given locator.
+     * the network of the server with the given locators.
+     * The server \c GuidPrefix_t is set to the default one: \c eprosima::fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX.
+     * If any other server is to be used, call the overload method that receives the \c GuidPrefix_t as parameter.
      *
-     * @param discovery_server_locators The locator of the server whose domain is to be monitored,
-     *                                  formatted as "IPV4address:port".
+     * @param discovery_server_locators The locator list of the server whose network is to be monitored,
+     *                                  formatted as a semicolon separated list of locators "IPaddress:port".
      * @param domain_listener Listener with the callback to use to inform of events.
      * @param callback_mask Mask of the callbacks. Only the events that have the mask bit set will be informed.
      * @param data_mask Mask of the data types that will be monitored.
      * @return The ID of the created statistics Domain.
      */
     static EntityId init_monitor(
+            std::string discovery_server_locators,
+            DomainListener* domain_listener = nullptr,
+            CallbackMask callback_mask = CallbackMask::all(),
+            DataKindMask data_mask = DataKindMask::none());
+
+    /**
+     * @brief Starts monitoring the network corresponding to a server.
+     *
+     * This function creates a new statistics DomainParticipant that starts monitoring
+     * the network of the server with the given \c GuidPrefix_t and with the given locators.
+     *
+     * @param discovery_server_guid_prefix Server \c GuidPrefix_t to be monitored.
+     * @param discovery_server_locators The locator list of the server whose network is to be monitored,
+     *                                  formatted as a semicolon separated list of locators "IPaddress:port".
+     * @param domain_listener Listener with the callback to use to inform of events.
+     * @param callback_mask Mask of the callbacks. Only the events that have the mask bit set will be informed.
+     * @param data_mask Mask of the data types that will be monitored.
+     * @return The ID of the created statistics Domain.
+     */
+    static EntityId init_monitor(
+            std::string discovery_server_guid_prefix,
             std::string discovery_server_locators,
             DomainListener* domain_listener = nullptr,
             CallbackMask callback_mask = CallbackMask::all(),

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -93,6 +93,7 @@ void find_or_create_topic_and_type(
     {
         if (topic_desc->get_type_name() != type->getName())
         {
+            details::StatisticsBackendData::get_instance()->unlock();
             throw Error(topic_name + " is not using expected type " + type->getName() +
                           " and is using instead type " + topic_desc->get_type_name());
         }
@@ -104,6 +105,7 @@ void find_or_create_topic_and_type(
         catch (const std::bad_cast& e)
         {
             // TODO[ILG]: Could we support other TopicDescription types in this context?
+            details::StatisticsBackendData::get_instance()->unlock();
             throw Error(topic_name + " is already used but is not a simple Topic: " + e.what());
         }
 
@@ -113,6 +115,7 @@ void find_or_create_topic_and_type(
         if (ReturnCode_t::RETCODE_PRECONDITION_NOT_MET == monitor->participant->register_type(type, type->getName()))
         {
             // Name already in use
+            details::StatisticsBackendData::get_instance()->unlock();
             throw Error(std::string("Type name ") + type->getName() + " is already in use");
         }
         monitor->topics[topic_name] =

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <fstream>
 #include <sstream>
+#include <string>
 
 #include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
@@ -31,9 +32,13 @@
 #include <fastdds/dds/topic/qos/TopicQos.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/topic/TopicDescription.hpp>
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
+#include <fastdds/rtps/attributes/ServerAttributes.h>
+#include <fastdds/rtps/common/Locator.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 #include <fastdds/statistics/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/statistics/topic_names.hpp>
+#include <fastrtps/utils/IPLocator.h>
 
 #include <fastdds_statistics_backend/StatisticsBackend.hpp>
 #include <fastdds_statistics_backend/types/JSONTags.h>
@@ -49,6 +54,7 @@
 #include "detail/data_aggregation.hpp"
 
 using namespace eprosima::fastdds::dds;
+using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::statistics;
 
 namespace eprosima {
@@ -163,48 +169,19 @@ void register_statistics_type_and_topic(
     }
 }
 
-void StatisticsBackend::set_physical_listener(
-        PhysicalListener* listener,
-        CallbackMask callback_mask,
-        DataKindMask data_mask)
-{
-    details::StatisticsBackendData::get_instance()->lock();
-    details::StatisticsBackendData::get_instance()->physical_listener_ = listener;
-    details::StatisticsBackendData::get_instance()->physical_callback_mask_ = callback_mask;
-    details::StatisticsBackendData::get_instance()->physical_data_mask_ = data_mask;
-    details::StatisticsBackendData::get_instance()->unlock();
-}
-
-void StatisticsBackend::set_domain_listener(
-        EntityId monitor_id,
-        DomainListener* listener,
-        CallbackMask callback_mask,
-        DataKindMask data_mask)
-{
-    auto monitor = details::StatisticsBackendData::get_instance()->monitors_by_entity_.find(monitor_id);
-    if (monitor == details::StatisticsBackendData::get_instance()->monitors_by_entity_.end())
-    {
-        throw BadParameter("There is no monitor with the given ID");
-    }
-
-    monitor->second->domain_listener = listener;
-    monitor->second->domain_callback_mask = callback_mask;
-    monitor->second->data_mask = data_mask;
-}
-
-EntityId StatisticsBackend::init_monitor(
-        DomainId domain_id,
+EntityId create_and_register_monitor(
+        const std::string& domain_name,
         DomainListener* domain_listener,
-        CallbackMask callback_mask,
-        DataKindMask data_mask)
+        const CallbackMask& callback_mask,
+        const DataKindMask& data_mask,
+        const DomainParticipantQos& participant_qos,
+        const DomainId domain_id = 0)
 {
     details::StatisticsBackendData::get_instance()->lock();
 
     /* Create monitor instance and register it in the database */
     std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
-    std::stringstream domain_name;
-    domain_name << domain_id;
-    std::shared_ptr<database::Domain> domain = std::make_shared<database::Domain>(domain_name.str());
+    std::shared_ptr<database::Domain> domain = std::make_shared<database::Domain>(domain_name);
     try
     {
         domain->id = details::StatisticsBackendData::get_instance()->database_->insert(domain);
@@ -230,16 +207,6 @@ EntityId StatisticsBackend::init_monitor(
         details::StatisticsBackendData::get_instance()->data_queue_);
 
     /* Create DomainParticipant */
-    DomainParticipantQos participant_qos = DomainParticipantFactory::get_instance()->get_default_participant_qos();
-    /* Previous string conversion is needed for string_255 */
-    std::string participant_name = "monitor_domain_" + std::to_string(domain_id);
-    participant_qos.name(participant_name);
-    /* Avoid using SHM transport by default */
-    std::shared_ptr<eprosima::fastdds::rtps::UDPv4TransportDescriptor> udp_transport =
-            std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
-    participant_qos.transport().user_transports.push_back(udp_transport);
-    participant_qos.transport().use_builtin_transports = false;
-
     StatusMask participant_mask = StatusMask::all();
     participant_mask ^= StatusMask::data_on_readers();
     monitor->participant = DomainParticipantFactory::get_instance()->create_participant(
@@ -295,6 +262,60 @@ EntityId StatisticsBackend::init_monitor(
     return domain->id;
 }
 
+void StatisticsBackend::set_physical_listener(
+        PhysicalListener* listener,
+        CallbackMask callback_mask,
+        DataKindMask data_mask)
+{
+    details::StatisticsBackendData::get_instance()->lock();
+    details::StatisticsBackendData::get_instance()->physical_listener_ = listener;
+    details::StatisticsBackendData::get_instance()->physical_callback_mask_ = callback_mask;
+    details::StatisticsBackendData::get_instance()->physical_data_mask_ = data_mask;
+    details::StatisticsBackendData::get_instance()->unlock();
+}
+
+void StatisticsBackend::set_domain_listener(
+        EntityId monitor_id,
+        DomainListener* listener,
+        CallbackMask callback_mask,
+        DataKindMask data_mask)
+{
+    auto monitor = details::StatisticsBackendData::get_instance()->monitors_by_entity_.find(monitor_id);
+    if (monitor == details::StatisticsBackendData::get_instance()->monitors_by_entity_.end())
+    {
+        throw BadParameter("There is no monitor with the given ID");
+    }
+
+    monitor->second->domain_listener = listener;
+    monitor->second->domain_callback_mask = callback_mask;
+    monitor->second->data_mask = data_mask;
+}
+
+EntityId StatisticsBackend::init_monitor(
+        DomainId domain_id,
+        DomainListener* domain_listener,
+        CallbackMask callback_mask,
+        DataKindMask data_mask)
+{
+    /* Set domain_name */
+    std::stringstream domain_name;
+    domain_name << domain_id;
+
+    /* Set DomainParticipantQoS */
+    DomainParticipantQos participant_qos = DomainParticipantFactory::get_instance()->get_default_participant_qos();
+    /* Previous string conversion is needed for string_255 */
+    std::string participant_name = "monitor_domain_" + std::to_string(domain_id);
+    participant_qos.name(participant_name);
+    /* Avoid using SHM transport by default */
+    std::shared_ptr<eprosima::fastdds::rtps::UDPv4TransportDescriptor> udp_transport =
+            std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
+    participant_qos.transport().user_transports.push_back(udp_transport);
+    participant_qos.transport().use_builtin_transports = false;
+
+    return create_and_register_monitor(domain_name.str(), domain_listener, callback_mask, data_mask, participant_qos,
+            domain_id);
+}
+
 void StatisticsBackend::stop_monitor(
         EntityId monitor_id)
 {
@@ -340,11 +361,78 @@ EntityId StatisticsBackend::init_monitor(
         CallbackMask callback_mask,
         DataKindMask data_mask)
 {
-    static_cast<void>(discovery_server_locators);
-    static_cast<void>(domain_listener);
-    static_cast<void>(callback_mask);
-    static_cast<void>(data_mask);
-    return EntityId();
+    return init_monitor(DEFAULT_ROS2_SERVER_GUIDPREFIX, discovery_server_locators, domain_listener, callback_mask,
+            data_mask);
+}
+
+EntityId StatisticsBackend::init_monitor(
+        std::string discovery_server_guid_prefix,
+        std::string discovery_server_locators,
+        DomainListener* domain_listener,
+        CallbackMask callback_mask,
+        DataKindMask data_mask)
+{
+    /* Set DomainParticipantQoS */
+    DomainParticipantQos participant_qos = DomainParticipantFactory::get_instance()->get_default_participant_qos();
+    participant_qos.name("monitor_discovery_server_" + discovery_server_guid_prefix);
+
+    /* Avoid using SHM transport by default */
+    std::shared_ptr<eprosima::fastdds::rtps::UDPv4TransportDescriptor> udp_transport =
+            std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
+    participant_qos.transport().user_transports.push_back(udp_transport);
+    participant_qos.transport().use_builtin_transports = false;
+
+    participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
+        eprosima::fastrtps::rtps::DiscoveryProtocol_t::SUPER_CLIENT;
+    RemoteServerAttributes server;
+    // Set the server guidPrefix
+    server.ReadguidPrefix(discovery_server_guid_prefix.c_str());
+    // Add locators
+    std::stringstream locators(discovery_server_locators);
+    std::string locator_str;
+    while (std::getline(locators, locator_str, ';'))
+    {
+        eprosima::fastrtps::rtps::Locator_t locator;
+        // Get IP address and port
+        std::stringstream locator_sstream(locator_str);
+        std::string ip;
+        std::string port_str;
+        std::getline(locator_sstream, ip, ':');
+        std::getline(locator_sstream, port_str);
+        // Set IP address
+        if (!eprosima::fastrtps::rtps::IPLocator::setIPv4(locator, ip))
+        {
+            locator.kind = LOCATOR_KIND_UDPv6;
+            if (!eprosima::fastrtps::rtps::IPLocator::setIPv6(locator,ip))
+            {
+                throw BadParameter(ip + " does not have a valid IP address format");
+            }
+        }
+        // Set port
+        if (port_str.find_first_not_of("1234567890") != std::string::npos)
+        {
+            throw BadParameter(port_str + " does not have a valid format");
+        }
+        unsigned long port = std::stoul(port_str);
+        if (port > std::numeric_limits<uint32_t>::max())
+        {
+            throw BadParameter(port_str + " is out of range");
+        }
+        locator.port = port;
+        // Check unicast/multicast address
+        if (eprosima::fastrtps::rtps::IPLocator::isMulticast(locator))
+        {
+            server.metatrafficMulticastLocatorList.push_back(locator);
+        }
+        else
+        {
+            server.metatrafficUnicastLocatorList.push_back(locator);
+        }
+    }
+    participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(server);
+
+    return create_and_register_monitor(discovery_server_guid_prefix, domain_listener, callback_mask, data_mask,
+            participant_qos);
 }
 
 void StatisticsBackend::restart_monitor(

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -316,7 +316,7 @@ EntityId StatisticsBackend::init_monitor(
     participant_qos.transport().use_builtin_transports = false;
 
     return create_and_register_monitor(domain_name.str(), domain_listener, callback_mask, data_mask, participant_qos,
-            domain_id);
+                   domain_id);
 }
 
 void StatisticsBackend::stop_monitor(
@@ -365,7 +365,7 @@ EntityId StatisticsBackend::init_monitor(
         DataKindMask data_mask)
 {
     return init_monitor(DEFAULT_ROS2_SERVER_GUIDPREFIX, discovery_server_locators, domain_listener, callback_mask,
-            data_mask);
+                   data_mask);
 }
 
 EntityId StatisticsBackend::init_monitor(
@@ -386,7 +386,7 @@ EntityId StatisticsBackend::init_monitor(
     participant_qos.transport().use_builtin_transports = false;
 
     participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
-        eprosima::fastrtps::rtps::DiscoveryProtocol_t::SUPER_CLIENT;
+            eprosima::fastrtps::rtps::DiscoveryProtocol_t::SUPER_CLIENT;
     RemoteServerAttributes server;
     // Set the server guidPrefix
     server.ReadguidPrefix(discovery_server_guid_prefix.c_str());
@@ -420,7 +420,7 @@ EntityId StatisticsBackend::init_monitor(
     participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(server);
 
     return create_and_register_monitor(discovery_server_guid_prefix, domain_listener, callback_mask, data_mask,
-            participant_qos);
+                   participant_qos);
 }
 
 void StatisticsBackend::restart_monitor(

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -379,6 +379,10 @@ set(INIT_MONITOR_TEST_LIST
     init_monitor_register_type_fails
     init_monitor_topic_exists
     init_monitor_topic_exists_with_another_type
+    init_monitor_invalid_ipv4
+    init_monitor_invalid_ipv6
+    init_monitor_invalid_port
+    init_monitor_port_out_of_range
     )
 
 foreach(test_name ${INIT_MONITOR_TEST_LIST})

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -312,6 +312,7 @@ set(INIT_MONITOR_TEST_LIST
     init_monitor_domain_id_null_listener_all_data
     init_monitor_several_monitors
     init_monitor_twice
+    init_server_monitor_several_locators
     stop_monitor
     init_monitor_check_participant_name
     init_monitor_check_participant_transport
@@ -383,6 +384,8 @@ set(INIT_MONITOR_TEST_LIST
     init_monitor_invalid_ipv6
     init_monitor_invalid_port
     init_monitor_port_out_of_range
+    init_monitor_unsupported_shm
+    init_monitor_extra_characters
     )
 
 foreach(test_name ${INIT_MONITOR_TEST_LIST})

--- a/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
@@ -230,6 +230,25 @@ public:
                         all_datakind_mask_), Error);
     }
 
+    void check_init_monitor_discovery_server_failure(
+            const std::string& server_locators)
+    {
+        DomainListener domain_listener;
+        std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
+
+        EXPECT_THROW(StatisticsBackend::init_monitor(
+                server_locators,
+                &domain_listener,
+                all_callback_mask_,
+                all_datakind_mask_), BadParameter);
+        EXPECT_THROW(StatisticsBackend::init_monitor(
+                server_guid_prefix,
+                server_locators,
+                &domain_listener,
+                all_callback_mask_,
+                all_datakind_mask_), BadParameter);
+    }
+
     ~init_monitor_factory_fails_tests()
     {
         // Clear memory
@@ -339,6 +358,34 @@ TEST_F(init_monitor_factory_fails_tests, init_monitor_topic_exists_with_another_
             .WillByDefault(Return(&topic));
 
     check_init_monitor_failure();
+}
+
+TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_ipv4)
+{
+    std::string server_locators = "192.356.0.1:11811";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+}
+
+TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_ipv6)
+{
+    std::string server_locators = "::0:G5a:11811";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+}
+
+TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_port)
+{
+    std::string server_locators = "192.356.0.1:-11811";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+}
+
+TEST_F(init_monitor_factory_fails_tests, init_monitor_port_out_of_range)
+{
+    std::string server_locators = "192.356.0.1:4294967296";
+
+    check_init_monitor_discovery_server_failure(server_locators);
 }
 
 int main(

--- a/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
@@ -388,6 +388,20 @@ TEST_F(init_monitor_factory_fails_tests, init_monitor_port_out_of_range)
     check_init_monitor_discovery_server_failure(server_locators);
 }
 
+TEST_F(init_monitor_factory_fails_tests, init_monitor_unsupported_shm)
+{
+    std::string server_locators = "SHM:[_]:11815";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+}
+
+TEST_F(init_monitor_factory_fails_tests, init_monitor_extra_characters)
+{
+    std::string server_locators = "UDPv4:[192.356.0.1]:1181:ABC";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
@@ -213,21 +213,21 @@ public:
         std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
         EXPECT_THROW(StatisticsBackend::init_monitor(
-                        domain_id,
-                        &domain_listener,
-                        all_callback_mask_,
-                        all_datakind_mask_), Error);
+                    domain_id,
+                    &domain_listener,
+                    all_callback_mask_,
+                    all_datakind_mask_), Error);
         EXPECT_THROW(StatisticsBackend::init_monitor(
-                        server_locators,
-                        &domain_listener,
-                        all_callback_mask_,
-                        all_datakind_mask_), Error);
+                    server_locators,
+                    &domain_listener,
+                    all_callback_mask_,
+                    all_datakind_mask_), Error);
         EXPECT_THROW(StatisticsBackend::init_monitor(
-                        server_guid_prefix,
-                        server_locators,
-                        &domain_listener,
-                        all_callback_mask_,
-                        all_datakind_mask_), Error);
+                    server_guid_prefix,
+                    server_locators,
+                    &domain_listener,
+                    all_callback_mask_,
+                    all_datakind_mask_), Error);
     }
 
     void check_init_monitor_discovery_server_failure(
@@ -237,16 +237,16 @@ public:
         std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
 
         EXPECT_THROW(StatisticsBackend::init_monitor(
-                server_locators,
-                &domain_listener,
-                all_callback_mask_,
-                all_datakind_mask_), BadParameter);
+                    server_locators,
+                    &domain_listener,
+                    all_callback_mask_,
+                    all_datakind_mask_), BadParameter);
         EXPECT_THROW(StatisticsBackend::init_monitor(
-                server_guid_prefix,
-                server_locators,
-                &domain_listener,
-                all_callback_mask_,
-                all_datakind_mask_), BadParameter);
+                    server_guid_prefix,
+                    server_locators,
+                    &domain_listener,
+                    all_callback_mask_,
+                    all_datakind_mask_), BadParameter);
     }
 
     ~init_monitor_factory_fails_tests()

--- a/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
@@ -210,7 +210,7 @@ public:
         DomainId domain_id = 0;
         DomainListener domain_listener;
         std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
-        std::string server_locators = "127.0.0.1:11811";
+        std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
         EXPECT_THROW(StatisticsBackend::init_monitor(
                         domain_id,
@@ -319,7 +319,7 @@ TEST_F(init_monitor_factory_fails_tests, init_monitor_topic_exists)
     DomainId domain_id = 0;
     DomainListener domain_listener;
     std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
-    std::string server_locators = "127.0.0.1:11811";
+    std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
     for (auto topic_type : topic_types_)
     {
@@ -362,28 +362,28 @@ TEST_F(init_monitor_factory_fails_tests, init_monitor_topic_exists_with_another_
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_ipv4)
 {
-    std::string server_locators = "192.356.0.1:11811";
+    std::string server_locators = "UDPv4:[192.356.0.1]:11811";
 
     check_init_monitor_discovery_server_failure(server_locators);
 }
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_ipv6)
 {
-    std::string server_locators = "::0:G5a:11811";
+    std::string server_locators = "UDPv6:[::0:G5a]:11811";
 
     check_init_monitor_discovery_server_failure(server_locators);
 }
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_port)
 {
-    std::string server_locators = "192.356.0.1:-11811";
+    std::string server_locators = "UDPv4:[192.356.0.1]:-11811";
 
     check_init_monitor_discovery_server_failure(server_locators);
 }
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_port_out_of_range)
 {
-    std::string server_locators = "192.356.0.1:4294967296";
+    std::string server_locators = "UDPv4:[192.356.0.1]:4294967296";
 
     check_init_monitor_discovery_server_failure(server_locators);
 }

--- a/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
@@ -205,6 +205,31 @@ public:
         EXPECT_CALL(subscriber_, create_datareader(_, _, _, _)).Times(AnyNumber());
     }
 
+    void check_init_monitor_failure()
+    {
+        DomainId domain_id = 0;
+        DomainListener domain_listener;
+        std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
+        std::string server_locators = "127.0.0.1:11811";
+
+        EXPECT_THROW(StatisticsBackend::init_monitor(
+                        domain_id,
+                        &domain_listener,
+                        all_callback_mask_,
+                        all_datakind_mask_), Error);
+        EXPECT_THROW(StatisticsBackend::init_monitor(
+                        server_locators,
+                        &domain_listener,
+                        all_callback_mask_,
+                        all_datakind_mask_), Error);
+        EXPECT_THROW(StatisticsBackend::init_monitor(
+                        server_guid_prefix,
+                        server_locators,
+                        &domain_listener,
+                        all_callback_mask_,
+                        all_datakind_mask_), Error);
+    }
+
     ~init_monitor_factory_fails_tests()
     {
         // Clear memory
@@ -222,54 +247,33 @@ constexpr const DataKind init_monitor_factory_fails_tests::all_data_kinds_[];
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_participant_creation_fails)
 {
-    DomainId domain_id = 0;
-    DomainListener domain_listener;
-
     // Expect failure on the participant creation
-    EXPECT_CALL(*domain_participant_factory_, create_participant(_, _, _, _)).Times(1)
-            .WillOnce(Return(nullptr));
-    ASSERT_THROW(StatisticsBackend::init_monitor(
-                domain_id,
-                &domain_listener,
-                all_callback_mask_,
-                all_datakind_mask_), Error);
+    EXPECT_CALL(*domain_participant_factory_, create_participant(_, _, _, _)).Times(3)
+            .WillRepeatedly(Return(nullptr));
+
+    check_init_monitor_failure();
 }
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_subscriber_creation_fails)
 {
-    DomainId domain_id = 0;
-    DomainListener domain_listener;
-
     // Expect failure on the subscriber creation
-    EXPECT_CALL(domain_participant_, create_subscriber(_, _, _)).Times(1)
-            .WillOnce(Return(nullptr));
-    EXPECT_THROW(StatisticsBackend::init_monitor(
-                domain_id,
-                &domain_listener,
-                all_callback_mask_,
-                all_datakind_mask_), Error);
+    EXPECT_CALL(domain_participant_, create_subscriber(_, _, _)).Times(3)
+            .WillRepeatedly(Return(nullptr));
+
+    check_init_monitor_failure();
 }
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_datareader_creation_fails)
 {
-    DomainId domain_id = 0;
-    DomainListener domain_listener;
-
     // Expect failure on the datareader creation
-    EXPECT_CALL(subscriber_, create_datareader(_, _, _, _)).Times(1)
-            .WillOnce(Return(nullptr));
-    EXPECT_THROW(StatisticsBackend::init_monitor(
-                domain_id,
-                &domain_listener,
-                all_callback_mask_,
-                all_datakind_mask_), Error);
+    EXPECT_CALL(subscriber_, create_datareader(_, _, _, _)).Times(3)
+            .WillRepeatedly(Return(nullptr));
+
+    check_init_monitor_failure();
 }
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_topic_creation_fails)
 {
-    DomainId domain_id = 0;
-    DomainListener domain_listener;
-
     // Expect failure on the topic creation
     // We need to cover all parameter cases to be implementation agnostic
     ON_CALL(domain_participant_, create_topic(_, _, _, _, _))
@@ -278,32 +282,25 @@ TEST_F(init_monitor_factory_fails_tests, init_monitor_topic_creation_fails)
             .WillByDefault(Return(nullptr));
     ON_CALL(domain_participant_, create_topic(_, _, _))
             .WillByDefault(Return(nullptr));
-    EXPECT_THROW(StatisticsBackend::init_monitor(
-                domain_id,
-                &domain_listener,
-                all_callback_mask_,
-                all_datakind_mask_), Error);
+
+    check_init_monitor_failure();
 }
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_register_type_fails)
 {
-    DomainId domain_id = 0;
-    DomainListener domain_listener;
-
     // Expect failure on the type registration
     ON_CALL(domain_participant_, register_type(_, _))
             .WillByDefault(Return(eprosima::fastrtps::types::ReturnCode_t::RETCODE_PRECONDITION_NOT_MET));
-    EXPECT_THROW(StatisticsBackend::init_monitor(
-                domain_id,
-                &domain_listener,
-                all_callback_mask_,
-                all_datakind_mask_), Error);
+
+    check_init_monitor_failure();
 }
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_topic_exists)
 {
     DomainId domain_id = 0;
     DomainListener domain_listener;
+    std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
+    std::string server_locators = "127.0.0.1:11811";
 
     for (auto topic_type : topic_types_)
     {
@@ -322,21 +319,26 @@ TEST_F(init_monitor_factory_fails_tests, init_monitor_topic_exists)
                 &domain_listener,
                 all_callback_mask_,
                 all_datakind_mask_));
+    EXPECT_NO_THROW(StatisticsBackend::init_monitor(
+                server_locators,
+                &domain_listener,
+                all_callback_mask_,
+                all_datakind_mask_));
+    EXPECT_NO_THROW(StatisticsBackend::init_monitor(
+                server_guid_prefix,
+                server_locators,
+                &domain_listener,
+                all_callback_mask_,
+                all_datakind_mask_));
 }
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_topic_exists_with_another_type)
 {
-    DomainId domain_id = 0;
-    DomainListener domain_listener;
-
     Topic topic("custom_topic", "custom_type");
     ON_CALL(domain_participant_, lookup_topicdescription(_))
             .WillByDefault(Return(&topic));
-    EXPECT_THROW(StatisticsBackend::init_monitor(
-                domain_id,
-                &domain_listener,
-                all_callback_mask_,
-                all_datakind_mask_), Error);
+
+    check_init_monitor_failure();
 }
 
 int main(

--- a/test/unittest/StatisticsBackend/InitMonitorTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorTests.cpp
@@ -207,12 +207,14 @@ public:
         if (is_unicast)
         {
             EXPECT_NE(std::find(server_qos.metatrafficUnicastLocatorList.begin(),
-                server_qos.metatrafficUnicastLocatorList.end(), locator), server_qos.metatrafficUnicastLocatorList.end());
+                    server_qos.metatrafficUnicastLocatorList.end(), locator),
+                    server_qos.metatrafficUnicastLocatorList.end());
         }
         else
         {
             EXPECT_NE(std::find(server_qos.metatrafficMulticastLocatorList.begin(),
-                server_qos.metatrafficMulticastLocatorList.end(), locator), server_qos.metatrafficMulticastLocatorList.end());
+                    server_qos.metatrafficMulticastLocatorList.end(), locator),
+                    server_qos.metatrafficMulticastLocatorList.end());
         }
     }
 
@@ -221,10 +223,10 @@ public:
             const std::string& server_guid_prefix)
     {
         EXPECT_EQ(participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol,
-            eprosima::fastrtps::rtps::DiscoveryProtocol_t::SUPER_CLIENT);
+                eprosima::fastrtps::rtps::DiscoveryProtocol_t::SUPER_CLIENT);
 
         RemoteServerAttributes server_qos =
-            participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.front();
+                participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.front();
         GuidPrefix_t guid_prefix;
         std::istringstream(server_guid_prefix) >> guid_prefix;
         EXPECT_EQ(server_qos.guidPrefix, guid_prefix);
@@ -268,7 +270,7 @@ TEST_F(init_monitor_tests, init_monitor_domain_id_all_callback_all_data)
     std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
     auto domain_monitors = init_monitors(domain_id, &domain_listener, server_guid_prefix, server_locators,
-        all_callback_mask_, all_datakind_mask_);
+                    all_callback_mask_, all_datakind_mask_);
 
     std::vector<EntityId> monitor_ids;
     for (const auto& monitor : domain_monitors)
@@ -311,7 +313,7 @@ TEST_F(init_monitor_tests, init_monitor_domain_id_no_callback_all_data)
     std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
     auto domain_monitors = init_monitors(domain_id, &domain_listener, server_guid_prefix, server_locators,
-        CallbackMask::none(), all_datakind_mask_);
+                    CallbackMask::none(), all_datakind_mask_);
 
     std::vector<EntityId> monitor_ids;
     for (const auto& monitor : domain_monitors)
@@ -354,7 +356,7 @@ TEST_F(init_monitor_tests, init_monitor_domain_id_all_callback_no_data)
     std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
     auto domain_monitors = init_monitors(domain_id, &domain_listener, server_guid_prefix, server_locators,
-        all_callback_mask_, DataKindMask::none());
+                    all_callback_mask_, DataKindMask::none());
 
     std::vector<EntityId> monitor_ids;
     for (const auto& monitor : domain_monitors)
@@ -396,7 +398,7 @@ TEST_F(init_monitor_tests, init_monitor_domain_id_null_listener_all_data)
     std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
     auto domain_monitors = init_monitors(domain_id, nullptr, server_guid_prefix, server_locators,
-        all_callback_mask_, all_datakind_mask_);
+                    all_callback_mask_, all_datakind_mask_);
 
     std::vector<EntityId> monitor_ids;
     for (const auto& monitor : domain_monitors)
@@ -492,7 +494,7 @@ TEST_F(init_monitor_tests, init_monitor_twice)
     std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
     init_monitors(domain_id, &domain_listener, server_guid_prefix, server_locators,
-        all_callback_mask_, all_datakind_mask_);
+            all_callback_mask_, all_datakind_mask_);
 
     EXPECT_THROW(StatisticsBackend::init_monitor(
                 domain_id,
@@ -513,7 +515,7 @@ TEST_F(init_monitor_tests, init_monitor_twice)
 
     auto domain_monitors = details::StatisticsBackendData::get_instance()->monitors_by_entity_;
 
-        /* Check that three monitors are created */
+    /* Check that three monitors are created */
     EXPECT_EQ(domain_monitors.size(), 3);
 
     std::vector<EntityId> monitor_ids;
@@ -569,10 +571,10 @@ TEST_F(init_monitor_tests, init_server_monitor_several_locators)
     domain_monitors[monitor_id]->participant->get_qos(participant_qos);
 
     EXPECT_EQ(participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol,
-        eprosima::fastrtps::rtps::DiscoveryProtocol_t::SUPER_CLIENT);
+            eprosima::fastrtps::rtps::DiscoveryProtocol_t::SUPER_CLIENT);
 
     const RemoteServerAttributes& server_qos =
-        participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.front();
+            participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.front();
 
     check_locator(server_qos, LOCATOR_KIND_UDPv4, "127.0.0.1", 11811);
     check_locator(server_qos, LOCATOR_KIND_TCPv4, "127.0.0.1", 11812);

--- a/test/unittest/StatisticsBackend/InitMonitorTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorTests.cpp
@@ -232,7 +232,7 @@ TEST_F(init_monitor_tests, init_monitor_domain_id_all_callback_all_data)
     DomainId domain_id = 0;
     DomainListener domain_listener;
     std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
-    std::string server_locators = "127.0.0.1:11811";
+    std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
     auto domain_monitors = init_monitors(domain_id, &domain_listener, server_guid_prefix, server_locators,
         all_callback_mask_, all_datakind_mask_);
@@ -275,7 +275,7 @@ TEST_F(init_monitor_tests, init_monitor_domain_id_no_callback_all_data)
     DomainId domain_id = 0;
     DomainListener domain_listener;
     std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
-    std::string server_locators = "127.0.0.1:11811";
+    std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
     auto domain_monitors = init_monitors(domain_id, &domain_listener, server_guid_prefix, server_locators,
         CallbackMask::none(), all_datakind_mask_);
@@ -318,7 +318,7 @@ TEST_F(init_monitor_tests, init_monitor_domain_id_all_callback_no_data)
     DomainId domain_id = 0;
     DomainListener domain_listener;
     std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
-    std::string server_locators = "127.0.0.1:11811";
+    std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
     auto domain_monitors = init_monitors(domain_id, &domain_listener, server_guid_prefix, server_locators,
         all_callback_mask_, DataKindMask::none());
@@ -360,7 +360,7 @@ TEST_F(init_monitor_tests, init_monitor_domain_id_null_listener_all_data)
 {
     DomainId domain_id = 0;
     std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
-    std::string server_locators = "127.0.0.1:11811";
+    std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
     auto domain_monitors = init_monitors(domain_id, nullptr, server_guid_prefix, server_locators,
         all_callback_mask_, all_datakind_mask_);
@@ -456,7 +456,7 @@ TEST_F(init_monitor_tests, init_monitor_twice)
     DomainId domain_id = 0;
     DomainListener domain_listener;
     std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
-    std::string server_locators = "127.0.0.1:11811";
+    std::string server_locators = "UDPv4:[127.0.0.1]:11811";
 
     init_monitors(domain_id, &domain_listener, server_guid_prefix, server_locators,
         all_callback_mask_, all_datakind_mask_);


### PR DESCRIPTION
This PR implements and tests `init_monitor` overloads to start monitoring a Discovery Server network. The PR has added a new overload of `init_monitor` to provide the Server `guidPrefix`. If not provided, the default `guidPrefix` set in Fast DDS is used.

A future blackbox test where a couple of Discovery Servers networks are launched and then monitored is needed. This is put on hold until the first blackbox is merged, and we can build upon that.