### PR TITLE
locators notification [11918]

### DIFF
--- a/include/fastdds_statistics_backend/listener/PhysicalListener.hpp
+++ b/include/fastdds_statistics_backend/listener/PhysicalListener.hpp
@@ -38,16 +38,13 @@ public:
     /*!
      * This function is called when a new Host is discovered by the library.
      *
-     * @param participant_id Entity ID of the participant that discovered the Host.
      * @param host_id Entity ID of the discovered Host.
      * @param status The status of the discovered Host.
      */
     virtual void on_host_discovery(
-            EntityId participant_id,
             EntityId host_id,
             const Status& status)
     {
-        static_cast<void>(participant_id);
         static_cast<void>(host_id);
         static_cast<void>(status);
     }
@@ -55,16 +52,13 @@ public:
     /*!
      * This function is called when a new User is discovered by the library.
      *
-     * @param participant_id Entity ID of the participant that discovered the User.
      * @param user_id Entity ID of the discovered User.
      * @param status The status of the discovered User.
      */
     virtual void on_user_discovery(
-            EntityId participant_id,
             EntityId user_id,
             const Status& status)
     {
-        static_cast<void>(participant_id);
         static_cast<void>(user_id);
         static_cast<void>(status);
     }
@@ -72,16 +66,13 @@ public:
     /*!
      * This function is called when a new Process is discovered by the library.
      *
-     * @param participant_id Entity ID of the participant that discovered the Process.
      * @param process_id Entity ID of the discovered Process.
      * @param status The status of the discovered Process.
      */
     virtual void on_process_discovery(
-            EntityId participant_id,
             EntityId process_id,
             const Status& status)
     {
-        static_cast<void>(participant_id);
         static_cast<void>(process_id);
         static_cast<void>(status);
     }
@@ -89,16 +80,13 @@ public:
     /*!
      * This function is called when a new Locator is discovered by the library.
      *
-     * @param participant_id Entity ID of the participant that discovered the Locator.
      * @param locator_id Entity ID of the discovered Locator.
      * @param status The status of the discovered Locator.
      */
     virtual void on_locator_discovery(
-            EntityId participant_id,
             EntityId locator_id,
             const Status& status)
     {
-        static_cast<void>(participant_id);
         static_cast<void>(locator_id);
         static_cast<void>(status);
     }

--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -275,7 +275,6 @@ void StatisticsBackendData::on_domain_entity_discovery(
 }
 
 void StatisticsBackendData::on_physical_entity_discovery(
-        EntityId participant_id,
         EntityId entity_id,
         EntityKind entity_kind,
         DiscoveryStatus discovery_status)
@@ -291,7 +290,7 @@ void StatisticsBackendData::on_physical_entity_discovery(
 
             if (should_call_physical_listener(CallbackKind::ON_HOST_DISCOVERY))
             {
-                physical_listener_->on_host_discovery(participant_id, entity_id, host_status_);
+                physical_listener_->on_host_discovery(entity_id, host_status_);
                 host_status_.on_status_read();
             }
             break;
@@ -303,7 +302,7 @@ void StatisticsBackendData::on_physical_entity_discovery(
 
             if (should_call_physical_listener(CallbackKind::ON_USER_DISCOVERY))
             {
-                physical_listener_->on_user_discovery(participant_id, entity_id, user_status_);
+                physical_listener_->on_user_discovery(entity_id, user_status_);
                 user_status_.on_status_read();
             }
             break;
@@ -315,7 +314,7 @@ void StatisticsBackendData::on_physical_entity_discovery(
 
             if (should_call_physical_listener(CallbackKind::ON_PROCESS_DISCOVERY))
             {
-                physical_listener_->on_process_discovery(participant_id, entity_id, process_status_);
+                physical_listener_->on_process_discovery(entity_id, process_status_);
                 process_status_.on_status_read();
             }
             break;
@@ -327,7 +326,7 @@ void StatisticsBackendData::on_physical_entity_discovery(
 
             if (should_call_physical_listener(CallbackKind::ON_LOCATOR_DISCOVERY))
             {
-                physical_listener_->on_locator_discovery(participant_id, entity_id, locator_status_);
+                physical_listener_->on_locator_discovery(entity_id, locator_status_);
                 locator_status_.on_status_read();
             }
             break;

--- a/src/cpp/StatisticsBackendData.hpp
+++ b/src/cpp/StatisticsBackendData.hpp
@@ -145,13 +145,11 @@ public:
      *
      * Physical entities can be discovered or undiscovered, never updated
      *
-     * @param participant_id Entity ID of the participant that discovered the entity.
      * @param entity_id The entity_id of the discovered entity
      * @param entity_kind EntityKind of the discovery event
      * @param discovery_status The reason why the method is being called
      */
     void on_physical_entity_discovery(
-            EntityId participant_id,
             EntityId entity_id,
             EntityKind entity_kind,
             DiscoveryStatus discovery_status);

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -495,12 +495,21 @@ std::shared_ptr<Locator> Database::get_locator_nts(
         locator = std::make_shared<Locator>("locator_" + std::to_string(entity_id.value()));
         EntityId locator_id = entity_id;
         insert_nts(locator, locator_id);
+        notify_locator_discovery(locator_id);
     }
     else
     {
         locator = locator_it->second;
     }
     return locator;
+}
+
+void Database::notify_locator_discovery (
+        EntityId locator_id)
+{
+    details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+        locator_id, EntityKind::LOCATOR,
+        details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
 }
 
 void Database::insert_nts(

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -4369,7 +4369,7 @@ void Database::change_entity_status_of_kind(
             if (host != nullptr && host->active != active)
             {
                 host->active = active;
-                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain_id, entity_id,
+                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(entity_id,
                         entity_kind, get_status(active));
             }
             break;
@@ -4421,7 +4421,7 @@ void Database::change_entity_status_of_kind(
                 }
 
                 // Discovering user after discovering host
-                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain_id, entity_id,
+                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(entity_id,
                         entity_kind, get_status(active));
             }
             break;
@@ -4473,7 +4473,7 @@ void Database::change_entity_status_of_kind(
                 }
 
                 // Discovering process after discovering user
-                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain_id, entity_id,
+                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(entity_id,
                         entity_kind, get_status(active));
             }
             break;

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -505,7 +505,7 @@ std::shared_ptr<Locator> Database::get_locator_nts(
 }
 
 void Database::notify_locator_discovery (
-        EntityId locator_id)
+        const EntityId& locator_id)
 {
     details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
         locator_id, EntityKind::LOCATOR,

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -517,8 +517,16 @@ protected:
         /* Add to x_by_y_ collections and to locators_ */
         for (auto& locator_it : endpoint->locators)
         {
-            // Add locator to locators_
-            locators_[locator_it.first] = locator_it.second;
+            // See if we already know the locator
+            if (locators_.find(locator_it.first) == locators_.end())
+            {
+                // Is a new one, must add and inform the user
+                // The connection to the endpoint is still not done, but that's expected at this moment
+                locators_[locator_it.first] = locator_it.second;
+                notify_locator_discovery(locator_it.first);
+            }
+
+            // Even if it is not new, it may be new to the participant
             // Add reader's locators to locators_by_participant_
             locators_by_participant_[endpoint->participant->id][locator_it.first] = locator_it.second;
             // Add reader's participant to participants_by_locator_
@@ -533,6 +541,14 @@ protected:
         /* Insert endpoint in the database */
         dds_endpoints<T>()[endpoint->participant->domain->id][endpoint->id] = endpoint;
     }
+
+    /**
+     * @brief Notifies the user about a new discovered locator.
+     * 
+     * @param locator_id The ID of the discovered locator.
+     */
+    void notify_locator_discovery (
+            EntityId locator_id);
 
     /**
      * @brief Get a dump of an Entity stored in the database.

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -544,7 +544,7 @@ protected:
 
     /**
      * @brief Notifies the user about a new discovered locator.
-     * 
+     *
      * @param locator_id The ID of the discovered locator.
      */
     void notify_locator_discovery (

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -548,7 +548,7 @@ protected:
      * @param locator_id The ID of the discovered locator.
      */
     void notify_locator_discovery (
-            EntityId locator_id);
+            const EntityId& locator_id);
 
     /**
      * @brief Get a dump of an Entity stored in the database.

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -367,7 +367,7 @@ protected:
                 assert(info.discovery_status == details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
                 info.entity->id = database_->insert(info.entity);
 
-                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(info.domain_id,
+                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                         info.entity->id,
                         info.entity->kind, info.discovery_status);
             }

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -368,8 +368,8 @@ protected:
                 info.entity->id = database_->insert(info.entity);
 
                 details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                        info.entity->id,
-                        info.entity->kind, info.discovery_status);
+                    info.entity->id,
+                    info.entity->kind, info.discovery_status);
             }
             // Domains are not discovered, they are created on monitor initialization
             else if (EntityKind::DOMAIN == info.entity->kind)

--- a/src/cpp/subscriber/StatisticsParticipantListener.cpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.cpp
@@ -135,40 +135,30 @@ void StatisticsParticipantListener::process_endpoint_discovery(
 
     /* Start processing the locator info */
 
-    // Take all the locators already defined for this participant.
-    // This will be used only if there is no physical info.
-    // Even if the host info is not available, the participant can only have one locator
-    // with a given address/port combination, so we don't want to add duplicates
-    auto participant_locators = database_->get_entities(EntityKind::LOCATOR, participant_id.second);
-
     // Routine to process one locator from the locator list of the endpoint
     auto process_locators = [&](const Locator_t& dds_locator)
             {
-                std::shared_ptr<database::Locator> locator =
-                        std::make_shared<database::Locator>(to_string(dds_locator));
+                std::shared_ptr<database::Locator> locator;
 
-                // we need to create only one copy of the locator for this participant
-                using namespace std::placeholders;
-                auto found = std::find_if(participant_locators.begin(), participant_locators.end(),
-                                std::bind([](std::shared_ptr<database::Entity> new_locator,
-                                std::shared_ptr<const database::Entity> existing)
-                                {
-                                    return new_locator->name == existing->name;
-                                }, locator, _1));
-                if (found != participant_locators.end())
+                // Look for an existing locator
+                // There can only be one
+                auto locator_ids = database_->get_entities_by_name(EntityKind::LOCATOR, to_string(dds_locator));
+                assert(locator_ids.empty() || locator_ids.size() == 1);
+
+                if (!locator_ids.empty())
                 {
-                    // The locator exists. Add the existing one.
-                    auto existing = std::const_pointer_cast<database::Locator>(
-                        std::static_pointer_cast<const database::Locator>(*found));
-                    endpoint->locators[existing->id] = existing;
+                    // The locator exists.
+                    locator = std::const_pointer_cast<database::Locator>(
+                            std::static_pointer_cast<const database::Locator>(database_->get_entity(locator_ids.front().second)));
                 }
                 else
                 {
                     // The locator is not in the database. Add the new one.
+                    locator = std::make_shared<database::Locator>(to_string(dds_locator));
                     locator->id = database_->generate_entity_id();
-                    endpoint->locators[locator->id] = locator;
-                    participant_locators.push_back(locator);
                 }
+
+                endpoint->locators[locator->id] = locator;
             };
 
     for (const auto& dds_locator : info.info.remote_locators().unicast)

--- a/src/cpp/subscriber/StatisticsParticipantListener.cpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.cpp
@@ -149,7 +149,8 @@ void StatisticsParticipantListener::process_endpoint_discovery(
                 {
                     // The locator exists.
                     locator = std::const_pointer_cast<database::Locator>(
-                            std::static_pointer_cast<const database::Locator>(database_->get_entity(locator_ids.front().second)));
+                        std::static_pointer_cast<const database::Locator>(database_->get_entity(locator_ids.front().
+                                second)));
                 }
                 else
                 {

--- a/test/mock/StatisticsBackend/StatisticsBackendData.hpp
+++ b/test/mock/StatisticsBackend/StatisticsBackendData.hpp
@@ -48,8 +48,7 @@ public:
                 EntityKind entity_kind,
                 DiscoveryStatus discovery_status));
 
-    MOCK_METHOD4(on_physical_entity_discovery, void(
-                EntityId participant_id,
+    MOCK_METHOD3(on_physical_entity_discovery, void(
                 EntityId entity_id,
                 EntityKind entity_kind,
                 DiscoveryStatus discovery_status));

--- a/test/unittest/Database/DatabaseStatusTests.cpp
+++ b/test/unittest/Database/DatabaseStatusTests.cpp
@@ -53,14 +53,14 @@ public:
 
         // Simulate the discover of the entities
         details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                host->id,
-                host->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+            host->id,
+            host->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
         details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                user->id,
-                user->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+            user->id,
+            user->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
         details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                process->id,
-                process->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+            process->id,
+            process->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
         details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain->id,
                 topic->id,
                 topic->kind,

--- a/test/unittest/Database/DatabaseStatusTests.cpp
+++ b/test/unittest/Database/DatabaseStatusTests.cpp
@@ -52,13 +52,13 @@ public:
         db.change_entity_status_test(topic->id, true, domain->id);
 
         // Simulate the discover of the entities
-        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain->id,
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 host->id,
                 host->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
-        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain->id,
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 user->id,
                 user->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
-        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain->id,
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 process->id,
                 process->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
         details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain->id,

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -3466,7 +3466,7 @@ TEST_F(database_queue_tests, push_physical_data_process_exists)
     EXPECT_CALL(database, link_participant_with_process(EntityId(1), EntityId(4))).Times(1);
 
     // Expectation: The user is not notified
-    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _, _)).Times(0);
+    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _)).Times(0);
 
     // Add to the queue and wait to be processed
     data_queue.push(timestamp, data);
@@ -3541,7 +3541,7 @@ TEST_F(database_queue_tests, push_physical_data_no_participant_exists)
             .WillOnce(Return(process));
 
     // Expectation: The user is not notified
-    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _, _)).Times(0);
+    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _)).Times(0);
 
     // Add to the queue and wait to be processed
     // The processing should not progress the exception.
@@ -3631,7 +3631,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_exists)
 
     // Expectation: The user is notified of the new process
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(4), EntityKind::PROCESS,
+            on_physical_entity_discovery(EntityId(4), EntityKind::PROCESS,
             details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     // Expectation: The link method is called with appropriate arguments
@@ -3723,7 +3723,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_exists_process_insert
             .WillOnce(Invoke(&insert_args_process, &InsertEntityArgs::insert));
 
     // Expectation: The user is not notified
-    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _, _)).Times(0);
+    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _)).Times(0);
 
 
     // Expectation: The link method is not called
@@ -3808,7 +3808,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_exists)
 
     // Expectation: The user is notified of the new process
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(3), EntityKind::USER,
+            on_physical_entity_discovery(EntityId(3), EntityKind::USER,
             details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     // Expectation: The process is created and given ID 4
@@ -3826,7 +3826,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_exists)
 
     // Expectation: The user is notified of the new process
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(4), EntityKind::PROCESS,
+            on_physical_entity_discovery(EntityId(4), EntityKind::PROCESS,
             details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     EXPECT_CALL(database, insert(_)).Times(2)
@@ -3915,7 +3915,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_exists_user_i
             .WillOnce(Invoke(&insert_args_user, &InsertEntityArgs::insert));
 
     // Expectation: The user is not notified of the new user
-    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _, _)).Times(0);
+    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _)).Times(0);
 
     // Expectation: The link method is not called
     EXPECT_CALL(database, link_participant_with_process(EntityId(1), EntityId(4))).Times(0);
@@ -3993,7 +3993,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_no_host_exist
 
     // Expectation: The user is notified of the new host
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(3), EntityKind::HOST,
+            on_physical_entity_discovery(EntityId(3), EntityKind::HOST,
             details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     // Expectation: The user is created and given ID 4
@@ -4010,7 +4010,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_no_host_exist
 
     // Expectation: The user is notified of the new user
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(4), EntityKind::USER,
+            on_physical_entity_discovery(EntityId(4), EntityKind::USER,
             details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     // Expectation: The process is created and given ID 5
@@ -4028,7 +4028,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_no_host_exist
 
     // Expectation: The user is notified of the new process
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(5), EntityKind::PROCESS,
+            on_physical_entity_discovery(EntityId(5), EntityKind::PROCESS,
             details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     EXPECT_CALL(database, insert(_)).Times(3)
@@ -4111,7 +4111,7 @@ TEST_F(database_queue_tests, push_physical_data_no_process_no_user_no_host_exist
             .WillOnce(Invoke(&insert_args_host, &InsertEntityArgs::insert));
 
     // Expectation: The user is not notified
-    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _, _)).Times(0);
+    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_physical_entity_discovery(_, _, _)).Times(0);
 
     // Expectation: The link method is not called
     EXPECT_CALL(database, link_participant_with_process(EntityId(1), EntityId(5))).Times(0);
@@ -4204,7 +4204,7 @@ TEST_F(database_queue_tests, push_physical_data_wrong_processname_format)
 
     // Expectation: The user is notified of the new process
     EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
-            on_physical_entity_discovery(EntityId(1), EntityId(4), EntityKind::PROCESS,
+            on_physical_entity_discovery(EntityId(4), EntityKind::PROCESS,
             details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     // Expectation: The link method is called with appropriate arguments

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -250,6 +250,22 @@ foreach(test_name ${USER_LISTENERS_TEST_LIST_DATAS})
 
 endforeach()
 
+set(USER_LISTENERS_TEST_END_TO_END
+    participant_added
+    )
+
+foreach(test_name ${USER_LISTENERS_TEST_END_TO_END})
+
+    add_test(NAME calling_user_listeners_tests_end_to_end.${test_name}
+            COMMAND calling_user_listeners_tests
+            --gtest_filter=calling_user_listeners_tests_end_to_end.${test_name}:*/calling_user_listeners_tests_end_to_end.${test_name}/*)
+
+    if(TEST_FRIENDLY_PATH)
+        set_tests_properties(calling_user_listeners_tests_end_to_end.${test_name} PROPERTIES ENVIRONMENT "PATH=${TEST_FRIENDLY_PATH}")
+    endif(TEST_FRIENDLY_PATH)
+
+endforeach()
+
 
 # init_monitor_tests
 ##################################################################

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -251,7 +251,7 @@ foreach(test_name ${USER_LISTENERS_TEST_LIST_DATAS})
 endforeach()
 
 set(USER_LISTENERS_TEST_END_TO_END
-    participant_added
+    entity_discovery_end_to_end
     )
 
 foreach(test_name ${USER_LISTENERS_TEST_END_TO_END})

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -1543,7 +1543,7 @@ public:
  * this tests does not: Its entry point is the internal DDS discovery
  * listener, where a discovery notification is simulated, and it uses
  * a real backend and database from there on. Hence the 'pseudo-blackbox'
- * 
+ *
  * This was necessary because some end user notifications have complex trigger
  * configurations, and are not easily tested with pure unit testing,
  * which leads to some cases being easily overlooked and not correctly tested.

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -1534,6 +1534,8 @@ public:
 
 };
 
+// Windows dll does not export ParticipantProxyData class members (private APIs)
+#if !defined(_WIN32)
 /*
  * This test is a pseudo-blackbox thet checks that user listeners are called
  * when new entities are discovered and undicovered.
@@ -2108,6 +2110,7 @@ TEST_F(calling_user_listeners_tests_end_to_end, entity_discovery_end_to_end)
     ASSERT_EQ(2, participant->data_writers.size());
     EXPECT_EQ(writer2.get(), participant->data_writers.find(writer2->id)->second.get());
 }
+#endif //!defined(_WIN32)
 
 int main(
         int argc,

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -1537,8 +1537,8 @@ public:
 // Windows dll does not export ParticipantProxyData class members (private APIs)
 #if !defined(_WIN32)
 /*
- * This test is a pseudo-blackbox thet checks that user listeners are called
- * when new entities are discovered and undicovered.
+ * This test is a pseudo-blackbox that checks that user listeners are called
+ * when new entities are discovered and undiscovered.
  * While other tests in the 'unittest' folder rely on mocks,
  * this tests does not: Its entry point is the internal DDS discovery
  * listener, where a discovery notification is simulated, and it uses

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -17,6 +17,8 @@
 #include <gmock/gmock.h>
 
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/DomainParticipantListener.hpp>
+#include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
 #include <fastdds_statistics_backend/exception/Exception.hpp>
@@ -24,6 +26,7 @@
 #include <fastdds_statistics_backend/types/types.hpp>
 #include <database/database_queue.hpp>
 #include <database/database.hpp>
+#include <database/entities.hpp>
 #include <Monitor.hpp>
 #include <StatisticsBackendData.hpp>
 
@@ -1454,6 +1457,671 @@ GTEST_INSTANTIATE_TEST_MACRO(
         std::make_tuple(DataKind::SAMPLE_DATAS)
         ));
 
+using ::testing::StrictMock;
+
+class calling_user_listeners_tests_end_to_end : public ::testing::Test
+{
+public:
+
+    calling_user_listeners_tests_end_to_end()
+    {
+        // Set the profile to ignore discovery data from other processes
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->load_XML_profiles_file("profile.xml");
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->load_profiles();
+
+        monitor_id_ = StatisticsBackend::init_monitor(0, &domain_listener_, CallbackMask::all(), DataKindMask::all());
+        StatisticsBackend::set_physical_listener(
+            &physical_listener_,
+            CallbackMask::all(),
+            DataKindMask::all());
+
+        // Get the participant listener of the created monitor
+        monitor_ = details::StatisticsBackendData::get_instance()->monitors_by_entity_[monitor_id_];
+        participant_listener_ = monitor_->participant_listener;
+        reader_listener_ = monitor_->reader_listener;
+        participant_ = monitor_->participant;
+
+        // Initialize other attributes
+        std::stringstream(participant_guid_str_) >> participant_guid_;
+        std::stringstream(datareader_guid_str_) >> datareader_guid_;
+        std::stringstream(datawriter_guid_str_) >> datawriter_guid_;
+
+    }
+
+    ~calling_user_listeners_tests_end_to_end()
+    {
+        StatisticsBackend::set_physical_listener(
+            nullptr,
+            CallbackMask::none(),
+            DataKindMask::none());
+
+        details::StatisticsBackendData::reset_instance();
+    }
+
+    MockedPhysicalListener physical_listener_;
+    MockedDomainListener domain_listener_;
+    EntityId monitor_id_;
+    std::shared_ptr<details::Monitor> monitor_;
+
+    eprosima::fastdds::dds::DomainParticipantListener* participant_listener_;
+    eprosima::fastdds::dds::DataReaderListener* reader_listener_;
+
+    eprosima::fastdds::dds::DomainParticipant* participant_;
+    eprosima::fastrtps::rtps::GUID_t participant_guid_;
+    std::string participant_guid_str_ = "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.1.c1";
+    std::string participant_name_ = "Participant";
+
+    eprosima::fastrtps::rtps::GUID_t datareader_guid_;
+    std::string datareader_guid_str_ = "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.1";
+    eprosima::fastrtps::rtps::GUID_t datawriter_guid_;
+    std::string datawriter_guid_str_ = "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.2";
+
+    std::string topic_name_ = "Topic";
+    std::string topic_type_ = "DataType";
+
+};
+
+TEST_F(calling_user_listeners_tests_end_to_end, participant_added)
+{
+    /* PARTICIPANT */
+    DomainEntityDiscoveryArgs participant_discovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(1, status.total_count);
+                EXPECT_EQ(1, status.total_count_change);
+                EXPECT_EQ(1, status.current_count);
+                EXPECT_EQ(1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_participant_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&participant_discovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    // Simulate the discovery of a participant
+    eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes attributes;
+    eprosima::fastrtps::rtps::ParticipantProxyData participant_data(attributes);
+    participant_data.m_guid = participant_guid_;
+    participant_data.m_participantName = participant_name_;
+
+    // Finish building the discovered participant info
+    eprosima::fastrtps::rtps::ParticipantDiscoveryInfo participant_info(participant_data);
+    participant_info.status = eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT;
+
+    // Execution: Call the listener
+    participant_listener_->on_participant_discovery(participant_, std::move(participant_info));
+    details::StatisticsBackendData::get_instance()->entity_queue_->flush();
+
+    // Check that the participant was created OK
+    const std::shared_ptr<const database::DomainParticipant> participant =
+            std::dynamic_pointer_cast<const database::DomainParticipant>(
+        details::StatisticsBackendData::get_instance()->database_->get_entity(participant_discovery_args.
+                discovered_entity_id_));
+    ASSERT_TRUE(participant);
+    ASSERT_TRUE(participant->active);
+    ASSERT_EQ(monitor_id_, participant->domain->id);
+    ASSERT_EQ(participant_guid_str_, participant->guid);
+    ASSERT_EQ(participant_name_, participant->name);
+    ASSERT_EQ(nullptr, participant->process);
+    ASSERT_TRUE(participant->data_readers.empty());
+    ASSERT_TRUE(participant->data_writers.empty());
+
+    /* TOPIC */
+    // the topic will be discovered with the datawriter
+    DomainEntityDiscoveryArgs topic_discovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(1, status.total_count);
+                EXPECT_EQ(1, status.total_count_change);
+                EXPECT_EQ(1, status.current_count);
+                EXPECT_EQ(1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_topic_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&topic_discovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    /* DATAWRITER */
+    DomainEntityDiscoveryArgs datawriter_discovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(1, status.total_count);
+                EXPECT_EQ(1, status.total_count_change);
+                EXPECT_EQ(1, status.current_count);
+                EXPECT_EQ(1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_datawriter_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&datawriter_discovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    PhysicalEntityDiscoveryArgs writer_locator_discovery_args([&](
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(1, status.total_count);
+                EXPECT_EQ(1, status.total_count_change);
+                EXPECT_EQ(1, status.current_count);
+                EXPECT_EQ(1, status.current_count_change);
+            });
+
+    EXPECT_CALL(physical_listener_, on_locator_discovery(_, _)).Times(1)
+            .WillOnce(Invoke(&writer_locator_discovery_args, &PhysicalEntityDiscoveryArgs::on_discovery));
+
+    // Start building the discovered writer info
+    eprosima::fastrtps::rtps::WriterProxyData writer_data(1, 1);
+
+    // The discovered writer is in the participant
+    writer_data.guid(datawriter_guid_);
+
+    // The discovered writer is in the topic
+    writer_data.topicName(topic_name_);
+    writer_data.typeName(topic_type_);
+
+    // The discovered writer contains the locator
+    eprosima::fastrtps::rtps::Locator_t writer_locator(LOCATOR_KIND_UDPv4, 1024);
+    writer_locator.address[12] = 127;
+    writer_locator.address[15] = 1;
+    writer_data.add_unicast_locator(writer_locator);
+
+    // Finish building the discovered writer info
+    eprosima::fastrtps::rtps::WriterDiscoveryInfo writer_info(writer_data);
+    writer_info.status = eprosima::fastrtps::rtps::WriterDiscoveryInfo::DISCOVERED_WRITER;
+
+    // Execution: Call the listener
+    participant_listener_->on_publisher_discovery(participant_, std::move(writer_info));
+    details::StatisticsBackendData::get_instance()->entity_queue_->flush();
+
+    // Check that the writer was created OK
+    const std::shared_ptr<const database::DataWriter> writer =
+            std::dynamic_pointer_cast<const database::DataWriter>(
+        details::StatisticsBackendData::get_instance()->database_->get_entity(datawriter_discovery_args.
+                discovered_entity_id_));
+    ASSERT_TRUE(writer);
+    ASSERT_TRUE(writer->active);
+    ASSERT_EQ(participant->id, writer->participant->id);
+
+    // Check that the topic was created OK
+    ASSERT_TRUE(writer->topic);
+    const std::shared_ptr<const database::Topic> topic = writer->topic;
+    ASSERT_TRUE(topic->active);
+    ASSERT_EQ(monitor_id_, topic->domain->id);
+    ASSERT_EQ(topic_name_, topic->name);
+    ASSERT_EQ(topic_type_, topic->data_type);
+    ASSERT_EQ(1, topic->data_writers.size());
+    ASSERT_EQ(writer.get(), topic->data_writers.find(writer->id)->second.get());
+    ASSERT_TRUE(topic->data_readers.empty());
+
+    // Check that the locator was created OK
+    ASSERT_EQ(1, writer->locators.size());
+    const std::shared_ptr<const database::Locator> wlocator =
+            writer->locators.begin()->second;
+    ASSERT_TRUE(wlocator->active);
+    std::stringstream s;
+    s << writer_locator;
+    ASSERT_EQ(s.str(), wlocator->name);
+    ASSERT_EQ(1, wlocator->data_writers.size());
+    ASSERT_EQ(writer.get(), wlocator->data_writers.find(writer->id)->second.get());
+
+    /* DATAREADER */
+    DomainEntityDiscoveryArgs datareader_discovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(1, status.total_count);
+                EXPECT_EQ(1, status.total_count_change);
+                EXPECT_EQ(1, status.current_count);
+                EXPECT_EQ(1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_datareader_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&datareader_discovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    PhysicalEntityDiscoveryArgs reader_locator_discovery_args([&](
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(2, status.total_count);
+                EXPECT_EQ(1, status.total_count_change);
+                EXPECT_EQ(2, status.current_count);
+                EXPECT_EQ(1, status.current_count_change);
+            });
+
+    EXPECT_CALL(physical_listener_, on_locator_discovery(_, _)).Times(1)
+            .WillOnce(Invoke(&reader_locator_discovery_args, &PhysicalEntityDiscoveryArgs::on_discovery));
+
+    // Start building the discovered reader info
+    eprosima::fastrtps::rtps::ReaderProxyData reader_data(1, 1);
+
+    // The discovered reader is in the participant
+    reader_data.guid(datareader_guid_);
+
+    // The discovered reader is in the topic
+    reader_data.topicName(topic_name_);
+    reader_data.typeName(topic_type_);
+
+    // The discovered reader contains the locator
+    eprosima::fastrtps::rtps::Locator_t reader_locator(LOCATOR_KIND_UDPv4, 2048);
+    reader_locator.address[12] = 127;
+    reader_locator.address[15] = 1;
+    reader_data.add_unicast_locator(reader_locator);
+
+    // Finish building the discovered reader info
+    eprosima::fastrtps::rtps::ReaderDiscoveryInfo reader_info(reader_data);
+    reader_info.status = eprosima::fastrtps::rtps::ReaderDiscoveryInfo::DISCOVERED_READER;
+
+    // Execution: Call the listener
+    participant_listener_->on_subscriber_discovery(participant_, std::move(reader_info));
+    details::StatisticsBackendData::get_instance()->entity_queue_->flush();
+
+    // Check that the reader was created OK
+    const std::shared_ptr<const database::DataReader> reader =
+            std::dynamic_pointer_cast<const database::DataReader>(
+        details::StatisticsBackendData::get_instance()->database_->get_entity(datareader_discovery_args.
+                discovered_entity_id_));
+    ASSERT_TRUE(reader);
+    ASSERT_TRUE(reader->active);
+    ASSERT_EQ(participant->id, reader->participant->id);
+
+    // Check that the topic was created OK
+    ASSERT_TRUE(reader->topic);
+    ASSERT_EQ(writer->topic.get(), reader->topic.get());
+    ASSERT_TRUE(topic->active);
+    ASSERT_EQ(monitor_id_, topic->domain->id);
+    ASSERT_EQ(topic_name_, topic->name);
+    ASSERT_EQ(topic_type_, topic->data_type);
+    ASSERT_EQ(1, topic->data_readers.size());
+    ASSERT_EQ(reader.get(), topic->data_readers.find(reader->id)->second.get());
+    ASSERT_EQ(1, topic->data_writers.size());
+    ASSERT_EQ(writer.get(), topic->data_writers.find(writer->id)->second.get());
+
+    // Check that the locator was created OK
+    ASSERT_EQ(1, reader->locators.size());
+    const std::shared_ptr<const database::Locator> rlocator =
+            reader->locators.begin()->second;
+    ASSERT_TRUE(rlocator->active);
+    s.str(std::string());
+    s << reader_locator;
+    ASSERT_EQ(s.str(), rlocator->name);
+    ASSERT_EQ(1, rlocator->data_readers.size());
+    ASSERT_EQ(reader.get(), rlocator->data_readers.find(reader->id)->second.get());
+
+
+    /* A DATAREADER on another topic, on the writer's locator */
+    DomainEntityDiscoveryArgs topic2_discovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(2, status.total_count);
+                EXPECT_EQ(1, status.total_count_change);
+                EXPECT_EQ(2, status.current_count);
+                EXPECT_EQ(1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_topic_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&topic2_discovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    DomainEntityDiscoveryArgs datareader2_discovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(2, status.total_count);
+                EXPECT_EQ(1, status.total_count_change);
+                EXPECT_EQ(2, status.current_count);
+                EXPECT_EQ(1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_datareader_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&datareader2_discovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    // Start building the discovered reader info
+    eprosima::fastrtps::rtps::ReaderProxyData reader2_data(1, 1);
+
+    // The discovered reader is in the participant
+    eprosima::fastrtps::rtps::GUID_t datareader2_guid_;
+    std::stringstream("01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.3") >> datareader2_guid_;
+    reader2_data.guid(datareader2_guid_);
+
+    // The discovered reader is in the topic
+    std::string topic2_name = "Topic2";
+    reader2_data.topicName(topic2_name);
+    reader2_data.typeName(topic_type_);
+
+    // The discovered reader contains the locator
+    reader2_data.add_unicast_locator(writer_locator);
+
+    // Finish building the discovered reader info
+    eprosima::fastrtps::rtps::ReaderDiscoveryInfo reader2_info(reader2_data);
+    reader2_info.status = eprosima::fastrtps::rtps::ReaderDiscoveryInfo::DISCOVERED_READER;
+
+    // Execution: Call the listener
+    participant_listener_->on_subscriber_discovery(participant_, std::move(reader2_info));
+    details::StatisticsBackendData::get_instance()->entity_queue_->flush();
+
+    // Check that the reader was created OK
+    const std::shared_ptr<const database::DataReader> reader2 =
+            std::dynamic_pointer_cast<const database::DataReader>(
+        details::StatisticsBackendData::get_instance()->database_->get_entity(datareader2_discovery_args.
+                discovered_entity_id_));
+    ASSERT_TRUE(reader2);
+    ASSERT_TRUE(reader2->active);
+    ASSERT_EQ(participant->id, reader2->participant->id);
+
+    // Check that the topic was created OK
+    ASSERT_TRUE(reader2->topic);
+    const std::shared_ptr<const database::Topic> topic2 = reader2->topic;
+    ASSERT_TRUE(topic2->active);
+    ASSERT_EQ(monitor_id_, topic2->domain->id);
+    ASSERT_EQ(topic2_name, topic2->name);
+    ASSERT_EQ(topic_type_, topic2->data_type);
+    ASSERT_EQ(1, topic2->data_readers.size());
+    ASSERT_EQ(reader2.get(), topic2->data_readers.find(reader2->id)->second.get());
+    ASSERT_TRUE(topic2->data_writers.empty());
+
+    // Check that the locator is OK
+    ASSERT_EQ(1, reader2->locators.size());
+    ASSERT_EQ(wlocator.get(), reader2->locators.begin()->second.get());
+    ASSERT_TRUE(wlocator->active);
+    ASSERT_EQ(1, wlocator->data_readers.size());
+    ASSERT_EQ(reader2.get(), wlocator->data_readers.find(reader2->id)->second.get());
+    ASSERT_EQ(1, wlocator->data_writers.size());
+    ASSERT_EQ(writer.get(), wlocator->data_writers.find(writer->id)->second.get());
+
+    /* A DATAWRITER on the second topic, on the reader's locator */
+    DomainEntityDiscoveryArgs datawriter2_discovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(2, status.total_count);
+                EXPECT_EQ(1, status.total_count_change);
+                EXPECT_EQ(2, status.current_count);
+                EXPECT_EQ(1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_datawriter_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&datawriter2_discovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    // Start building the discovered writer info
+    eprosima::fastrtps::rtps::WriterProxyData writer2_data(1, 1);
+
+    // The discovered writer is in the participant
+    eprosima::fastrtps::rtps::GUID_t datawriter2_guid_;
+    std::stringstream("01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.4") >> datawriter2_guid_;
+    writer2_data.guid(datawriter2_guid_);
+
+    // The discovered writer contains the locator
+    writer2_data.add_unicast_locator(reader_locator);
+
+    // The discovered writer is in the topic
+    writer2_data.topicName(topic2_name);
+    writer2_data.typeName(topic_type_);
+
+    // Finish building the discovered writer info
+    eprosima::fastrtps::rtps::WriterDiscoveryInfo writer2_info(writer2_data);
+    writer2_info.status = eprosima::fastrtps::rtps::WriterDiscoveryInfo::DISCOVERED_WRITER;
+
+    // Execution: Call the listener
+    participant_listener_->on_publisher_discovery(participant_, std::move(writer2_info));
+    details::StatisticsBackendData::get_instance()->entity_queue_->flush();
+
+    // Check that the writer was created OK
+    const std::shared_ptr<const database::DataWriter> writer2 =
+            std::dynamic_pointer_cast<const database::DataWriter>(
+        details::StatisticsBackendData::get_instance()->database_->get_entity(datawriter2_discovery_args.
+                discovered_entity_id_));
+    ASSERT_TRUE(writer2);
+    ASSERT_TRUE(writer2->active);
+    ASSERT_EQ(participant->id, writer2->participant->id);
+
+    // Check that the topic is OK
+    ASSERT_TRUE(writer2->topic);
+    ASSERT_EQ(topic2.get(), writer2->topic.get());
+    ASSERT_TRUE(topic2->active);
+    ASSERT_EQ(1, topic2->data_readers.size());
+    ASSERT_EQ(reader2.get(), topic2->data_readers.find(reader2->id)->second.get());
+    ASSERT_EQ(1, topic2->data_writers.size());
+    ASSERT_EQ(writer2.get(), topic2->data_writers.find(writer2->id)->second.get());
+
+    // Check that the locator is OK
+    ASSERT_EQ(1, writer2->locators.size());
+    ASSERT_EQ(rlocator.get(), writer2->locators.begin()->second.get());
+    ASSERT_TRUE(rlocator->active);
+    ASSERT_EQ(1, rlocator->data_readers.size());
+    ASSERT_EQ(reader.get(), rlocator->data_readers.find(reader->id)->second.get());
+    ASSERT_EQ(1, rlocator->data_writers.size());
+    ASSERT_EQ(writer2.get(), rlocator->data_writers.find(writer2->id)->second.get());
+
+    /* Remove the DATAWRITER and DATAREADER on the first TOPIC */
+    DomainEntityDiscoveryArgs datawriter_undiscovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(2, status.total_count);
+                EXPECT_EQ(0, status.total_count_change);
+                EXPECT_EQ(1, status.current_count);
+                EXPECT_EQ(-1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_datawriter_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&datawriter_undiscovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    eprosima::fastrtps::rtps::WriterDiscoveryInfo writer_undiscovery_info (writer_data);
+    writer_undiscovery_info.status = eprosima::fastrtps::rtps::WriterDiscoveryInfo::REMOVED_WRITER;
+
+    // Execution: Call the listener
+    participant_listener_->on_publisher_discovery(participant_, std::move(writer_undiscovery_info));
+    details::StatisticsBackendData::get_instance()->entity_queue_->flush();
+
+    ASSERT_FALSE(writer->active);
+    ASSERT_TRUE(reader->active);
+    ASSERT_TRUE(topic->active);
+    ASSERT_EQ(1, topic->data_readers.size());
+    ASSERT_EQ(reader.get(), topic->data_readers.find(reader->id)->second.get());
+    ASSERT_EQ(1, topic->data_writers.size());
+    ASSERT_EQ(writer.get(), topic->data_writers.find(writer->id)->second.get());
+    ASSERT_TRUE(wlocator->active);
+    ASSERT_TRUE(rlocator->active);
+    ASSERT_TRUE(participant->active);
+    ASSERT_EQ(2, participant->data_readers.size());
+    ASSERT_EQ(reader.get(), participant->data_readers.find(reader->id)->second.get());
+    ASSERT_EQ(2, participant->data_writers.size());
+    ASSERT_EQ(writer.get(), participant->data_writers.find(writer->id)->second.get());
+
+    DomainEntityDiscoveryArgs datareader_undiscovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(2, status.total_count);
+                EXPECT_EQ(0, status.total_count_change);
+                EXPECT_EQ(1, status.current_count);
+                EXPECT_EQ(-1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_datareader_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&datareader_undiscovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    DomainEntityDiscoveryArgs topic_undiscovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(2, status.total_count);
+                EXPECT_EQ(0, status.total_count_change);
+                EXPECT_EQ(1, status.current_count);
+                EXPECT_EQ(-1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_topic_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&topic_undiscovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    eprosima::fastrtps::rtps::ReaderDiscoveryInfo reader_undiscovery_info(reader_data);
+    reader_undiscovery_info.status = eprosima::fastrtps::rtps::ReaderDiscoveryInfo::REMOVED_READER;
+
+    // Execution: Call the listener
+    participant_listener_->on_subscriber_discovery(participant_, std::move(reader_undiscovery_info));
+    details::StatisticsBackendData::get_instance()->entity_queue_->flush();
+
+    ASSERT_FALSE(writer->active);
+    ASSERT_FALSE(reader->active);
+    ASSERT_FALSE(topic->active);
+    ASSERT_EQ(1, topic->data_readers.size());
+    ASSERT_EQ(reader.get(), topic->data_readers.find(reader->id)->second.get());
+    ASSERT_EQ(1, topic->data_writers.size());
+    ASSERT_EQ(writer.get(), topic->data_writers.find(writer->id)->second.get());
+    ASSERT_TRUE(wlocator->active);
+    ASSERT_TRUE(rlocator->active);
+    ASSERT_TRUE(participant->active);
+    ASSERT_EQ(2, participant->data_readers.size());
+    ASSERT_EQ(reader.get(), participant->data_readers.find(reader->id)->second.get());
+    ASSERT_EQ(2, participant->data_writers.size());
+    ASSERT_EQ(writer.get(), participant->data_writers.find(writer->id)->second.get());
+
+    /* Remove the DATAWRITER and DATAREADER on the second TOPIC */
+    DomainEntityDiscoveryArgs datawriter2_undiscovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(2, status.total_count);
+                EXPECT_EQ(0, status.total_count_change);
+                EXPECT_EQ(0, status.current_count);
+                EXPECT_EQ(-1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_datawriter_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&datawriter2_undiscovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    eprosima::fastrtps::rtps::WriterDiscoveryInfo writer2_undiscovery_info (writer2_data);
+    writer2_undiscovery_info.status = eprosima::fastrtps::rtps::WriterDiscoveryInfo::REMOVED_WRITER;
+
+    // Execution: Call the listener
+    participant_listener_->on_publisher_discovery(participant_, std::move(writer2_undiscovery_info));
+    details::StatisticsBackendData::get_instance()->entity_queue_->flush();
+
+    ASSERT_FALSE(writer2->active);
+    ASSERT_TRUE(reader2->active);
+    ASSERT_TRUE(topic2->active);
+    ASSERT_EQ(1, topic2->data_readers.size());
+    ASSERT_EQ(reader2.get(), topic2->data_readers.find(reader2->id)->second.get());
+    ASSERT_EQ(1, topic2->data_writers.size());
+    ASSERT_EQ(writer2.get(), topic2->data_writers.find(writer2->id)->second.get());
+    ASSERT_TRUE(wlocator->active);
+    ASSERT_TRUE(rlocator->active);
+    ASSERT_TRUE(participant->active);
+    ASSERT_EQ(2, participant->data_readers.size());
+    ASSERT_EQ(reader2.get(), participant->data_readers.find(reader2->id)->second.get());
+    ASSERT_EQ(2, participant->data_writers.size());
+    ASSERT_EQ(writer2.get(), participant->data_writers.find(writer2->id)->second.get());
+
+    DomainEntityDiscoveryArgs datareader2_undiscovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(2, status.total_count);
+                EXPECT_EQ(0, status.total_count_change);
+                EXPECT_EQ(0, status.current_count);
+                EXPECT_EQ(-1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_datareader_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&datareader2_undiscovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    DomainEntityDiscoveryArgs topic2_undiscovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(2, status.total_count);
+                EXPECT_EQ(0, status.total_count_change);
+                EXPECT_EQ(0, status.current_count);
+                EXPECT_EQ(-1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_topic_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&topic2_undiscovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    eprosima::fastrtps::rtps::ReaderDiscoveryInfo reader2_undiscovery_info(reader2_data);
+    reader2_undiscovery_info.status = eprosima::fastrtps::rtps::ReaderDiscoveryInfo::REMOVED_READER;
+
+    // Execution: Call the listener
+    participant_listener_->on_subscriber_discovery(participant_, std::move(reader2_undiscovery_info));
+    details::StatisticsBackendData::get_instance()->entity_queue_->flush();
+
+    ASSERT_FALSE(writer2->active);
+    ASSERT_FALSE(reader2->active);
+    ASSERT_FALSE(topic2->active);
+    ASSERT_EQ(1, topic2->data_readers.size());
+    ASSERT_EQ(reader2.get(), topic2->data_readers.find(reader2->id)->second.get());
+    ASSERT_EQ(1, topic2->data_writers.size());
+    ASSERT_EQ(writer2.get(), topic2->data_writers.find(writer2->id)->second.get());
+    ASSERT_TRUE(wlocator->active);
+    ASSERT_TRUE(rlocator->active);
+    ASSERT_TRUE(participant->active);
+    ASSERT_EQ(2, participant->data_readers.size());
+    ASSERT_EQ(reader2.get(), participant->data_readers.find(reader2->id)->second.get());
+    ASSERT_EQ(2, participant->data_writers.size());
+    ASSERT_EQ(writer2.get(), participant->data_writers.find(writer2->id)->second.get());
+
+    /* Remove the PARTICIPANT */
+    DomainEntityDiscoveryArgs participant_undiscovery_args([&](
+                EntityId domain_id,
+                EntityId /*entity_id*/,
+                const DomainListener::Status& status)
+            {
+                EXPECT_EQ(monitor_id_, domain_id);
+                EXPECT_EQ(1, status.total_count);
+                EXPECT_EQ(0, status.total_count_change);
+                EXPECT_EQ(0, status.current_count);
+                EXPECT_EQ(-1, status.current_count_change);
+            });
+
+    EXPECT_CALL(domain_listener_, on_participant_discovery(monitor_id_, _, _)).Times(1)
+            .WillOnce(Invoke(&participant_undiscovery_args, &DomainEntityDiscoveryArgs::on_discovery));
+
+    eprosima::fastrtps::rtps::ParticipantDiscoveryInfo participant_undiscovery_info(participant_data);
+    participant_undiscovery_info.status = eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::REMOVED_PARTICIPANT;
+
+    // Execution: Call the listener
+    participant_listener_->on_participant_discovery(participant_, std::move(participant_undiscovery_info));
+    details::StatisticsBackendData::get_instance()->entity_queue_->flush();
+
+    ASSERT_FALSE(writer2->active);
+    ASSERT_FALSE(reader2->active);
+    ASSERT_FALSE(topic2->active);
+    ASSERT_EQ(1, topic2->data_readers.size());
+    ASSERT_EQ(reader2.get(), topic2->data_readers.find(reader2->id)->second.get());
+    ASSERT_EQ(1, topic2->data_writers.size());
+    ASSERT_EQ(writer2.get(), topic2->data_writers.find(writer2->id)->second.get());
+    ASSERT_TRUE(wlocator->active);
+    ASSERT_TRUE(rlocator->active);
+    ASSERT_FALSE(participant->active);
+    ASSERT_EQ(2, participant->data_readers.size());
+    ASSERT_EQ(reader2.get(), participant->data_readers.find(reader2->id)->second.get());
+    ASSERT_EQ(2, participant->data_writers.size());
+    ASSERT_EQ(writer2.get(), participant->data_writers.find(writer2->id)->second.get());
+}
 
 int main(
         int argc,

--- a/test/unittest/StatisticsBackend/IsActiveTests.cpp
+++ b/test/unittest/StatisticsBackend/IsActiveTests.cpp
@@ -73,14 +73,14 @@ public:
 
         // Simulate the discover of the entities
         details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                host->id,
-                host->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+            host->id,
+            host->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
         details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                user->id,
-                user->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+            user->id,
+            user->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
         details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                process->id,
-                process->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+            process->id,
+            process->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
         details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain->id,
                 topic->id,
                 topic->kind,

--- a/test/unittest/StatisticsBackend/IsActiveTests.cpp
+++ b/test/unittest/StatisticsBackend/IsActiveTests.cpp
@@ -72,13 +72,13 @@ public:
         db->change_entity_status_test(topic->id, true, domain->id);
 
         // Simulate the discover of the entities
-        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain->id,
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 host->id,
                 host->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
-        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain->id,
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 user->id,
                 user->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
-        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(domain->id,
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
                 process->id,
                 process->kind, details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
         details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(domain->id,

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -513,29 +513,24 @@ TEST_F(statistics_backend_tests, internal_callbacks_negative_cases)
             ".*");
 
     // Check that there is a Participant with EntityId(9)
-    // This will be used in all calls to on_physical_entity_discovery
     result = StatisticsBackendTest::get_entities(EntityKind::PARTICIPANT, EntityId(9));
     ASSERT_EQ(1, result.size());
-    EntityId participant_id = EntityId(9);
 
-    // Avoid a participant discovering itself
+    // Calling on_physical_entity_discovery with a domain entity should fail
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                participant_id,
                 EntityId(9),
                 EntityKind::PARTICIPANT,
                 details::StatisticsBackendData::DISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                participant_id,
-                EntityId(10),
+                EntityId(9),
                 EntityKind::PARTICIPANT,
-                details::StatisticsBackendData::DISCOVERY),
+                details::StatisticsBackendData::UNDISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                participant_id,
-                EntityId(10),
+                EntityId(9),
                 EntityKind::PARTICIPANT,
-                details::StatisticsBackendData::DISCOVERY),
+                details::StatisticsBackendData::UPDATE),
             ".*");
 
     // Check that there is a topic with EntityId(11)
@@ -544,22 +539,19 @@ TEST_F(statistics_backend_tests, internal_callbacks_negative_cases)
 
     // Calling on_physical_entity_discovery with a domain entity should fail
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                participant_id,
                 EntityId(11),
                 EntityKind::TOPIC,
                 details::StatisticsBackendData::DISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                participant_id,
                 EntityId(11),
                 EntityKind::TOPIC,
-                details::StatisticsBackendData::DISCOVERY),
+                details::StatisticsBackendData::UNDISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                participant_id,
                 EntityId(11),
                 EntityKind::TOPIC,
-                details::StatisticsBackendData::DISCOVERY),
+                details::StatisticsBackendData::UPDATE),
             ".*");
 
     // Check that there is a datareader with EntityId(13)
@@ -568,22 +560,19 @@ TEST_F(statistics_backend_tests, internal_callbacks_negative_cases)
 
     // Calling on_physical_entity_discovery with a domain entity should fail
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                participant_id,
                 EntityId(13),
                 EntityKind::DATAREADER,
                 details::StatisticsBackendData::DISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                participant_id,
                 EntityId(13),
                 EntityKind::DATAREADER,
-                details::StatisticsBackendData::DISCOVERY),
+                details::StatisticsBackendData::UNDISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                participant_id,
                 EntityId(13),
                 EntityKind::DATAREADER,
-                details::StatisticsBackendData::DISCOVERY),
+                details::StatisticsBackendData::UPDATE),
             ".*");
 
     // Check that there is a datawriter with EntityId(17)
@@ -592,22 +581,19 @@ TEST_F(statistics_backend_tests, internal_callbacks_negative_cases)
 
     // Calling on_physical_entity_discovery with a domain entity should fail
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                participant_id,
                 EntityId(17),
                 EntityKind::DATAWRITER,
                 details::StatisticsBackendData::DISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                participant_id,
                 EntityId(17),
                 EntityKind::DATAWRITER,
-                details::StatisticsBackendData::DISCOVERY),
+                details::StatisticsBackendData::UNDISCOVERY),
             ".*");
     ASSERT_DEATH(details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                participant_id,
                 EntityId(17),
                 EntityKind::DATAWRITER,
-                details::StatisticsBackendData::DISCOVERY),
+                details::StatisticsBackendData::UPDATE),
             ".*");
 
 #endif // ifndef NDEBUG


### PR DESCRIPTION
* Physical listener callbacks have been changed and now they take no participant ID as parameter
  * Locators could be discovered outside any participant (by traffic)
  * Other physical entities can be discovered with a participant, but then linked to many others, without notifying the user. Therefore, notifying about the first participant is somehow pointless.
  * Neither the monitor team nor DB seem to be using this at the moment, so the API change is more or less safe

* Additionally, the notification to the user is done in the Database class instead of the Queue (where all the rest of notifications take place). The reasons are:
  * When adding the new Endpoint to the queue, it must have a map of locators, complete with the final ID. We cannot just push the new locators to the queue and then push the entity, since we could not get the ID of the new locators. Instead, we keep the current solution of requesting a new ID to the database and let the database notify the user when the locator is created.
  * The locators can be discovered by statistic data, and in this case we have the same problem, we cannot just add a new locator to the queue because we need its ID to insert the data. Again, we let the database insert the locator and notify the user
  * Either of these calls will be done on the queue's thread: one when processing a new endpoint and the other when processing a new data