### PR TITLE
Dump and clear [11908]

### DIFF
--- a/docs/code/StatisticsBackendTests.cpp
+++ b/docs/code/StatisticsBackendTests.cpp
@@ -424,13 +424,19 @@ void dump_load_examples()
     {
         //CONF-DUMP-LOAD-EXAMPLE
         // Save the database to a file
-        StatisticsBackend::dump_database("new_backend_dump.json");
+        StatisticsBackend::dump_database("new_backend_dump.json", false);
 
         // Reset the Backend to empty the current database contents
         StatisticsBackend::reset();
 
         // Load an old backup to the emptied Backend
         StatisticsBackend::load_database("old_backend_dump.json");
+        //!--
+    }
+    {
+        //CONF-DUMP-AND_CLEAR-EXAMPLE
+        // Save the database to a file, cleaning the statistics data
+        StatisticsBackend::dump_database("new_backend_dump.json", true);
         //!--
     }
 }

--- a/docs/rst/statistics_backend/dump_load.rst
+++ b/docs/rst/statistics_backend/dump_load.rst
@@ -32,3 +32,10 @@ resetting the Backend in between.
     :end-before: //!
     :dedent: 8
 
+The bool parameter of |dump_database-api| indicates if the statistics data of all entities must being cleared.
+
+.. literalinclude:: /code/StatisticsBackendTests.cpp
+    :language: c++
+    :start-after: //CONF-DUMP-AND_CLEAR-EXAMPLE
+    :end-before: //!
+    :dedent: 8

--- a/docs/rst/statistics_backend/dump_load.rst
+++ b/docs/rst/statistics_backend/dump_load.rst
@@ -32,7 +32,8 @@ resetting the Backend in between.
     :end-before: //!
     :dedent: 8
 
-The bool parameter of |dump_database-api| indicates if the statistics data of all entities must being cleared.
+The bool parameter of |dump_database-api| indicates if the statistics data
+of all entities must be cleared after the dump.
 
 .. literalinclude:: /code/StatisticsBackendTests.cpp
     :language: c++

--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -353,7 +353,7 @@ public:
 
     /**
      * @brief Get a dump of the database.
-     * 
+     *
      * @param clear If true, clear all the statistics data of all entities.
      *
      * @return DatabaseDump object representing the backend database.
@@ -363,12 +363,12 @@ public:
 
     /**
      * @brief Dump Fast DDS Statistics Backend's database to a file.
-     * 
+     *
      * @param filename The name of the file where the database is dumped.
      * @param clear If true, clear all the statistics data of all entities.
      */
     static void dump_database(
-            const std::string& filename, 
+            const std::string& filename,
             bool clear);
 
     /**

--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -353,18 +353,23 @@ public:
 
     /**
      * @brief Get a dump of the database.
+     * 
+     * @param clear If true, clear all the statistics data of all entities.
      *
      * @return DatabaseDump object representing the backend database.
      */
-    static DatabaseDump dump_database();
+    static DatabaseDump dump_database(
+            bool clear);
 
     /**
      * @brief Dump Fast DDS Statistics Backend's database to a file.
-     *
+     * 
      * @param filename The name of the file where the database is dumped.
+     * @param clear If true, clear all the statistics data of all entities.
      */
     static void dump_database(
-            const std::string& filename);
+            const std::string& filename, 
+            bool clear);
 
     /**
      * @brief Load Fast DDS Statistics Backend's database from a file.

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -669,7 +669,7 @@ Graph StatisticsBackend::get_graph()
 }
 
 DatabaseDump StatisticsBackend::dump_database(
-    const bool clear)
+        const bool clear)
 {
     return details::StatisticsBackendData::get_instance()->database_->dump_database(clear);
 }

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -668,13 +668,15 @@ Graph StatisticsBackend::get_graph()
     return Graph();
 }
 
-DatabaseDump StatisticsBackend::dump_database()
+DatabaseDump StatisticsBackend::dump_database(
+    const bool clear)
 {
-    return details::StatisticsBackendData::get_instance()->database_->dump_database();
+    return details::StatisticsBackendData::get_instance()->database_->dump_database(clear);
 }
 
 void StatisticsBackend::dump_database(
-        const std::string& filename)
+        const std::string& filename,
+        const bool clear)
 {
     // Open the file
     std::ofstream file(filename);
@@ -684,7 +686,7 @@ void StatisticsBackend::dump_database(
     }
 
     // Dump the data
-    file << StatisticsBackend::dump_database();
+    file << StatisticsBackend::dump_database(clear);
 }
 
 void StatisticsBackend::load_database(

--- a/src/cpp/database/data.cpp
+++ b/src/cpp/database/data.cpp
@@ -19,50 +19,66 @@ namespace eprosima {
 namespace statistics_backend {
 namespace database {
 
-void DomainParticipantData::clear()
+void DomainParticipantData::clear(
+        bool clear_last_reported)
 {
-    RTPSData::clear();
+    RTPSData::clear(clear_last_reported);
     discovered_entity.clear();
     pdp_packets.clear();
-    last_reported_pdp_packets.clear();
     edp_packets.clear();
-    last_reported_edp_packets.clear();
+    if (clear_last_reported)
+    {
+        last_reported_pdp_packets.clear();
+        last_reported_edp_packets.clear();
+    }
 }
 
-void DataReaderData::clear()
+void DataReaderData::clear(
+        bool clear_last_reported)
 {
     subscription_throughput.clear();
     acknack_count.clear();
-    last_reported_acknack_count.clear();
     nackfrag_count.clear();
-    last_reported_nackfrag_count.clear();
+    if (clear_last_reported)
+    {
+        last_reported_acknack_count.clear();
+        last_reported_nackfrag_count.clear();
+    }
 }
 
-void RTPSData::clear()
+void RTPSData::clear(
+        bool clear_last_reported)
 {
     rtps_packets_sent.clear();
-    last_reported_rtps_packets_sent_count.clear();
     rtps_bytes_sent.clear();
-    last_reported_rtps_bytes_sent_count.clear();
     rtps_packets_lost.clear();
-    last_reported_rtps_packets_lost_count.clear();
     rtps_bytes_lost.clear();
-    last_reported_rtps_bytes_lost_count.clear();
+    if (clear_last_reported)
+    {
+        last_reported_rtps_packets_sent_count.clear();
+        last_reported_rtps_bytes_sent_count.clear();
+        last_reported_rtps_packets_lost_count.clear();
+        last_reported_rtps_bytes_lost_count.clear();
+    }
 }
 
-void DataWriterData::clear()
+void DataWriterData::clear(
+        bool clear_last_reported)
 {
     history2history_latency.clear();
     publication_throughput.clear();
     resent_datas.clear();
-    last_reported_resent_datas.clear();
     heartbeat_count.clear();
-    last_reported_heartbeat_count.clear();
     gap_count.clear();
-    last_reported_gap_count.clear();
     data_count.clear();
-    last_reported_data_count.clear();
     sample_datas.clear();
+    if (clear_last_reported)
+    {
+        last_reported_resent_datas.clear();
+        last_reported_heartbeat_count.clear();
+        last_reported_gap_count.clear();
+        last_reported_data_count.clear();
+    }
 }
 
 void LocatorData::clear()

--- a/src/cpp/database/data.hpp
+++ b/src/cpp/database/data.hpp
@@ -45,7 +45,8 @@ struct RTPSData
     /**
      * Clear the vectors and maps, and set the counts to zero
      */
-    virtual void clear() = 0;
+    virtual void clear(
+            bool clear_last_reported = true) = 0;
 
     /*
      * Packet count data reported by topic: eprosima::fastdds::statistics::RTPS_SENT_TOPIC
@@ -116,7 +117,8 @@ struct DomainParticipantData : RTPSData
     /**
      * Clear the vectors and maps, and set the counts to zero
      */
-    void clear() final;
+    void clear(
+            bool clear_last_reported = true) final;
 
     /*
      * Data reported by topic: eprosima::fastdds::statistics::DISCOVERY_TOPIC
@@ -165,7 +167,8 @@ struct DataReaderData
     /**
      * Clear the vectors and maps, and set the counts to zero
      */
-    void clear();
+    void clear(
+            bool clear_last_reported = true);
 
     /*
      * Data reported by topic: eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT_TOPIC
@@ -209,7 +212,8 @@ struct DataWriterData
     /**
      * Clear the vectors and maps, and set the counts to zero
      */
-    void clear();
+    void clear(
+            bool clear_last_reported = true);
 
     /*
      * Data reported by topic: eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT_TOPIC

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -2450,7 +2450,7 @@ void Database::insert_ddsendpoint_to_locator(
 }
 
 DatabaseDump Database::dump_database(
-    bool clear)
+        bool clear)
 {
     std::unique_lock<std::shared_timed_mutex> lock(mutex_);
 
@@ -3170,34 +3170,34 @@ DatabaseDump Database::dump_data_(
 void Database::clear_database()
 {
     // Participants
-    for (const auto &super_it : participants_)
+    for (const auto& super_it : participants_)
     {
         // For each entity of this kind in the domain
-        for (const auto &it : super_it.second)
+        for (const auto& it : super_it.second)
         {
             it.second->data.clear();
         }
     }
     // Datawriters
-    for (const auto &super_it : datawriters_)
+    for (const auto& super_it : datawriters_)
     {
         // For each entity of this kind in the domain
-        for (const auto &it : super_it.second)
+        for (const auto& it : super_it.second)
         {
             it.second->data.clear();
         }
     }
     // Datareaders
-    for (const auto &super_it : datareaders_)
+    for (const auto& super_it : datareaders_)
     {
         // For each entity of this kind in the domain
-        for (const auto &it : super_it.second)
+        for (const auto& it : super_it.second)
         {
             it.second->data.clear();
         }
     }
     // Locators
-    for (const auto &it : locators_)
+    for (const auto& it : locators_)
     {
         it.second->data.clear();
     }

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -2449,8 +2449,11 @@ void Database::insert_ddsendpoint_to_locator(
     locator->data_readers[endpoint->id] = endpoint;
 }
 
-DatabaseDump Database::dump_database()
+DatabaseDump Database::dump_database(
+    bool clear)
 {
+    std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+
     DatabaseDump dump = DatabaseDump::object();
 
     // Add version
@@ -2579,6 +2582,11 @@ DatabaseDump Database::dump_database()
         }
 
         dump[LOCATOR_CONTAINER_TAG] = container;
+    }
+
+    if (clear)
+    {
+        clear_database();
     }
 
     return dump;
@@ -3157,6 +3165,42 @@ DatabaseDump Database::dump_data_(
     }
 
     return data_dump;
+}
+
+void Database::clear_database()
+{
+    // Participants
+    for (const auto &super_it : participants_)
+    {
+        // For each entity of this kind in the domain
+        for (const auto &it : super_it.second)
+        {
+            it.second->data.clear();
+        }
+    }
+    // Datawriters
+    for (const auto &super_it : datawriters_)
+    {
+        // For each entity of this kind in the domain
+        for (const auto &it : super_it.second)
+        {
+            it.second->data.clear();
+        }
+    }
+    // Datareaders
+    for (const auto &super_it : datareaders_)
+    {
+        // For each entity of this kind in the domain
+        for (const auto &it : super_it.second)
+        {
+            it.second->data.clear();
+        }
+    }
+    // Locators
+    for (const auto &it : locators_)
+    {
+        it.second->data.clear();
+    }
 }
 
 /**

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -2586,7 +2586,7 @@ DatabaseDump Database::dump_database(
 
     if (clear)
     {
-        clear_database();
+        clear_statistics_data();
     }
 
     return dump;
@@ -3167,7 +3167,7 @@ DatabaseDump Database::dump_data_(
     return data_dump;
 }
 
-void Database::clear_database()
+void Database::clear_statistics_data()
 {
     // Participants
     for (const auto& super_it : participants_)
@@ -3175,7 +3175,7 @@ void Database::clear_database()
         // For each entity of this kind in the domain
         for (const auto& it : super_it.second)
         {
-            it.second->data.clear();
+            it.second->data.clear(false);
         }
     }
     // Datawriters
@@ -3184,7 +3184,7 @@ void Database::clear_database()
         // For each entity of this kind in the domain
         for (const auto& it : super_it.second)
         {
-            it.second->data.clear();
+            it.second->data.clear(false);
         }
     }
     // Datareaders
@@ -3193,7 +3193,7 @@ void Database::clear_database()
         // For each entity of this kind in the domain
         for (const auto& it : super_it.second)
         {
-            it.second->data.clear();
+            it.second->data.clear(false);
         }
     }
     // Locators

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -591,7 +591,7 @@ protected:
     /**
      * @brief Remove the statistics data of the database. This not include the info or discovery data.
      */
-    void clear_database();
+    void clear_statistics_data();
 
     /**
      * @brief Insert a new entity into the database. This method is not thread safe.

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -306,7 +306,7 @@ public:
 
     /**
      * @brief Get a dump of the database.
-     * 
+     *
      * @param clear If true, remove the statistics data of the database. This not include the info or discovery data.
      *
      * @return DatabaseDump object representing the backend database.
@@ -588,10 +588,10 @@ protected:
     DatabaseDump dump_data_(
             const std::map<EntityId, ByteCountSample>& data);
 
-	/**
+    /**
      * @brief Remove the statistics data of the database. This not include the info or discovery data.
      */
-	void clear_database();
+    void clear_database();
 
     /**
      * @brief Insert a new entity into the database. This method is not thread safe.

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -306,10 +306,13 @@ public:
 
     /**
      * @brief Get a dump of the database.
+     * 
+     * @param clear If true, remove the statistics data of the database. This not include the info or discovery data.
      *
      * @return DatabaseDump object representing the backend database.
      */
-    DatabaseDump dump_database();
+    DatabaseDump dump_database(
+            const bool clear = false);
 
     /**
      * @brief Load Entities and their data from dump (json) object.
@@ -584,6 +587,11 @@ protected:
             const std::map<EntityId, EntityCountSample>& data);
     DatabaseDump dump_data_(
             const std::map<EntityId, ByteCountSample>& data);
+
+	/**
+     * @brief Remove the statistics data of the database. This not include the info or discovery data.
+     */
+	void clear_database();
 
     /**
      * @brief Insert a new entity into the database. This method is not thread safe.

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -409,6 +409,7 @@ set(DATABASE_DUMP_TEST_LIST
     id_to_string
     time_to_string
     dump_no_process_participant_link
+    dump_and_clear_database
     )
 
 foreach(test_name ${DATABASE_DUMP_TEST_LIST})

--- a/test/unittest/Database/DatabaseDumpTests.cpp
+++ b/test/unittest/Database/DatabaseDumpTests.cpp
@@ -433,6 +433,115 @@ TEST(database, dump_unlinked_database)
     ASSERT_EQ(db.dump_database(), dump);
 }
 
+// Test the dump of a database with a clear of the statistics data
+TEST(database, dump_and_clear_database)
+{
+    DataBaseTest db;
+    initialize_database(db, 1, 1);
+
+    // Check database contains statistics data
+    {
+       // Participants
+        for (const auto &super_it : db.participants())
+        {
+            // For each entity of this kind in the domain
+            for (const auto &it : super_it.second)
+            {
+                ASSERT_FALSE(it.second->data.discovered_entity.empty());
+                ASSERT_FALSE(it.second->data.pdp_packets.empty());
+                ASSERT_FALSE(it.second->data.edp_packets.empty());
+                ASSERT_FALSE(it.second->data.rtps_packets_sent.empty());
+                ASSERT_FALSE(it.second->data.rtps_bytes_sent.empty());
+                ASSERT_FALSE(it.second->data.rtps_packets_lost.empty());
+                ASSERT_FALSE(it.second->data.rtps_bytes_lost.empty());
+            }
+        }
+        // Datawriters
+        for (const auto &super_it : db.datawriters())
+        {
+            // For each entity of this kind in the domain
+            for (const auto &it : super_it.second)
+            {
+                ASSERT_FALSE(it.second->data.publication_throughput.empty());
+                ASSERT_FALSE(it.second->data.resent_datas.empty());
+                ASSERT_FALSE(it.second->data.heartbeat_count.empty());
+                ASSERT_FALSE(it.second->data.gap_count.empty());
+                ASSERT_FALSE(it.second->data.data_count.empty());
+                ASSERT_FALSE(it.second->data.sample_datas.empty());
+                ASSERT_FALSE(it.second->data.history2history_latency.empty());
+            }
+        }
+        // Datareaders
+        for (const auto &super_it : db.datareaders())
+        {
+            // For each entity of this kind in the domain
+            for (const auto &it : super_it.second)
+            {
+                ASSERT_FALSE(it.second->data.subscription_throughput.empty());
+                ASSERT_FALSE(it.second->data.acknack_count.empty());
+                ASSERT_FALSE(it.second->data.nackfrag_count.empty());
+            }
+        }
+        // Locators
+        for (const auto &it : db.locators())
+        {
+            ASSERT_FALSE(it.second->data.network_latency_per_locator.empty());
+        }
+    }
+
+    DatabaseDump dump = db.dump_database(true);
+
+    // Check database does not contain statistics data
+    {
+         // Participants
+        for (const auto &super_it : db.participants())
+        {
+            // For each entity of this kind in the domain
+            for (const auto &it : super_it.second)
+            {
+                ASSERT_TRUE(it.second->data.discovered_entity.empty());
+                ASSERT_TRUE(it.second->data.pdp_packets.empty());
+                ASSERT_TRUE(it.second->data.edp_packets.empty());
+                ASSERT_TRUE(it.second->data.rtps_packets_sent.empty());
+                ASSERT_TRUE(it.second->data.rtps_bytes_sent.empty());
+                ASSERT_TRUE(it.second->data.rtps_packets_lost.empty());
+                ASSERT_TRUE(it.second->data.rtps_bytes_lost.empty());
+            }
+        }
+        // Datawriters
+        for (const auto &super_it : db.datawriters())
+        {
+            // For each entity of this kind in the domain
+            for (const auto &it : super_it.second)
+            {
+                ASSERT_TRUE(it.second->data.publication_throughput.empty());
+                ASSERT_TRUE(it.second->data.resent_datas.empty());
+                ASSERT_TRUE(it.second->data.heartbeat_count.empty());
+                ASSERT_TRUE(it.second->data.gap_count.empty());
+                ASSERT_TRUE(it.second->data.data_count.empty());
+                ASSERT_TRUE(it.second->data.sample_datas.empty());
+                ASSERT_TRUE(it.second->data.history2history_latency.empty());
+            }
+        }
+        // Datareaders
+        for (const auto &super_it : db.datareaders())
+        {
+            // For each entity of this kind in the domain
+            for (const auto &it : super_it.second)
+            {
+                ASSERT_TRUE(it.second->data.subscription_throughput.empty());
+                ASSERT_TRUE(it.second->data.acknack_count.empty());
+                ASSERT_TRUE(it.second->data.nackfrag_count.empty());
+            }
+        }
+        // Locators
+        for (const auto &it : db.locators())
+        {
+            ASSERT_TRUE(it.second->data.network_latency_per_locator.empty());
+        }
+    }
+}
+
 // Test the database method id_to_string()
 TEST(database, id_to_string)
 {

--- a/test/unittest/Database/DatabaseDumpTests.cpp
+++ b/test/unittest/Database/DatabaseDumpTests.cpp
@@ -454,6 +454,19 @@ TEST(database, dump_and_clear_database)
                 ASSERT_FALSE(it.second->data.rtps_bytes_sent.empty());
                 ASSERT_FALSE(it.second->data.rtps_packets_lost.empty());
                 ASSERT_FALSE(it.second->data.rtps_bytes_lost.empty());
+
+                ASSERT_FALSE(it.second->data.last_reported_rtps_packets_sent_count.empty());
+                ASSERT_FALSE(it.second->data.last_reported_rtps_bytes_sent_count.empty());
+                ASSERT_FALSE(it.second->data.last_reported_rtps_packets_lost_count.empty());
+                ASSERT_FALSE(it.second->data.last_reported_rtps_bytes_lost_count.empty());
+                ASSERT_FALSE(it.second->data.last_reported_pdp_packets.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_pdp_packets.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_edp_packets.count == 0);
+                ASSERT_FALSE(it.second->data.last_reported_edp_packets.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_edp_packets.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_edp_packets.count == 0);
             }
         }
         // Datawriters
@@ -469,6 +482,23 @@ TEST(database, dump_and_clear_database)
                 ASSERT_FALSE(it.second->data.data_count.empty());
                 ASSERT_FALSE(it.second->data.sample_datas.empty());
                 ASSERT_FALSE(it.second->data.history2history_latency.empty());
+
+                ASSERT_FALSE(it.second->data.last_reported_resent_datas.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_resent_datas.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_resent_datas.count == 0);
+                ASSERT_FALSE(it.second->data.last_reported_heartbeat_count.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_heartbeat_count.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_heartbeat_count.count == 0);
+                ASSERT_FALSE(it.second->data.last_reported_gap_count.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_gap_count.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_gap_count.count == 0);
+                ASSERT_FALSE(it.second->data.last_reported_data_count.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_data_count.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_data_count.count == 0);
             }
         }
         // Datareaders
@@ -480,6 +510,15 @@ TEST(database, dump_and_clear_database)
                 ASSERT_FALSE(it.second->data.subscription_throughput.empty());
                 ASSERT_FALSE(it.second->data.acknack_count.empty());
                 ASSERT_FALSE(it.second->data.nackfrag_count.empty());
+
+                ASSERT_FALSE(it.second->data.last_reported_acknack_count.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_acknack_count.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_acknack_count.count == 0);
+                ASSERT_FALSE(it.second->data.last_reported_nackfrag_count.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_nackfrag_count.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_nackfrag_count.count == 0);
             }
         }
         // Locators
@@ -506,6 +545,19 @@ TEST(database, dump_and_clear_database)
                 ASSERT_TRUE(it.second->data.rtps_bytes_sent.empty());
                 ASSERT_TRUE(it.second->data.rtps_packets_lost.empty());
                 ASSERT_TRUE(it.second->data.rtps_bytes_lost.empty());
+
+                ASSERT_FALSE(it.second->data.last_reported_rtps_packets_sent_count.empty());
+                ASSERT_FALSE(it.second->data.last_reported_rtps_bytes_sent_count.empty());
+                ASSERT_FALSE(it.second->data.last_reported_rtps_packets_lost_count.empty());
+                ASSERT_FALSE(it.second->data.last_reported_rtps_bytes_lost_count.empty());
+                ASSERT_FALSE(it.second->data.last_reported_pdp_packets.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_pdp_packets.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_edp_packets.count == 0);
+                ASSERT_FALSE(it.second->data.last_reported_edp_packets.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_edp_packets.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_edp_packets.count == 0);
             }
         }
         // Datawriters
@@ -521,6 +573,23 @@ TEST(database, dump_and_clear_database)
                 ASSERT_TRUE(it.second->data.data_count.empty());
                 ASSERT_TRUE(it.second->data.sample_datas.empty());
                 ASSERT_TRUE(it.second->data.history2history_latency.empty());
+
+                ASSERT_FALSE(it.second->data.last_reported_resent_datas.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_resent_datas.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_resent_datas.count == 0);
+                ASSERT_FALSE(it.second->data.last_reported_heartbeat_count.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_heartbeat_count.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_heartbeat_count.count == 0);
+                ASSERT_FALSE(it.second->data.last_reported_gap_count.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_gap_count.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_gap_count.count == 0);
+                ASSERT_FALSE(it.second->data.last_reported_data_count.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_data_count.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_data_count.count == 0);
             }
         }
         // Datareaders
@@ -532,6 +601,15 @@ TEST(database, dump_and_clear_database)
                 ASSERT_TRUE(it.second->data.subscription_throughput.empty());
                 ASSERT_TRUE(it.second->data.acknack_count.empty());
                 ASSERT_TRUE(it.second->data.nackfrag_count.empty());
+
+                ASSERT_FALSE(it.second->data.last_reported_acknack_count.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_acknack_count.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_acknack_count.count == 0);
+                ASSERT_FALSE(it.second->data.last_reported_nackfrag_count.kind == DataKind::INVALID &&
+                        it.second->data.last_reported_nackfrag_count.src_ts ==
+                        std::chrono::system_clock::time_point() &&
+                        it.second->data.last_reported_nackfrag_count.count == 0);
             }
         }
         // Locators

--- a/test/unittest/Database/DatabaseDumpTests.cpp
+++ b/test/unittest/Database/DatabaseDumpTests.cpp
@@ -441,11 +441,11 @@ TEST(database, dump_and_clear_database)
 
     // Check database contains statistics data
     {
-       // Participants
-        for (const auto &super_it : db.participants())
+        // Participants
+        for (const auto& super_it : db.participants())
         {
             // For each entity of this kind in the domain
-            for (const auto &it : super_it.second)
+            for (const auto& it : super_it.second)
             {
                 ASSERT_FALSE(it.second->data.discovered_entity.empty());
                 ASSERT_FALSE(it.second->data.pdp_packets.empty());
@@ -457,10 +457,10 @@ TEST(database, dump_and_clear_database)
             }
         }
         // Datawriters
-        for (const auto &super_it : db.datawriters())
+        for (const auto& super_it : db.datawriters())
         {
             // For each entity of this kind in the domain
-            for (const auto &it : super_it.second)
+            for (const auto& it : super_it.second)
             {
                 ASSERT_FALSE(it.second->data.publication_throughput.empty());
                 ASSERT_FALSE(it.second->data.resent_datas.empty());
@@ -472,10 +472,10 @@ TEST(database, dump_and_clear_database)
             }
         }
         // Datareaders
-        for (const auto &super_it : db.datareaders())
+        for (const auto& super_it : db.datareaders())
         {
             // For each entity of this kind in the domain
-            for (const auto &it : super_it.second)
+            for (const auto& it : super_it.second)
             {
                 ASSERT_FALSE(it.second->data.subscription_throughput.empty());
                 ASSERT_FALSE(it.second->data.acknack_count.empty());
@@ -483,7 +483,7 @@ TEST(database, dump_and_clear_database)
             }
         }
         // Locators
-        for (const auto &it : db.locators())
+        for (const auto& it : db.locators())
         {
             ASSERT_FALSE(it.second->data.network_latency_per_locator.empty());
         }
@@ -493,11 +493,11 @@ TEST(database, dump_and_clear_database)
 
     // Check database does not contain statistics data
     {
-         // Participants
-        for (const auto &super_it : db.participants())
+        // Participants
+        for (const auto& super_it : db.participants())
         {
             // For each entity of this kind in the domain
-            for (const auto &it : super_it.second)
+            for (const auto& it : super_it.second)
             {
                 ASSERT_TRUE(it.second->data.discovered_entity.empty());
                 ASSERT_TRUE(it.second->data.pdp_packets.empty());
@@ -509,10 +509,10 @@ TEST(database, dump_and_clear_database)
             }
         }
         // Datawriters
-        for (const auto &super_it : db.datawriters())
+        for (const auto& super_it : db.datawriters())
         {
             // For each entity of this kind in the domain
-            for (const auto &it : super_it.second)
+            for (const auto& it : super_it.second)
             {
                 ASSERT_TRUE(it.second->data.publication_throughput.empty());
                 ASSERT_TRUE(it.second->data.resent_datas.empty());
@@ -524,10 +524,10 @@ TEST(database, dump_and_clear_database)
             }
         }
         // Datareaders
-        for (const auto &super_it : db.datareaders())
+        for (const auto& super_it : db.datareaders())
         {
             // For each entity of this kind in the domain
-            for (const auto &it : super_it.second)
+            for (const auto& it : super_it.second)
             {
                 ASSERT_TRUE(it.second->data.subscription_throughput.empty());
                 ASSERT_TRUE(it.second->data.acknack_count.empty());
@@ -535,7 +535,7 @@ TEST(database, dump_and_clear_database)
             }
         }
         // Locators
-        for (const auto &it : db.locators())
+        for (const auto& it : db.locators())
         {
             ASSERT_TRUE(it.second->data.network_latency_per_locator.empty());
         }

--- a/test/unittest/StatisticsBackend/BackendDumpTests.cpp
+++ b/test/unittest/StatisticsBackend/BackendDumpTests.cpp
@@ -84,7 +84,7 @@ TEST(backend_dump_tests, database_dump_load)
     }
 
     // Dump the load
-    StatisticsBackend::dump_database(TEST_DUMP_FILE,false);
+    StatisticsBackend::dump_database(TEST_DUMP_FILE, false);
 
     // Load it by the JSON library and check equality
     load_file(TEST_DUMP_FILE, dump);
@@ -94,7 +94,7 @@ TEST(backend_dump_tests, database_dump_load)
     std::remove(TEST_DUMP_FILE);
 
     // Try dumping on a non-existent directory
-    ASSERT_THROW(StatisticsBackend::dump_database(NON_EXISTENT_FILE,false),
+    ASSERT_THROW(StatisticsBackend::dump_database(NON_EXISTENT_FILE, false),
             BadParameter);
 
     // Reset the backend and try loading a non existent file
@@ -108,15 +108,19 @@ TEST(backend_dump_tests, database_dump_and_clear)
 {
     StatisticsBackend::load_database(SIMPLE_DUMP_FILE);
 
-    auto participants = details::StatisticsBackendData::get_instance()->database_->get_entities(EntityKind::PARTICIPANT,EntityId::all());
-    auto datawriters = details::StatisticsBackendData::get_instance()->database_->get_entities(EntityKind::DATAWRITER,EntityId::all());
-    auto datareaders = details::StatisticsBackendData::get_instance()->database_->get_entities(EntityKind::DATAREADER,EntityId::all());
-    auto locators = details::StatisticsBackendData::get_instance()->database_->get_entities(EntityKind::LOCATOR,EntityId::all());
+    auto participants = details::StatisticsBackendData::get_instance()->database_->get_entities(EntityKind::PARTICIPANT,
+                    EntityId::all());
+    auto datawriters = details::StatisticsBackendData::get_instance()->database_->get_entities(EntityKind::DATAWRITER,
+                    EntityId::all());
+    auto datareaders = details::StatisticsBackendData::get_instance()->database_->get_entities(EntityKind::DATAREADER,
+                    EntityId::all());
+    auto locators = details::StatisticsBackendData::get_instance()->database_->get_entities(EntityKind::LOCATOR,
+                    EntityId::all());
 
     // Check database contains statistics data
     {
         // Participants
-        for (const auto &it : participants)
+        for (const auto& it : participants)
         {
             auto participant = std::dynamic_pointer_cast<const DomainParticipant>(it);
             ASSERT_FALSE(participant->data.discovered_entity.empty());
@@ -128,7 +132,7 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_FALSE(participant->data.rtps_bytes_lost.empty());
         }
         // Datawriters
-        for (const auto &it : datawriters)
+        for (const auto& it : datawriters)
         {
             auto datawriter = std::dynamic_pointer_cast<const DataWriter>(it);
             ASSERT_FALSE(datawriter->data.publication_throughput.empty());
@@ -139,7 +143,7 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_FALSE(datawriter->data.sample_datas.empty());
         }
         // Datareaders
-        for (const auto &it : datareaders)
+        for (const auto& it : datareaders)
         {
             auto datareader = std::dynamic_pointer_cast<const DataReader>(it);
             ASSERT_FALSE(datareader->data.subscription_throughput.empty());
@@ -147,7 +151,7 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_FALSE(datareader->data.nackfrag_count.empty());
         }
         // Locators
-        for (const auto &it : locators)
+        for (const auto& it : locators)
         {
             auto locator = std::dynamic_pointer_cast<const Locator>(it);
             ASSERT_FALSE(locator->data.network_latency_per_locator.empty());
@@ -164,12 +168,12 @@ TEST(backend_dump_tests, database_dump_and_clear)
     }
 
     // Dump the load
-    StatisticsBackend::dump_database(TEST_DUMP_AND_CLEAR_FILE,true);
+    StatisticsBackend::dump_database(TEST_DUMP_AND_CLEAR_FILE, true);
 
     // Check database does not contain statistics data
     {
         // Participants
-        for (const auto &it : participants)
+        for (const auto& it : participants)
         {
             auto participant = std::dynamic_pointer_cast<const DomainParticipant>(it);
             ASSERT_TRUE(participant->data.discovered_entity.empty());
@@ -181,7 +185,7 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_TRUE(participant->data.rtps_bytes_lost.empty());
         }
         // Datawriters
-        for (const auto &it : datawriters)
+        for (const auto& it : datawriters)
         {
             auto datawriter = std::dynamic_pointer_cast<const DataWriter>(it);
             ASSERT_TRUE(datawriter->data.publication_throughput.empty());
@@ -192,7 +196,7 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_TRUE(datawriter->data.sample_datas.empty());
         }
         // Datareaders
-        for (const auto &it : datareaders)
+        for (const auto& it : datareaders)
         {
             auto datareader = std::dynamic_pointer_cast<const DataReader>(it);
             ASSERT_TRUE(datareader->data.subscription_throughput.empty());
@@ -200,7 +204,7 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_TRUE(datareader->data.nackfrag_count.empty());
         }
         // Locators
-        for (const auto &it : locators)
+        for (const auto& it : locators)
         {
             auto locator = std::dynamic_pointer_cast<const Locator>(it);
             ASSERT_TRUE(locator->data.network_latency_per_locator.empty());

--- a/test/unittest/StatisticsBackend/BackendDumpTests.cpp
+++ b/test/unittest/StatisticsBackend/BackendDumpTests.cpp
@@ -84,7 +84,7 @@ TEST(backend_dump_tests, database_dump_load)
     }
 
     // Dump the load
-    StatisticsBackend::dump_database(TEST_DUMP_FILE);
+    StatisticsBackend::dump_database(TEST_DUMP_FILE,false);
 
     // Load it by the JSON library and check equality
     load_file(TEST_DUMP_FILE, dump);
@@ -94,13 +94,121 @@ TEST(backend_dump_tests, database_dump_load)
     std::remove(TEST_DUMP_FILE);
 
     // Try dumping on a non-existent directory
-    ASSERT_THROW(StatisticsBackend::dump_database(NON_EXISTENT_FILE),
+    ASSERT_THROW(StatisticsBackend::dump_database(NON_EXISTENT_FILE,false),
             BadParameter);
 
     // Reset the backend and try loading a non existent file
     StatisticsBackend::reset();
     ASSERT_THROW(StatisticsBackend::load_database(NON_EXISTENT_FILE),
             BadParameter);
+}
+
+// Test the dump of a database with a clear of the statistics data
+TEST(backend_dump_tests, database_dump_and_clear)
+{
+    StatisticsBackend::load_database(SIMPLE_DUMP_FILE);
+
+    auto participants = details::StatisticsBackendData::get_instance()->database_->get_entities(EntityKind::PARTICIPANT,EntityId::all());
+    auto datawriters = details::StatisticsBackendData::get_instance()->database_->get_entities(EntityKind::DATAWRITER,EntityId::all());
+    auto datareaders = details::StatisticsBackendData::get_instance()->database_->get_entities(EntityKind::DATAREADER,EntityId::all());
+    auto locators = details::StatisticsBackendData::get_instance()->database_->get_entities(EntityKind::LOCATOR,EntityId::all());
+
+    // Check database contains statistics data
+    {
+        // Participants
+        for (const auto &it : participants)
+        {
+            auto participant = std::dynamic_pointer_cast<const DomainParticipant>(it);
+            ASSERT_FALSE(participant->data.discovered_entity.empty());
+            ASSERT_FALSE(participant->data.pdp_packets.empty());
+            ASSERT_FALSE(participant->data.edp_packets.empty());
+            ASSERT_FALSE(participant->data.rtps_packets_sent.empty());
+            ASSERT_FALSE(participant->data.rtps_bytes_sent.empty());
+            ASSERT_FALSE(participant->data.rtps_packets_lost.empty());
+            ASSERT_FALSE(participant->data.rtps_bytes_lost.empty());
+        }
+        // Datawriters
+        for (const auto &it : datawriters)
+        {
+            auto datawriter = std::dynamic_pointer_cast<const DataWriter>(it);
+            ASSERT_FALSE(datawriter->data.publication_throughput.empty());
+            ASSERT_FALSE(datawriter->data.resent_datas.empty());
+            ASSERT_FALSE(datawriter->data.heartbeat_count.empty());
+            ASSERT_FALSE(datawriter->data.gap_count.empty());
+            ASSERT_FALSE(datawriter->data.data_count.empty());
+            ASSERT_FALSE(datawriter->data.sample_datas.empty());
+        }
+        // Datareaders
+        for (const auto &it : datareaders)
+        {
+            auto datareader = std::dynamic_pointer_cast<const DataReader>(it);
+            ASSERT_FALSE(datareader->data.subscription_throughput.empty());
+            ASSERT_FALSE(datareader->data.acknack_count.empty());
+            ASSERT_FALSE(datareader->data.nackfrag_count.empty());
+        }
+        // Locators
+        for (const auto &it : locators)
+        {
+            auto locator = std::dynamic_pointer_cast<const Locator>(it);
+            ASSERT_FALSE(locator->data.network_latency_per_locator.empty());
+        }
+    }
+
+    // Check if the output file exists (we do not want to overwrite anything)
+    constexpr const char* TEST_DUMP_AND_CLEAR_FILE = "test_dump_and_clear.json";
+    std::ifstream file(TEST_DUMP_AND_CLEAR_FILE);
+    if (file.good())
+    {
+        FAIL() << "File " << TEST_DUMP_AND_CLEAR_FILE << " exists in the testing directory";
+        return;
+    }
+
+    // Dump the load
+    StatisticsBackend::dump_database(TEST_DUMP_AND_CLEAR_FILE,true);
+
+    // Check database does not contain statistics data
+    {
+        // Participants
+        for (const auto &it : participants)
+        {
+            auto participant = std::dynamic_pointer_cast<const DomainParticipant>(it);
+            ASSERT_TRUE(participant->data.discovered_entity.empty());
+            ASSERT_TRUE(participant->data.pdp_packets.empty());
+            ASSERT_TRUE(participant->data.edp_packets.empty());
+            ASSERT_TRUE(participant->data.rtps_packets_sent.empty());
+            ASSERT_TRUE(participant->data.rtps_bytes_sent.empty());
+            ASSERT_TRUE(participant->data.rtps_packets_lost.empty());
+            ASSERT_TRUE(participant->data.rtps_bytes_lost.empty());
+        }
+        // Datawriters
+        for (const auto &it : datawriters)
+        {
+            auto datawriter = std::dynamic_pointer_cast<const DataWriter>(it);
+            ASSERT_TRUE(datawriter->data.publication_throughput.empty());
+            ASSERT_TRUE(datawriter->data.resent_datas.empty());
+            ASSERT_TRUE(datawriter->data.heartbeat_count.empty());
+            ASSERT_TRUE(datawriter->data.gap_count.empty());
+            ASSERT_TRUE(datawriter->data.data_count.empty());
+            ASSERT_TRUE(datawriter->data.sample_datas.empty());
+        }
+        // Datareaders
+        for (const auto &it : datareaders)
+        {
+            auto datareader = std::dynamic_pointer_cast<const DataReader>(it);
+            ASSERT_TRUE(datareader->data.subscription_throughput.empty());
+            ASSERT_TRUE(datareader->data.acknack_count.empty());
+            ASSERT_TRUE(datareader->data.nackfrag_count.empty());
+        }
+        // Locators
+        for (const auto &it : locators)
+        {
+            auto locator = std::dynamic_pointer_cast<const Locator>(it);
+            ASSERT_TRUE(locator->data.network_latency_per_locator.empty());
+        }
+    }
+
+    // Remove the dump file
+    std::remove(TEST_DUMP_AND_CLEAR_FILE);
 }
 
 int main(

--- a/test/unittest/StatisticsBackend/BackendDumpTests.cpp
+++ b/test/unittest/StatisticsBackend/BackendDumpTests.cpp
@@ -130,6 +130,19 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_FALSE(participant->data.rtps_bytes_sent.empty());
             ASSERT_FALSE(participant->data.rtps_packets_lost.empty());
             ASSERT_FALSE(participant->data.rtps_bytes_lost.empty());
+
+            ASSERT_FALSE(participant->data.last_reported_rtps_packets_sent_count.empty());
+            ASSERT_FALSE(participant->data.last_reported_rtps_bytes_sent_count.empty());
+            ASSERT_FALSE(participant->data.last_reported_rtps_packets_lost_count.empty());
+            ASSERT_FALSE(participant->data.last_reported_rtps_bytes_lost_count.empty());
+            ASSERT_FALSE(participant->data.last_reported_pdp_packets.kind == DataKind::INVALID &&
+                    participant->data.last_reported_pdp_packets.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    participant->data.last_reported_edp_packets.count == 0);
+            ASSERT_FALSE(participant->data.last_reported_edp_packets.kind == DataKind::INVALID &&
+                    participant->data.last_reported_edp_packets.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    participant->data.last_reported_edp_packets.count == 0);
         }
         // Datawriters
         for (const auto& it : datawriters)
@@ -141,6 +154,23 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_FALSE(datawriter->data.gap_count.empty());
             ASSERT_FALSE(datawriter->data.data_count.empty());
             ASSERT_FALSE(datawriter->data.sample_datas.empty());
+
+            ASSERT_FALSE(datawriter->data.last_reported_resent_datas.kind == DataKind::INVALID &&
+                    datawriter->data.last_reported_resent_datas.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    datawriter->data.last_reported_resent_datas.count == 0);
+            ASSERT_FALSE(datawriter->data.last_reported_heartbeat_count.kind == DataKind::INVALID &&
+                    datawriter->data.last_reported_heartbeat_count.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    datawriter->data.last_reported_heartbeat_count.count == 0);
+            ASSERT_FALSE(datawriter->data.last_reported_gap_count.kind == DataKind::INVALID &&
+                    datawriter->data.last_reported_gap_count.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    datawriter->data.last_reported_gap_count.count == 0);
+            ASSERT_FALSE(datawriter->data.last_reported_data_count.kind == DataKind::INVALID &&
+                    datawriter->data.last_reported_data_count.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    datawriter->data.last_reported_data_count.count == 0);
         }
         // Datareaders
         for (const auto& it : datareaders)
@@ -149,6 +179,15 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_FALSE(datareader->data.subscription_throughput.empty());
             ASSERT_FALSE(datareader->data.acknack_count.empty());
             ASSERT_FALSE(datareader->data.nackfrag_count.empty());
+
+            ASSERT_FALSE(datareader->data.last_reported_acknack_count.kind == DataKind::INVALID &&
+                    datareader->data.last_reported_acknack_count.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    datareader->data.last_reported_acknack_count.count == 0);
+            ASSERT_FALSE(datareader->data.last_reported_nackfrag_count.kind == DataKind::INVALID &&
+                    datareader->data.last_reported_nackfrag_count.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    datareader->data.last_reported_nackfrag_count.count == 0);
         }
         // Locators
         for (const auto& it : locators)
@@ -183,6 +222,19 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_TRUE(participant->data.rtps_bytes_sent.empty());
             ASSERT_TRUE(participant->data.rtps_packets_lost.empty());
             ASSERT_TRUE(participant->data.rtps_bytes_lost.empty());
+
+            ASSERT_FALSE(participant->data.last_reported_rtps_packets_sent_count.empty());
+            ASSERT_FALSE(participant->data.last_reported_rtps_bytes_sent_count.empty());
+            ASSERT_FALSE(participant->data.last_reported_rtps_packets_lost_count.empty());
+            ASSERT_FALSE(participant->data.last_reported_rtps_bytes_lost_count.empty());
+            ASSERT_FALSE(participant->data.last_reported_pdp_packets.kind == DataKind::INVALID &&
+                    participant->data.last_reported_pdp_packets.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    participant->data.last_reported_edp_packets.count == 0);
+            ASSERT_FALSE(participant->data.last_reported_edp_packets.kind == DataKind::INVALID &&
+                    participant->data.last_reported_edp_packets.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    participant->data.last_reported_edp_packets.count == 0);
         }
         // Datawriters
         for (const auto& it : datawriters)
@@ -194,6 +246,23 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_TRUE(datawriter->data.gap_count.empty());
             ASSERT_TRUE(datawriter->data.data_count.empty());
             ASSERT_TRUE(datawriter->data.sample_datas.empty());
+
+            ASSERT_FALSE(datawriter->data.last_reported_resent_datas.kind == DataKind::INVALID &&
+                    datawriter->data.last_reported_resent_datas.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    datawriter->data.last_reported_resent_datas.count == 0);
+            ASSERT_FALSE(datawriter->data.last_reported_heartbeat_count.kind == DataKind::INVALID &&
+                    datawriter->data.last_reported_heartbeat_count.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    datawriter->data.last_reported_heartbeat_count.count == 0);
+            ASSERT_FALSE(datawriter->data.last_reported_gap_count.kind == DataKind::INVALID &&
+                    datawriter->data.last_reported_gap_count.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    datawriter->data.last_reported_gap_count.count == 0);
+            ASSERT_FALSE(datawriter->data.last_reported_data_count.kind == DataKind::INVALID &&
+                    datawriter->data.last_reported_data_count.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    datawriter->data.last_reported_data_count.count == 0);
         }
         // Datareaders
         for (const auto& it : datareaders)
@@ -202,6 +271,15 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_TRUE(datareader->data.subscription_throughput.empty());
             ASSERT_TRUE(datareader->data.acknack_count.empty());
             ASSERT_TRUE(datareader->data.nackfrag_count.empty());
+
+            ASSERT_FALSE(datareader->data.last_reported_acknack_count.kind == DataKind::INVALID &&
+                    datareader->data.last_reported_acknack_count.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    datareader->data.last_reported_acknack_count.count == 0);
+            ASSERT_FALSE(datareader->data.last_reported_nackfrag_count.kind == DataKind::INVALID &&
+                    datareader->data.last_reported_nackfrag_count.src_ts ==
+                    std::chrono::system_clock::time_point() &&
+                    datareader->data.last_reported_nackfrag_count.count == 0);
         }
         // Locators
         for (const auto& it : locators)

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -560,6 +560,7 @@ get_win32_path_dependencies(backend_dump_tests TEST_FRIENDLY_PATH)
 
 set(BACKEND_DUMP_TEST_LIST
     database_dump_load
+    database_dump_and_clear
     reset
     )
 


### PR DESCRIPTION
- `dump_database()` now take the mutex at the start of the method. We forgot it on `dump` PR.
- Because the added parameter to `dump_database()`:
    - Updated `database_dump_load` test.
    - Updated documentation of dump