### PR TITLE
Data referring locator entities are not correctly inserted in database [11959]

### DIFF
--- a/include/fastdds_statistics_backend/listener/DomainListener.hpp
+++ b/include/fastdds_statistics_backend/listener/DomainListener.hpp
@@ -168,7 +168,9 @@ public:
     /*!
      * This function is called when a new data sample is available.
      *
-     * @param domain_id Entity ID of the domain to which the data belongs.
+     * @param domain_id Entity ID of the domain to which the data belongs. If data_kind is NETWORK_LATENCY,
+     * this id is EntityId::invalid(), because this data_kind came from a locator,
+     * and locators are not associated with any domain.
      * @param entity_id Entity ID of the entity to which the data refers.
      * @param data_kind Data kind of the received data.
      */

--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -101,7 +101,7 @@ void StatisticsBackendData::on_data_available(
         EntityId entity_id,
         DataKind data_kind)
 {
-    // If data_kind is of type NETWORK_LATENCY, the domain_id is not knew,
+    // If data_kind is of type NETWORK_LATENCY, the domain_id is not known,
     // because this data came from a locator, and locators are not associated with any domain.
     if (data_kind == DataKind::NETWORK_LATENCY )
     {

--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -101,16 +101,28 @@ void StatisticsBackendData::on_data_available(
         EntityId entity_id,
         DataKind data_kind)
 {
-    auto monitor = monitors_by_entity_.find(domain_id);
-    assert(monitor != monitors_by_entity_.end());
-
-    if (should_call_domain_listener(monitor->second, CallbackKind::ON_DATA_AVAILABLE, data_kind))
+    // If data_kind is of type NETWORK_LATENCY, the domain_id is not knew,
+    // because this data came from a locator, and locators are not associated with any domain.
+    if (data_kind == DataKind::NETWORK_LATENCY )
     {
-        monitor->second->domain_listener->on_data_available(domain_id, entity_id, data_kind);
+        if (should_call_physical_listener(CallbackKind::ON_DATA_AVAILABLE, data_kind))
+        {
+            physical_listener_->on_data_available(EntityId::invalid(), entity_id, data_kind);
+        }
     }
-    else if (should_call_physical_listener(CallbackKind::ON_DATA_AVAILABLE, data_kind))
+    else
     {
-        physical_listener_->on_data_available(domain_id, entity_id, data_kind);
+        auto monitor = monitors_by_entity_.find(domain_id);
+        assert(monitor != monitors_by_entity_.end());
+
+        if (should_call_domain_listener(monitor->second, CallbackKind::ON_DATA_AVAILABLE, data_kind))
+        {
+            monitor->second->domain_listener->on_data_available(domain_id, entity_id, data_kind);
+        }
+        else if (should_call_physical_listener(CallbackKind::ON_DATA_AVAILABLE, data_kind))
+        {
+            physical_listener_->on_data_available(domain_id, entity_id, data_kind);
+        }
     }
 }
 

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -537,29 +537,17 @@ void Database::insert_nts(
         {
             /* Check that the entity is a known locator */
             auto locator_it = locators_.find(entity_id);
-            if (locator_it != locators_.end())
-            {
-                const NetworkLatencySample& network_latency = dynamic_cast<const NetworkLatencySample&>(sample);
-                /* Check that the remote entity is a known locator */
-                if (locators_.find(network_latency.remote_locator) != locators_.end())
-                {
-                    locator_it->second->data.network_latency_per_locator[network_latency.remote_locator].push_back(
-                        network_latency);
-                }
-                else
-                {
-                    throw BadParameter(std::to_string(
-                                      network_latency.remote_locator.value()) +
-                                  " does not refer to a known locator");
-                }
+            assert(locator_it != locators_.end());
 
-                break;
-            }
-            else
-            {
-                throw BadParameter(std::to_string(
-                                  entity_id.value()) + " does not refer to a known locator");
-            }
+            const NetworkLatencySample& network_latency = dynamic_cast<const NetworkLatencySample&>(sample);
+
+            /* Check that the remote entity is a known locator */
+            assert(locators_.find(network_latency.remote_locator) != locators_.end());
+
+            locator_it->second->data.network_latency_per_locator[network_latency.remote_locator].push_back(
+                network_latency);
+
+            break;
         }
         case DataKind::PUBLICATION_THROUGHPUT:
         {

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -71,20 +71,35 @@ void DatabaseDataQueue::process_sample_type(
     sample.data = item.data();
     std::string remote_locator = deserialize_locator(item.dst_locator());
     auto found_remote_locators = database_->get_entities_by_name(EntityKind::LOCATOR, remote_locator);
+
+    // If the remote locator has not been discovered, create it
     if (found_remote_locators.empty())
     {
-        throw Error("Locator " + remote_locator + " not found");
+        // Give him a unique name
+        std::shared_ptr<Locator> locator = std::make_shared<Locator>(remote_locator);
+        sample.remote_locator =  database_->insert(locator);
     }
-    sample.remote_locator = found_remote_locators.front().second;
+    else
+    {
+        sample.remote_locator = found_remote_locators.front().second;
+    }
 
     std::string source_locator = deserialize_locator(item.src_locator());
     auto found_entities = database_->get_entities_by_name(entity_kind, source_locator);
+
+    // If the source locator has not been discovered, create it
     if (found_entities.empty())
     {
-        throw Error("Entity " + source_locator + " not found");
+        // Give him a unique name
+        std::shared_ptr<Locator> locator = std::make_shared<Locator>(source_locator);
+        domain = EntityId::invalid();
+        entity = database_->insert(locator);
     }
-    domain = found_entities.front().first;
-    entity = found_entities.front().second;
+    else
+    {
+        domain = found_entities.front().first;
+        entity = found_entities.front().second;
+    }
 }
 
 template<>

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -1767,30 +1767,40 @@ TEST_F(database_tests, insert_sample_network_latency)
 
 TEST_F(database_tests, insert_sample_network_latency_unknown_locator)
 {
+#ifndef NDEBUG
+
     NetworkLatencySample sample;
     sample.remote_locator = reader_locator->id;
     sample.data = 12;
 
     EntityId locator_id = db.generate_entity_id();
     ASSERT_THROW(db.get_entity(locator_id), BadParameter);
-    ASSERT_THROW(db.insert(domain_id, locator_id, sample), BadParameter);
+    ASSERT_DEATH(db.insert(domain_id, locator_id, sample), "");
     ASSERT_THROW(db.get_entity(locator_id), BadParameter);
+
+#endif // ifndef NDEBUG
 }
 
 TEST_F(database_tests, insert_sample_network_latency_unknown_remote_locator)
 {
+#ifndef NDEBUG
+
     NetworkLatencySample sample;
     EntityId remote_id = db.generate_entity_id();
     sample.remote_locator = remote_id;
     sample.data = 12;
 
     ASSERT_THROW(db.get_entity(remote_id), BadParameter);
-    ASSERT_THROW(db.insert(domain_id, writer_locator->id, sample), BadParameter);
+    ASSERT_DEATH(db.insert(domain_id, writer_locator->id, sample), "");
     ASSERT_THROW(db.get_entity(remote_id), BadParameter);
+
+#endif // ifndef NDEBUG
 }
 
 TEST_F(database_tests, insert_sample_network_latency_unknown_both_locators)
 {
+#ifndef NDEBUG
+
     NetworkLatencySample sample;
     EntityId remote_id = db.generate_entity_id();
     sample.remote_locator = remote_id;
@@ -1799,9 +1809,11 @@ TEST_F(database_tests, insert_sample_network_latency_unknown_both_locators)
     EntityId locator_id = db.generate_entity_id();
     ASSERT_THROW(db.get_entity(remote_id), BadParameter);
     ASSERT_THROW(db.get_entity(locator_id), BadParameter);
-    ASSERT_THROW(db.insert(domain_id, locator_id, sample), BadParameter);
+    ASSERT_DEATH(db.insert(domain_id, locator_id, sample), "");
     ASSERT_THROW(db.get_entity(locator_id), BadParameter);
     ASSERT_THROW(db.get_entity(remote_id), BadParameter);
+
+#endif // ifndef NDEBUG
 }
 
 TEST_F(database_tests, insert_sample_publication_throughput)
@@ -2310,8 +2322,10 @@ TEST_F(database_tests, insert_sample_valid_wrong_domain)
     HistoryLatencySample history_lantency_sample;
     ASSERT_THROW(db.insert(db.generate_entity_id(), writer_id, history_lantency_sample), BadParameter);
 
+#ifndef NDEBUG
     NetworkLatencySample network_lantency_sample;
-    ASSERT_THROW(db.insert(db.generate_entity_id(), writer_locator->id, network_lantency_sample), BadParameter);
+    ASSERT_DEATH(db.insert(db.generate_entity_id(), writer_locator->id, network_lantency_sample), "");
+#endif // ifndef NDEBUG
 
     PublicationThroughputSample pub_throughput_sample;
     ASSERT_THROW(db.insert(db.generate_entity_id(), writer_id, pub_throughput_sample), BadParameter);

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -1773,13 +1773,8 @@ TEST_F(database_tests, insert_sample_network_latency_unknown_locator)
 
     EntityId locator_id = db.generate_entity_id();
     ASSERT_THROW(db.get_entity(locator_id), BadParameter);
-    ASSERT_NO_THROW(db.insert(domain_id, locator_id, sample));
-    ASSERT_NO_THROW(db.get_entity(locator_id));
-    auto locator = db.locators().at(locator_id);
-
-    ASSERT_EQ(locator->data.network_latency_per_locator[reader_locator->id].size(), 1);
-    ASSERT_EQ(locator->data.network_latency_per_locator[reader_locator->id][0],
-            static_cast<EntityDataSample>(sample));
+    ASSERT_THROW(db.insert(domain_id, locator_id, sample), BadParameter);
+    ASSERT_THROW(db.get_entity(locator_id), BadParameter);
 }
 
 TEST_F(database_tests, insert_sample_network_latency_unknown_remote_locator)
@@ -1790,12 +1785,8 @@ TEST_F(database_tests, insert_sample_network_latency_unknown_remote_locator)
     sample.data = 12;
 
     ASSERT_THROW(db.get_entity(remote_id), BadParameter);
-    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample));
-    ASSERT_NO_THROW(db.get_entity(remote_id));
-
-    ASSERT_EQ(writer_locator->data.network_latency_per_locator[remote_id].size(), 1);
-    ASSERT_EQ(writer_locator->data.network_latency_per_locator[remote_id][0],
-            static_cast<EntityDataSample>(sample));
+    ASSERT_THROW(db.insert(domain_id, writer_locator->id, sample), BadParameter);
+    ASSERT_THROW(db.get_entity(remote_id), BadParameter);
 }
 
 TEST_F(database_tests, insert_sample_network_latency_unknown_both_locators)
@@ -1808,14 +1799,9 @@ TEST_F(database_tests, insert_sample_network_latency_unknown_both_locators)
     EntityId locator_id = db.generate_entity_id();
     ASSERT_THROW(db.get_entity(remote_id), BadParameter);
     ASSERT_THROW(db.get_entity(locator_id), BadParameter);
-    ASSERT_NO_THROW(db.insert(domain_id, locator_id, sample));
-    ASSERT_NO_THROW(db.get_entity(locator_id));
-    ASSERT_NO_THROW(db.get_entity(remote_id));
-    auto locator = db.locators().at(locator_id);
-
-    ASSERT_EQ(locator->data.network_latency_per_locator[remote_id].size(), 1);
-    ASSERT_EQ(locator->data.network_latency_per_locator[remote_id][0],
-            static_cast<EntityDataSample>(sample));
+    ASSERT_THROW(db.insert(domain_id, locator_id, sample), BadParameter);
+    ASSERT_THROW(db.get_entity(locator_id), BadParameter);
+    ASSERT_THROW(db.get_entity(remote_id), BadParameter);
 }
 
 TEST_F(database_tests, insert_sample_publication_throughput)
@@ -2325,7 +2311,7 @@ TEST_F(database_tests, insert_sample_valid_wrong_domain)
     ASSERT_THROW(db.insert(db.generate_entity_id(), writer_id, history_lantency_sample), BadParameter);
 
     NetworkLatencySample network_lantency_sample;
-    ASSERT_NO_THROW(db.insert(db.generate_entity_id(), writer_locator->id, network_lantency_sample));
+    ASSERT_THROW(db.insert(db.generate_entity_id(), writer_locator->id, network_lantency_sample), BadParameter);
 
     PublicationThroughputSample pub_throughput_sample;
     ASSERT_THROW(db.insert(db.generate_entity_id(), writer_id, pub_throughput_sample), BadParameter);

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -1767,40 +1767,35 @@ TEST_F(database_tests, insert_sample_network_latency)
 
 TEST_F(database_tests, insert_sample_network_latency_unknown_locator)
 {
-#ifndef NDEBUG
-
     NetworkLatencySample sample;
     sample.remote_locator = reader_locator->id;
     sample.data = 12;
 
     EntityId locator_id = db.generate_entity_id();
     ASSERT_THROW(db.get_entity(locator_id), BadParameter);
+#ifndef NDEBUG
     ASSERT_DEATH(db.insert(domain_id, locator_id, sample), "");
+#endif // ifndef NDEBUG
     ASSERT_THROW(db.get_entity(locator_id), BadParameter);
 
-#endif // ifndef NDEBUG
 }
 
 TEST_F(database_tests, insert_sample_network_latency_unknown_remote_locator)
 {
-#ifndef NDEBUG
-
     NetworkLatencySample sample;
     EntityId remote_id = db.generate_entity_id();
     sample.remote_locator = remote_id;
     sample.data = 12;
 
     ASSERT_THROW(db.get_entity(remote_id), BadParameter);
+#ifndef NDEBUG
     ASSERT_DEATH(db.insert(domain_id, writer_locator->id, sample), "");
-    ASSERT_THROW(db.get_entity(remote_id), BadParameter);
-
 #endif // ifndef NDEBUG
+    ASSERT_THROW(db.get_entity(remote_id), BadParameter);
 }
 
 TEST_F(database_tests, insert_sample_network_latency_unknown_both_locators)
 {
-#ifndef NDEBUG
-
     NetworkLatencySample sample;
     EntityId remote_id = db.generate_entity_id();
     sample.remote_locator = remote_id;
@@ -1809,11 +1804,11 @@ TEST_F(database_tests, insert_sample_network_latency_unknown_both_locators)
     EntityId locator_id = db.generate_entity_id();
     ASSERT_THROW(db.get_entity(remote_id), BadParameter);
     ASSERT_THROW(db.get_entity(locator_id), BadParameter);
+#ifndef NDEBUG
     ASSERT_DEATH(db.insert(domain_id, locator_id, sample), "");
+#endif // ifndef NDEBUG
     ASSERT_THROW(db.get_entity(locator_id), BadParameter);
     ASSERT_THROW(db.get_entity(remote_id), BadParameter);
-
-#endif // ifndef NDEBUG
 }
 
 TEST_F(database_tests, insert_sample_publication_throughput)

--- a/test/unittest/DatabaseQueue/CMakeLists.txt
+++ b/test/unittest/DatabaseQueue/CMakeLists.txt
@@ -74,6 +74,7 @@ if(GTEST_FOUND AND GMOCK_FOUND)
         push_network_latency
         push_network_latency_no_source_locator
         push_network_latency_no_destination_locator
+        push_network_latency_no_locators
         push_publication_throughput
         push_publication_throughput_no_writer
         push_subscription_throughput

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -297,7 +297,6 @@ set(INIT_MONITOR_TEST_LIST
     init_monitor_several_monitors
     init_monitor_twice
     stop_monitor
-    monitor_data
     )
 
 foreach(test_name ${INIT_MONITOR_TEST_LIST})

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -297,6 +297,7 @@ set(INIT_MONITOR_TEST_LIST
     init_monitor_several_monitors
     init_monitor_twice
     stop_monitor
+    monitor_data
     )
 
 foreach(test_name ${INIT_MONITOR_TEST_LIST})

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -197,10 +197,10 @@ public:
                 EntityId,
                 EntityId,
                 const DomainListener::Status&)
-    {
-    },
+            {
+            },
             details::StatisticsBackendData::DiscoveryStatus const& discovery_status
-            = details::StatisticsBackendData::DISCOVERY)
+                = details::StatisticsBackendData::DISCOVERY)
     {
         // Set the callback of the expectations
         discovery_args_.callback_ = checker;
@@ -530,8 +530,8 @@ public:
                 EntityId,
                 EntityId,
                 const DomainListener::Status&)
-    {
-    })
+            {
+            })
     {
         // Set the callback of the expectations
         discovery_args_.callback_ = checker;
@@ -1214,14 +1214,30 @@ public:
 
         if (listener_kind == PHYSICAL)
         {
-            EXPECT_CALL(physical_listener_, on_data_available(monitor_id_, EntityId(1), data_kind_)).Times(1);
+            if (data_kind_ != DataKind::NETWORK_LATENCY)
+            {
+                EXPECT_CALL(physical_listener_, on_data_available(monitor_id_, EntityId(1), data_kind_)).Times(1);
+            }
+            else
+            {
+                EXPECT_CALL(physical_listener_,
+                        on_data_available(EntityId::invalid(), EntityId(1), data_kind_)).Times(1);
+            }
             EXPECT_CALL(domain_listener_, on_data_available(_, _, _)).Times(0);
-
         }
         else if (listener_kind == DOMAIN)
         {
-            EXPECT_CALL(physical_listener_, on_data_available(_, _, _)).Times(0);
-            EXPECT_CALL(domain_listener_, on_data_available(monitor_id_, EntityId(1), data_kind_)).Times(1);
+            if (data_kind_ != DataKind::NETWORK_LATENCY)
+            {
+                EXPECT_CALL(physical_listener_, on_data_available(_, _, _)).Times(0);
+                EXPECT_CALL(domain_listener_, on_data_available(monitor_id_, EntityId(1), data_kind_)).Times(1);
+            }
+            else
+            {
+                EXPECT_CALL(physical_listener_,
+                        on_data_available(EntityId::invalid(), EntityId(1), data_kind_)).Times(1);
+                EXPECT_CALL(domain_listener_, on_data_available(_, _, _)).Times(0);
+            }
         }
         else
         {

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -197,10 +197,10 @@ public:
                 EntityId,
                 EntityId,
                 const DomainListener::Status&)
-            {
-            },
+    {
+    },
             details::StatisticsBackendData::DiscoveryStatus const& discovery_status
-                = details::StatisticsBackendData::DISCOVERY)
+            = details::StatisticsBackendData::DISCOVERY)
     {
         // Set the callback of the expectations
         discovery_args_.callback_ = checker;
@@ -530,8 +530,8 @@ public:
                 EntityId,
                 EntityId,
                 const DomainListener::Status&)
-            {
-            })
+    {
+    })
     {
         // Set the callback of the expectations
         discovery_args_.callback_ = checker;


### PR DESCRIPTION
Draft until  Metatraffic topic and endpoints [11706] #80 is merged.

When merged, we can insert correctly the RTPS datas, but the NETWORK_LATENCY still needs the refactor of the locators