### PR TITLE
Refactor network latency data [12033]

### DIFF
--- a/docs/rst/statistics_backend/get_data.rst
+++ b/docs/rst/statistics_backend/get_data.rst
@@ -31,7 +31,7 @@ The following table illustrates the expected inputs depending on the query's |Da
 +===============================+====================================+====================================+
 | |FASTDDS_LATENCY-api|         | |DATAWRITER-api|                   | |DATAREADER-api|                   |
 +-------------------------------+------------------------------------+------------------------------------+
-| |NETWORK_LATENCY-api|         | |LOCATOR-api|                      | |LOCATOR-api|                      |
+| |NETWORK_LATENCY-api|         | |PARTICIPANT-api|                  | |LOCATOR-api|                      |
 +-------------------------------+------------------------------------+------------------------------------+
 | |PUBLICATION_THROUGHPUT-api|  | |DATAWRITER-api|                   | Not applicable                     |
 +-------------------------------+------------------------------------+------------------------------------+

--- a/include/fastdds_statistics_backend/types/types.hpp
+++ b/include/fastdds_statistics_backend/types/types.hpp
@@ -146,7 +146,7 @@ enum class EntityKind
  *     | Signature               | Entities source   | Entity target | No. entities |
  *     |-------------------------|-------------------|---------------|--------------|
  *     | FASTDDS_LATENCY         | DataWriter        | DataReader    | 2            |
- *     | NETWORK_LATENCY         | Locator           | Locator       | 2            |
+ *     | NETWORK_LATENCY         | DomainParticipant | Locator       | 2            |
  *     | PUBLICATION_THROUGHPUT  | DataWriter        |               | 1            |
  *     | SUBSCRIPTION_THROUGHPUT | DataReader        |               | 1            |
  *     | RTPS_PACKETS_SENT       | DomainParticipant | Locator       | 2            |

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -818,7 +818,7 @@ std::vector<std::pair<EntityKind, EntityKind>> StatisticsBackend::get_data_suppo
              {std::pair<EntityKind, EntityKind> (EntityKind::DATAWRITER, EntityKind::DATAREADER)})},
 
         {DataKind::NETWORK_LATENCY, std::vector<std::pair<EntityKind, EntityKind>>(
-             {std::pair<EntityKind, EntityKind> (EntityKind::LOCATOR, EntityKind::LOCATOR)})},
+             {std::pair<EntityKind, EntityKind> (EntityKind::PARTICIPANT, EntityKind::LOCATOR)})},
 
         {DataKind::PUBLICATION_THROUGHPUT, std::vector<std::pair<EntityKind, EntityKind>>(
              {std::pair<EntityKind, EntityKind> (EntityKind::DATAWRITER, EntityKind::INVALID)})},

--- a/src/cpp/database/data.cpp
+++ b/src/cpp/database/data.cpp
@@ -26,6 +26,7 @@ void DomainParticipantData::clear(
     discovered_entity.clear();
     pdp_packets.clear();
     edp_packets.clear();
+    network_latency_per_locator.clear();
     if (clear_last_reported)
     {
         last_reported_pdp_packets.clear();
@@ -79,11 +80,6 @@ void DataWriterData::clear(
         last_reported_gap_count.clear();
         last_reported_data_count.clear();
     }
-}
-
-void LocatorData::clear()
-{
-    network_latency_per_locator.clear();
 }
 
 } //namespace database

--- a/src/cpp/database/data.hpp
+++ b/src/cpp/database/data.hpp
@@ -161,7 +161,7 @@ struct DomainParticipantData : RTPSData
     /*
      * Data reported by topic: eprosima::fastdds::statistics::NETWORK_LATENCY_TOPIC
      *
-     * Store the reported latencies between the local and remote locator, identified by its
+     * Store the reported latencies between the participant and remote locator, identified by its
      * EntityId.
      */
     std::map<EntityId, std::vector<EntityDataSample>> network_latency_per_locator;

--- a/src/cpp/database/data.hpp
+++ b/src/cpp/database/data.hpp
@@ -157,6 +157,14 @@ struct DomainParticipantData : RTPSData
      * This is done to speed up the calculation of the entries in edp_packets
      */
     EntityCountSample last_reported_edp_packets;
+
+    /*
+     * Data reported by topic: eprosima::fastdds::statistics::NETWORK_LATENCY_TOPIC
+     *
+     * Store the reported latencies between the local and remote locator, identified by its
+     * EntityId.
+     */
+    std::map<EntityId, std::vector<EntityDataSample>> network_latency_per_locator;
 };
 
 /*
@@ -291,25 +299,6 @@ struct DataWriterData
      * EntityId) histories.
      */
     std::map<EntityId, std::vector<EntityDataSample>> history2history_latency;
-};
-
-/*
- * Data related to a locator
- */
-struct LocatorData
-{
-    /**
-     * Clear the vectors and maps, and set the counts to zero
-     */
-    void clear();
-
-    /*
-     * Data reported by topic: eprosima::fastdds::statistics::NETWORK_LATENCY_TOPIC
-     *
-     * Store the reported latencies between the local and remote locator, identified by its
-     * EntityId.
-     */
-    std::map<EntityId, std::vector<EntityDataSample>> network_latency_per_locator;
 };
 
 } //namespace database

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -2803,6 +2803,9 @@ DatabaseDump Database::dump_entity_(
         // rtps_bytes_lost
         data[DATA_KIND_RTPS_BYTES_LOST_TAG] = dump_data_(entity->data.rtps_bytes_lost);
 
+        // network_latency_per_locator
+        data[DATA_KIND_NETWORK_LATENCY_TAG] = dump_data_(entity->data.network_latency_per_locator);
+
         // pdp_packets last reported
         data[DATA_KIND_PDP_PACKETS_LAST_REPORTED_TAG] = dump_data_(entity->data.last_reported_pdp_packets);
 
@@ -2970,16 +2973,6 @@ DatabaseDump Database::dump_entity_(
             subentities.push_back(id_to_string(sub_it.first));
         }
         entity_info[DATAREADER_CONTAINER_TAG] = subentities;
-    }
-
-    // Store data from the entity
-    {
-        DatabaseDump data = DatabaseDump::object();
-
-        // network_latency_per_locator
-        data[DATA_KIND_NETWORK_LATENCY_TAG] = dump_data_(entity->data.network_latency_per_locator);
-
-        entity_info[DATA_CONTAINER_TAG] = data;
     }
 
     return entity_info;

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -550,7 +550,7 @@ void Database::insert_nts(
             {
                 const NetworkLatencySample& network_latency = dynamic_cast<const NetworkLatencySample&>(sample);
                 participant->data.network_latency_per_locator[network_latency.remote_locator].push_back(
-                        network_latency);
+                    network_latency);
                 break;
             }
             throw BadParameter(std::to_string(

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -3316,9 +3316,6 @@ void Database::load_database(
             // Insert into database
             EntityId entity_id = EntityId(string_to_int(it.key()));
             insert_nts(entity, entity_id);
-
-            // Load data and insert into database
-            load_data((*it).at(DATA_CONTAINER_TAG), entity);
         }
     }
 
@@ -3779,6 +3776,34 @@ void Database::load_data(
                 // int16_t
                 sample.magnitude_order =
                         static_cast<int16_t>(string_to_int(to_string((*it).at(DATA_VALUE_MAGNITUDE_TAG))));
+
+                // EntityId
+                sample.remote_locator = EntityId(string_to_int(remote_it.key()));
+
+                // Insert data into database
+                insert_nts(entity->domain->id, entity->id, sample, true);
+            }
+        }
+    }
+
+    // network_latency
+    {
+        DatabaseDump container = dump.at(DATA_KIND_NETWORK_LATENCY_TAG);
+
+        // RemoteEntities iterator
+        for (auto remote_it = container.begin(); remote_it != container.end(); ++remote_it)
+        {
+            // Data iterator
+            for (auto it = container.at(remote_it.key()).begin(); it != container.at(remote_it.key()).end(); ++it)
+            {
+                NetworkLatencySample sample;
+
+                // std::chrono::system_clock::time_point
+                uint64_t time = string_to_uint((*it).at(DATA_VALUE_SRC_TIME_TAG));
+                sample.src_ts = nanoseconds_to_systemclock(time);
+
+                // double
+                sample.data = (*it).at(DATA_VALUE_DATA_TAG);
 
                 // EntityId
                 sample.remote_locator = EntityId(string_to_int(remote_it.key()));
@@ -4296,39 +4321,6 @@ void Database::load_data(
 
             // Insert data into database
             insert_nts(entity->participant->domain->id, entity->id, sample, true, true);
-        }
-    }
-}
-
-void Database::load_data(
-        const DatabaseDump& dump,
-        const std::shared_ptr<Locator>& entity)
-{
-    // NetworkLatency
-    {
-        DatabaseDump container = dump.at(DATA_KIND_NETWORK_LATENCY_TAG);
-
-        // RemoteEntities iterator
-        for (auto remote_it = container.begin(); remote_it != container.end(); ++remote_it)
-        {
-            // Data iterator
-            for (auto it = container.at(remote_it.key()).begin(); it != container.at(remote_it.key()).end(); ++it)
-            {
-                NetworkLatencySample sample;
-
-                // std::chrono::system_clock::time_point
-                uint64_t time = string_to_uint((*it).at(DATA_VALUE_SRC_TIME_TAG));
-                sample.src_ts = nanoseconds_to_systemclock(time);
-
-                // double
-                sample.data = (*it).at(DATA_VALUE_DATA_TAG);
-
-                // EntityId
-                sample.remote_locator = EntityId(string_to_int(remote_it.key()));
-
-                // Insert data into database
-                insert_nts(EntityId::invalid(), entity->id, sample, true);
-            }
         }
     }
 }

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -3218,11 +3218,6 @@ void Database::clear_statistics_data()
             it.second->data.clear(false);
         }
     }
-    // Locators
-    for (const auto& it : locators_)
-    {
-        it.second->data.clear();
-    }
 }
 
 /**

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1494,12 +1494,12 @@ std::vector<const StatisticsSample*> Database::select(
         }
         case DataKind::NETWORK_LATENCY:
         {
-            assert(EntityKind::LOCATOR == source_entity->kind);
+            assert(EntityKind::PARTICIPANT == source_entity->kind);
             assert(EntityKind::LOCATOR == target_entity->kind);
-            auto locator = std::static_pointer_cast<const Locator>(source_entity);
-            /* Look if the locator has information about the required locator */
-            auto remote_locator = locator->data.network_latency_per_locator.find(entity_id_target);
-            if (remote_locator != locator->data.network_latency_per_locator.end())
+            auto participant = std::static_pointer_cast<const DomainParticipant>(source_entity);
+            /* Look if the participant has information about the required locator */
+            auto remote_locator = participant->data.network_latency_per_locator.find(entity_id_target);
+            if (remote_locator != participant->data.network_latency_per_locator.end())
             {
                 /* Look for the samples between the given timestamps */
                 for (auto& sample : remote_locator->second)

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -544,18 +544,18 @@ void Database::insert_nts(
         }
         case DataKind::NETWORK_LATENCY:
         {
-            const NetworkLatencySample& network_latency = dynamic_cast<const NetworkLatencySample&>(sample);
-
-            // Create locator if it does not exist
-            std::shared_ptr<Locator> locator = get_locator_nts(entity_id);
-
-            // Create remote_locator if it does not exist
-            get_locator_nts(network_latency.remote_locator);
-
-            // Add the info to the locator
-            locator->data.network_latency_per_locator[network_latency.remote_locator].push_back(network_latency);
-
-            break;
+            /* Check that the entity is a known participant */
+            auto participant = participants_[domain_id][entity_id];
+            if (participant)
+            {
+                const NetworkLatencySample& network_latency = dynamic_cast<const NetworkLatencySample&>(sample);
+                participant->data.network_latency_per_locator[network_latency.remote_locator].push_back(
+                        network_latency);
+                break;
+            }
+            throw BadParameter(std::to_string(
+                              entity_id.value()) + " does not refer to a known participant in domain " + std::to_string(
+                              domain_id.value()));
         }
         case DataKind::PUBLICATION_THROUGHPUT:
         {

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -710,9 +710,6 @@ protected:
     void load_data(
             const DatabaseDump& dump,
             const std::shared_ptr<DataReader>& entity);
-    void load_data(
-            const DatabaseDump& dump,
-            const std::shared_ptr<Locator>& entity);
 
     /**
      * Change the status (active/inactive) of an entity given an EntityId.

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -76,9 +76,16 @@ void DatabaseDataQueue::process_sample_type(
     {
         std::shared_ptr<Locator> locator = std::make_shared<Locator>(remote_locator);
         locator->id = database_->insert(locator);
-        found_remote_locators = database_->get_entities_by_name(EntityKind::LOCATOR, remote_locator);
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                locator->id,
+                EntityKind::LOCATOR,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        sample.remote_locator = locator->id;
     }
-    sample.remote_locator = found_remote_locators.front().second;
+    else
+    {
+        sample.remote_locator = found_remote_locators.front().second;
+    }
 
     std::string source_locator = deserialize_guid(item.src_locator());
     // This call will throw BadParameter if there is no such entity

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -71,20 +71,21 @@ void DatabaseDataQueue::process_sample_type(
     sample.data = item.data();
     std::string remote_locator = deserialize_locator(item.dst_locator());
     auto found_remote_locators = database_->get_entities_by_name(EntityKind::LOCATOR, remote_locator);
+    // In case that the reported locator is not known, create it without being linked to an endpoint
     if (found_remote_locators.empty())
     {
-        throw Error("Locator " + remote_locator + " not found");
+        std::shared_ptr<Locator> locator = std::make_shared<Locator>(remote_locator);
+        locator->id = database_->insert(locator);
+        found_remote_locators = database_->get_entities_by_name(EntityKind::LOCATOR, remote_locator);
     }
     sample.remote_locator = found_remote_locators.front().second;
 
-    std::string source_locator = deserialize_locator(item.src_locator());
-    auto found_entities = database_->get_entities_by_name(entity_kind, source_locator);
-    if (found_entities.empty())
-    {
-        throw Error("Entity " + source_locator + " not found");
-    }
-    domain = found_entities.front().first;
-    entity = found_entities.front().second;
+    std::string source_locator = deserialize_guid(item.src_locator());
+    // This call will throw BadParameter if there is no such entity
+    // We let this exception through, as it meets expectations
+    auto found_entities = database_->get_entity_by_guid(entity_kind, source_locator);
+    domain = found_entities.first;
+    entity = found_entities.second;
 }
 
 template<>
@@ -287,7 +288,8 @@ void DatabaseDataQueue::process_sample()
             sample.src_ts = item.first;
             try
             {
-                process_sample_type(domain, entity, EntityKind::LOCATOR, sample, item.second->locator2locator_data());
+                process_sample_type(domain, entity, EntityKind::PARTICIPANT, sample,
+                        item.second->locator2locator_data());
                 database_->insert(domain, entity, sample);
                 details::StatisticsBackendData::get_instance()->on_data_available(domain, entity,
                         DataKind::NETWORK_LATENCY);

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -77,9 +77,9 @@ void DatabaseDataQueue::process_sample_type(
         std::shared_ptr<Locator> locator = std::make_shared<Locator>(remote_locator);
         locator->id = database_->insert(locator);
         details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                locator->id,
-                EntityKind::LOCATOR,
-                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+            locator->id,
+            EntityKind::LOCATOR,
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
         sample.remote_locator = locator->id;
     }
     else

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -479,6 +479,22 @@ protected:
         return ss.str();
     }
 
+    std::string deserialize_guid(
+            StatisticsLocator data) const
+    {
+        if (data.port() != 0)
+        {
+            throw Error("Wrong format: src_locator.port must be 0");
+        }
+        eprosima::fastrtps::rtps::GUID_t guid;
+        memcpy(guid.guidPrefix.value, data.address().data(), eprosima::fastrtps::rtps::GuidPrefix_t::size);
+        memcpy(guid.entityId.value, data.address().data() + eprosima::fastrtps::rtps::GuidPrefix_t::size,
+            eprosima::fastrtps::rtps::EntityId_t::size);
+        std::stringstream ss;
+        ss << guid;
+        return ss.str();
+    }
+
     std::string deserialize_locator(
             StatisticsLocator data) const
     {

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -489,7 +489,7 @@ protected:
         eprosima::fastrtps::rtps::GUID_t guid;
         memcpy(guid.guidPrefix.value, data.address().data(), eprosima::fastrtps::rtps::GuidPrefix_t::size);
         memcpy(guid.entityId.value, data.address().data() + eprosima::fastrtps::rtps::GuidPrefix_t::size,
-            eprosima::fastrtps::rtps::EntityId_t::size);
+                eprosima::fastrtps::rtps::EntityId_t::size);
         std::stringstream ss;
         ss << guid;
         return ss.str();

--- a/src/cpp/database/entities.cpp
+++ b/src/cpp/database/entities.cpp
@@ -67,7 +67,6 @@ void Locator::clear()
 {
     data_readers.clear();
     data_writers.clear();
-    data.clear();
 }
 
 template<>

--- a/src/cpp/database/entities.hpp
+++ b/src/cpp/database/entities.hpp
@@ -428,9 +428,6 @@ struct Locator : Entity
      * The collection is ordered by the EntityId of the DataWriter nodes.
      */
     std::map<EntityId, std::shared_ptr<DataWriter>> data_writers;
-
-    //! Actual statistical data reported by Fast DDS Statistics Module regarding this locator.
-    LocatorData data;
 };
 
 } //namespace database

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -130,7 +130,6 @@ set(DATA_TEST_LIST
     domainparticipant_data_clear
     datareader_data_clear
     datawriter_data_clear
-    locator_data_clear
 )
 
 foreach(test_name ${DATA_TEST_LIST})

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -248,9 +248,7 @@ set(DATABASE_TEST_LIST
     insert_sample_history_latency
     insert_sample_history_latency_wrong_entity
     insert_sample_network_latency
-    insert_sample_network_latency_unknown_locator
-    insert_sample_network_latency_unknown_remote_locator
-    insert_sample_network_latency_unknown_both_locators
+    insert_sample_network_latency_wrong_entity
     insert_sample_publication_throughput
     insert_sample_publication_throughput_wrong_entity
     insert_sample_subscription_throughput

--- a/test/unittest/Database/DataTests.cpp
+++ b/test/unittest/Database/DataTests.cpp
@@ -36,6 +36,8 @@ TEST(database, domainparticipant_data_clear)
     DiscoveryTimeSample time_sample;
     time_sample.discovered = true;
     time_sample.time = std::chrono::system_clock::now();
+    EntityDataSample data_sample;
+    data_sample.data = 11.0;
 
     // RTPSData
     data.rtps_packets_sent[EntityId(2)].push_back(count_sample);
@@ -53,6 +55,7 @@ TEST(database, domainparticipant_data_clear)
     data.last_reported_pdp_packets = count_sample;
     data.edp_packets.push_back(count_sample);
     data.last_reported_edp_packets = count_sample;
+    data.network_latency_per_locator[EntityId(6)].push_back(data_sample);
 
     /* Check that data in cleared */
     data.clear();
@@ -69,6 +72,7 @@ TEST(database, domainparticipant_data_clear)
     ASSERT_EQ(data.last_reported_pdp_packets.count, 0);
     ASSERT_TRUE(data.edp_packets.empty());
     ASSERT_EQ(data.last_reported_edp_packets.count, 0);
+    ASSERT_TRUE(data.network_latency_per_locator.empty());
 }
 
 TEST(database, datareader_data_clear)
@@ -131,26 +135,6 @@ TEST(database, datawriter_data_clear)
     ASSERT_TRUE(data.data_count.empty());
     ASSERT_EQ(data.last_reported_data_count.count, 0);
     ASSERT_TRUE(data.sample_datas.empty());
-}
-
-TEST(database, locator_data_clear)
-{
-    /* Add dummy data to LocatorData */
-    LocatorData data;
-    EntityDataSample data_sample;
-    data_sample.data = 11.0;
-    EntityCountSample count_sample;
-    count_sample.count = 12;
-    ByteCountSample byte_sample;
-    byte_sample.count = 13;
-    byte_sample.magnitude_order = 2;
-
-    // LocatorData
-    data.network_latency_per_locator[EntityId(6)].push_back(data_sample);
-
-    /* Check that data in cleared */
-    data.clear();
-    ASSERT_TRUE(data.network_latency_per_locator.empty());
 }
 
 int main(

--- a/test/unittest/Database/DatabaseDumpTests.cpp
+++ b/test/unittest/Database/DatabaseDumpTests.cpp
@@ -180,6 +180,15 @@ void initialize_participant_data(
         sample.magnitude_order = MAGNITUDE_DEFAULT;
         db.insert(DOMAIN_DEFAULT_ID(index), PARTICIPANT_DEFAULT_ID(index), sample);
     }
+
+    // network_latency_per_locator
+    {
+        NetworkLatencySample sample;
+        sample.src_ts = TIME_DEFAULT(time);
+        sample.data = DATA_DEFAULT;
+        sample.remote_locator = LOCATOR_DEFAULT_ID(index);
+        db.insert(DOMAIN_DEFAULT_ID(index), PARTICIPANT_DEFAULT_ID(index), sample);
+    }
 }
 
 void initialize_datawriter_data(
@@ -277,21 +286,6 @@ void initialize_datareader_data(
     }
 }
 
-void initialize_locator_data(
-        Database& db,
-        int index,
-        int time)
-{
-    // network_latency_per_locator
-    {
-        NetworkLatencySample sample;
-        sample.src_ts = TIME_DEFAULT(time);
-        sample.data = DATA_DEFAULT;
-        sample.remote_locator = LOCATOR_DEFAULT_ID(index);
-        db.insert(DOMAIN_DEFAULT_ID(index), LOCATOR_DEFAULT_ID(index), sample);
-    }
-}
-
 void initialize_database(
         Database& db,
         int n_entity,
@@ -306,7 +300,6 @@ void initialize_database(
             initialize_participant_data(db, i, j);
             initialize_datawriter_data(db, i, j);
             initialize_datareader_data(db, i, j);
-            initialize_locator_data(db, i, j);
         }
     }
 }
@@ -454,6 +447,7 @@ TEST(database, dump_and_clear_database)
                 ASSERT_FALSE(it.second->data.rtps_bytes_sent.empty());
                 ASSERT_FALSE(it.second->data.rtps_packets_lost.empty());
                 ASSERT_FALSE(it.second->data.rtps_bytes_lost.empty());
+                ASSERT_FALSE(it.second->data.network_latency_per_locator.empty());
 
                 ASSERT_FALSE(it.second->data.last_reported_rtps_packets_sent_count.empty());
                 ASSERT_FALSE(it.second->data.last_reported_rtps_bytes_sent_count.empty());
@@ -521,11 +515,6 @@ TEST(database, dump_and_clear_database)
                         it.second->data.last_reported_nackfrag_count.count == 0);
             }
         }
-        // Locators
-        for (const auto& it : db.locators())
-        {
-            ASSERT_FALSE(it.second->data.network_latency_per_locator.empty());
-        }
     }
 
     DatabaseDump dump = db.dump_database(true);
@@ -545,6 +534,7 @@ TEST(database, dump_and_clear_database)
                 ASSERT_TRUE(it.second->data.rtps_bytes_sent.empty());
                 ASSERT_TRUE(it.second->data.rtps_packets_lost.empty());
                 ASSERT_TRUE(it.second->data.rtps_bytes_lost.empty());
+                ASSERT_TRUE(it.second->data.network_latency_per_locator.empty());
 
                 ASSERT_FALSE(it.second->data.last_reported_rtps_packets_sent_count.empty());
                 ASSERT_FALSE(it.second->data.last_reported_rtps_bytes_sent_count.empty());
@@ -611,11 +601,6 @@ TEST(database, dump_and_clear_database)
                         std::chrono::system_clock::time_point() &&
                         it.second->data.last_reported_nackfrag_count.count == 0);
             }
-        }
-        // Locators
-        for (const auto& it : db.locators())
-        {
-            ASSERT_TRUE(it.second->data.network_latency_per_locator.empty());
         }
     }
 }

--- a/test/unittest/Database/DatabaseLoadInsertTests.cpp
+++ b/test/unittest/Database/DatabaseLoadInsertTests.cpp
@@ -284,6 +284,7 @@ TEST_F(database_load_insert_tests, load_insert)
             ASSERT_TRUE(insertedData.last_reported_pdp_packets == loadedData.last_reported_pdp_packets);
             ASSERT_TRUE(insertedData.edp_packets == loadedData.edp_packets);
             ASSERT_TRUE(insertedData.last_reported_edp_packets == loadedData.last_reported_edp_packets);
+            ASSERT_TRUE(map_compare(insertedData.network_latency_per_locator, loadedData.network_latency_per_locator));
         }
     }
 
@@ -334,17 +335,7 @@ TEST_F(database_load_insert_tests, load_insert)
         }
     }
 
-    // Locator
-    for (auto it = db.locators().cbegin(); it != db.locators().cend(); ++it)
-    {
-        LocatorData insertedData = db.locators().at(it->first)->data;
-        LocatorData loadedData = db_loaded.locators().at(it->first)->data;
-
-        ASSERT_TRUE(map_compare(insertedData.network_latency_per_locator, loadedData.network_latency_per_locator));
-    }
-
     // ------------------ Compare entities ------------------------
-
 
     // Host
     for (auto insertedIt = db.hosts().cbegin(), loadedIt = db_loaded.hosts().cbegin();

--- a/test/unittest/Database/DatabaseLoadTests.cpp
+++ b/test/unittest/Database/DatabaseLoadTests.cpp
@@ -339,7 +339,6 @@ TEST(database_load_tests, load_erased_keys)
 
     check_entity_no_key(dump, LOCATOR_CONTAINER_TAG, DATAWRITER_CONTAINER_TAG);
     check_entity_no_key(dump, LOCATOR_CONTAINER_TAG, DATAREADER_CONTAINER_TAG);
-    check_entity_no_key(dump, LOCATOR_CONTAINER_TAG, DATA_VALUE_DATA_TAG);
 
     // ------------ DATAWRITERS ----------------
 
@@ -378,6 +377,7 @@ TEST(database_load_tests, load_erased_keys)
     check_data_no_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_RTPS_PACKETS_SENT_LAST_REPORTED_TAG);
     check_data_no_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_EDP_PACKETS_LAST_REPORTED_TAG);
     check_data_no_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_PDP_PACKETS_LAST_REPORTED_TAG);
+    check_data_no_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_NETWORK_LATENCY_TAG);
 
     check_data_value_no_id_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_DISCOVERY_TIME_TAG);
     check_data_value_no_id_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_RTPS_PACKETS_SENT_TAG);
@@ -388,6 +388,7 @@ TEST(database_load_tests, load_erased_keys)
     check_data_value_no_id_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_RTPS_BYTES_SENT_LAST_REPORTED_TAG);
     check_data_value_no_id_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_RTPS_PACKETS_LOST_LAST_REPORTED_TAG);
     check_data_value_no_id_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_RTPS_PACKETS_SENT_LAST_REPORTED_TAG);
+    check_data_value_no_id_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_NETWORK_LATENCY_TAG);
 
     check_data_value_index_no_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_DISCOVERY_TIME_TAG,
             DATA_VALUE_SRC_TIME_TAG);
@@ -446,6 +447,10 @@ TEST(database_load_tests, load_erased_keys)
             DATA_VALUE_COUNT_TAG);
     check_data_value_index_last_no_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_RTPS_BYTES_LOST_LAST_REPORTED_TAG,
             DATA_VALUE_MAGNITUDE_TAG);
+    check_data_value_index_no_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_NETWORK_LATENCY_TAG,
+            DATA_VALUE_SRC_TIME_TAG);
+    check_data_value_index_no_key(dump, PARTICIPANT_CONTAINER_TAG, DATA_KIND_NETWORK_LATENCY_TAG,
+            DATA_VALUE_DATA_TAG);
 
     // ------------ DATAWRITER DATA ----------------
 
@@ -522,14 +527,6 @@ TEST(database_load_tests, load_erased_keys)
             DATA_VALUE_SRC_TIME_TAG);
     check_data_value_last_no_key(dump, DATAREADER_CONTAINER_TAG, DATA_KIND_NACKFRAG_COUNT_LAST_REPORTED_TAG,
             DATA_VALUE_COUNT_TAG);
-
-    // ------------ LOCATOR DATA ----------------
-
-    check_data_no_key(dump, LOCATOR_CONTAINER_TAG, DATA_KIND_NETWORK_LATENCY_TAG);
-
-    check_data_value_no_id_key(dump, LOCATOR_CONTAINER_TAG, DATA_KIND_NETWORK_LATENCY_TAG);
-    check_data_value_index_no_key(dump, LOCATOR_CONTAINER_TAG, DATA_KIND_NETWORK_LATENCY_TAG, DATA_VALUE_SRC_TIME_TAG);
-    check_data_value_index_no_key(dump, LOCATOR_CONTAINER_TAG, DATA_KIND_NETWORK_LATENCY_TAG, DATA_VALUE_DATA_TAG);
 }
 
 void check_and_restore(
@@ -746,7 +743,6 @@ TEST(database_load_tests, load_wrong_values)
     check_is_string(dump, dump[LOCATOR_CONTAINER_TAG].begin().value()[ALIAS_INFO_TAG]);
     check_is_id(dump, dump[LOCATOR_CONTAINER_TAG].begin().value()[DATAWRITER_CONTAINER_TAG]);
     check_is_id(dump, dump[LOCATOR_CONTAINER_TAG].begin().value()[DATAREADER_CONTAINER_TAG]);
-    check_is_id(dump, dump[LOCATOR_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]);
 
     // Datawriter
     check_is_id(dump, dump[DATAWRITER_CONTAINER_TAG]);
@@ -863,6 +859,18 @@ TEST(database_load_tests, load_wrong_values)
             [DATA_KIND_RTPS_BYTES_LOST_TAG].begin().value().begin().value()[DATA_VALUE_MAGNITUDE_TAG]);
     check_is_uint(dump, dump[PARTICIPANT_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
             [DATA_KIND_RTPS_BYTES_LOST_TAG].begin().value().begin().value()[DATA_VALUE_COUNT_TAG]);
+
+    // network_latency_per_locator
+    check_is_id(dump, dump[PARTICIPANT_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
+            [DATA_KIND_NETWORK_LATENCY_TAG]);
+    check_is_id(dump, dump[PARTICIPANT_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
+            [DATA_KIND_NETWORK_LATENCY_TAG].begin().value());
+    check_is_id(dump, dump[PARTICIPANT_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
+            [DATA_KIND_NETWORK_LATENCY_TAG].begin().value().begin().value());
+    check_is_string_uint(dump, dump[PARTICIPANT_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
+            [DATA_KIND_NETWORK_LATENCY_TAG].begin().value().begin().value()[DATA_VALUE_SRC_TIME_TAG]);
+    check_is_double(dump, dump[PARTICIPANT_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
+            [DATA_KIND_NETWORK_LATENCY_TAG].begin().value().begin().value()[DATA_VALUE_DATA_TAG]);
 
     // last_reported_edp_packets
     check_is_id(dump, dump[PARTICIPANT_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
@@ -1080,21 +1088,6 @@ TEST(database_load_tests, load_wrong_values)
             [DATA_KIND_NACKFRAG_COUNT_LAST_REPORTED_TAG][DATA_VALUE_SRC_TIME_TAG]);
     check_is_uint(dump, dump[DATAREADER_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
             [DATA_KIND_NACKFRAG_COUNT_LAST_REPORTED_TAG][DATA_VALUE_COUNT_TAG]);
-
-    // --------------------- Locators ---------------------
-
-    // network_latency_per_locator
-    check_is_id(dump, dump[LOCATOR_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
-            [DATA_KIND_NETWORK_LATENCY_TAG]);
-    check_is_id(dump, dump[LOCATOR_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
-            [DATA_KIND_NETWORK_LATENCY_TAG].begin().value());
-    check_is_id(dump, dump[LOCATOR_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
-            [DATA_KIND_NETWORK_LATENCY_TAG].begin().value().begin().value());
-    check_is_string_uint(dump, dump[LOCATOR_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
-            [DATA_KIND_NETWORK_LATENCY_TAG].begin().value().begin().value()[DATA_VALUE_SRC_TIME_TAG]);
-    check_is_double(dump, dump[LOCATOR_CONTAINER_TAG].begin().value()[DATA_CONTAINER_TAG]
-            [DATA_KIND_NETWORK_LATENCY_TAG].begin().value().begin().value()[DATA_VALUE_DATA_TAG]);
-
 }
 
 void check_reference(

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -1765,57 +1765,12 @@ TEST_F(database_tests, insert_sample_network_latency)
             static_cast<EntityDataSample>(sample_2));
 }
 
-TEST_F(database_tests, insert_sample_network_latency_unknown_locator)
+TEST_F(database_tests, insert_sample_network_latency_wrong_entity)
 {
     NetworkLatencySample sample;
     sample.remote_locator = reader_locator->id;
     sample.data = 12;
-
-    EntityId locator_id = db.generate_entity_id();
-    ASSERT_THROW(db.get_entity(locator_id), BadParameter);
-    ASSERT_NO_THROW(db.insert(domain_id, locator_id, sample));
-    ASSERT_NO_THROW(db.get_entity(locator_id));
-    auto locator = db.locators().at(locator_id);
-
-    ASSERT_EQ(locator->data.network_latency_per_locator[reader_locator->id].size(), 1);
-    ASSERT_EQ(locator->data.network_latency_per_locator[reader_locator->id][0],
-            static_cast<EntityDataSample>(sample));
-}
-
-TEST_F(database_tests, insert_sample_network_latency_unknown_remote_locator)
-{
-    NetworkLatencySample sample;
-    EntityId remote_id = db.generate_entity_id();
-    sample.remote_locator = remote_id;
-    sample.data = 12;
-
-    ASSERT_THROW(db.get_entity(remote_id), BadParameter);
-    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample));
-    ASSERT_NO_THROW(db.get_entity(remote_id));
-
-    ASSERT_EQ(writer_locator->data.network_latency_per_locator[remote_id].size(), 1);
-    ASSERT_EQ(writer_locator->data.network_latency_per_locator[remote_id][0],
-            static_cast<EntityDataSample>(sample));
-}
-
-TEST_F(database_tests, insert_sample_network_latency_unknown_both_locators)
-{
-    NetworkLatencySample sample;
-    EntityId remote_id = db.generate_entity_id();
-    sample.remote_locator = remote_id;
-    sample.data = 12;
-
-    EntityId locator_id = db.generate_entity_id();
-    ASSERT_THROW(db.get_entity(remote_id), BadParameter);
-    ASSERT_THROW(db.get_entity(locator_id), BadParameter);
-    ASSERT_NO_THROW(db.insert(domain_id, locator_id, sample));
-    ASSERT_NO_THROW(db.get_entity(locator_id));
-    ASSERT_NO_THROW(db.get_entity(remote_id));
-    auto locator = db.locators().at(locator_id);
-
-    ASSERT_EQ(locator->data.network_latency_per_locator[remote_id].size(), 1);
-    ASSERT_EQ(locator->data.network_latency_per_locator[remote_id][0],
-            static_cast<EntityDataSample>(sample));
+    ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
 }
 
 TEST_F(database_tests, insert_sample_publication_throughput)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -1751,17 +1751,17 @@ TEST_F(database_tests, insert_sample_network_latency)
     NetworkLatencySample sample;
     sample.remote_locator = reader_locator->id;
     sample.data = 12;
-    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample));
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample));
 
     NetworkLatencySample sample_2;
     sample_2.remote_locator = reader_locator->id;
     sample_2.data = 13;
-    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample_2));
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
 
-    ASSERT_EQ(writer_locator->data.network_latency_per_locator[reader_locator->id].size(), 2);
-    ASSERT_EQ(writer_locator->data.network_latency_per_locator[reader_locator->id][0],
+    ASSERT_EQ(participant->data.network_latency_per_locator[reader_locator->id].size(), 2);
+    ASSERT_EQ(participant->data.network_latency_per_locator[reader_locator->id][0],
             static_cast<EntityDataSample>(sample));
-    ASSERT_EQ(writer_locator->data.network_latency_per_locator[reader_locator->id][1],
+    ASSERT_EQ(participant->data.network_latency_per_locator[reader_locator->id][1],
             static_cast<EntityDataSample>(sample_2));
 }
 
@@ -2325,7 +2325,7 @@ TEST_F(database_tests, insert_sample_valid_wrong_domain)
     ASSERT_THROW(db.insert(db.generate_entity_id(), writer_id, history_lantency_sample), BadParameter);
 
     NetworkLatencySample network_lantency_sample;
-    ASSERT_NO_THROW(db.insert(db.generate_entity_id(), writer_locator->id, network_lantency_sample));
+    ASSERT_THROW(db.insert(db.generate_entity_id(), participant_id, network_lantency_sample), BadParameter);
 
     PublicationThroughputSample pub_throughput_sample;
     ASSERT_THROW(db.insert(db.generate_entity_id(), writer_id, pub_throughput_sample), BadParameter);
@@ -2743,18 +2743,18 @@ TEST_F(database_tests, select_invalid_entities)
     ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, process_id, reader_locator->id, t_from, t_to), "");
     ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, domain_id, reader_locator->id, t_from, t_to), "");
     ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, topic_id, reader_locator->id, t_from, t_to), "");
-    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, participant_id, reader_locator->id, t_from, t_to), "");
     ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, writer_id, reader_locator->id, t_from, t_to), "");
     ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_id, reader_locator->id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, t_from, t_to), "");
 
-    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, host_id, t_from, t_to), "");
-    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, user_id, t_from, t_to), "");
-    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, process_id, t_from, t_to), "");
-    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, domain_id, t_from, t_to), "");
-    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, topic_id, t_from, t_to), "");
-    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, participant_id, t_from, t_to), "");
-    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, writer_id, t_from, t_to), "");
-    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, reader_locator->id, reader_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, participant_id, host_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, participant_id, user_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, participant_id, process_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, participant_id, domain_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, participant_id, topic_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, participant_id, participant_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, participant_id, writer_id, t_from, t_to), "");
+    ASSERT_DEATH(db.select(DataKind::NETWORK_LATENCY, participant_id, reader_id, t_from, t_to), "");
 
     ASSERT_DEATH(db.select(DataKind::PUBLICATION_THROUGHPUT, host_id, t_from, t_to), "");
     ASSERT_DEATH(db.select(DataKind::PUBLICATION_THROUGHPUT, user_id, t_from, t_to), "");
@@ -3088,7 +3088,7 @@ TEST_F(database_tests, select_fastdds_latency)
 TEST_F(database_tests, select_network_latency)
 {
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, participant_id, reader_locator->id, src_ts,
             end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
@@ -3096,20 +3096,20 @@ TEST_F(database_tests, select_network_latency)
     sample_1.remote_locator = reader_locator->id;
     sample_1.data = 15;
     sample_1.src_ts = sample1_ts;
-    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample_1));
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_1));
     NetworkLatencySample sample_2;
     sample_2.remote_locator = reader_locator->id;
     sample_2.data = 5;
     sample_2.src_ts = sample2_ts;
-    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample_2));
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
     NetworkLatencySample sample_3;
     sample_3.remote_locator = reader_locator->id;
     sample_3.data = 25;
     sample_3.src_ts = sample3_ts;
-    ASSERT_NO_THROW(db.insert(domain_id, writer_locator->id, sample_3));
+    ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_3));
 
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, participant_id, reader_locator->id, src_ts,
             end_ts));
     ASSERT_EQ(data_output.size(), 3u);
     auto sample1 = static_cast<const EntityDataSample*>(data_output[0]);
@@ -3120,24 +3120,24 @@ TEST_F(database_tests, select_network_latency)
     EXPECT_EQ(*sample3, sample_3);
 
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, src_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, participant_id, reader_locator->id, src_ts,
             mid1_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, mid1_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, participant_id, reader_locator->id, mid1_ts,
             mid2_ts));
     ASSERT_EQ(data_output.size(), 1u);
     sample1 = static_cast<const EntityDataSample*>(data_output[0]);
     EXPECT_EQ(*sample1, sample_1);
 
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id, mid2_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, participant_id, reader_locator->id, mid2_ts,
             mid3_ts));
     EXPECT_EQ(data_output.size(), 0u);
 
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, writer_locator->id, reader_locator->id,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, participant_id, reader_locator->id,
             sample2_ts, sample3_ts));
     ASSERT_EQ(data_output.size(), 2u);
     sample1 = static_cast<const EntityDataSample*>(data_output[0]);
@@ -3146,7 +3146,7 @@ TEST_F(database_tests, select_network_latency)
     EXPECT_EQ(*sample2, sample_3);
 
     data_output.clear();
-    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, reader_locator->id, writer_locator->id, src_ts,
+    ASSERT_NO_THROW(data_output = db.select(DataKind::NETWORK_LATENCY, participant_id, writer_locator->id, src_ts,
             end_ts));
     EXPECT_EQ(data_output.size(), 0u);
 }

--- a/test/unittest/DatabaseQueue/CMakeLists.txt
+++ b/test/unittest/DatabaseQueue/CMakeLists.txt
@@ -72,7 +72,8 @@ if(GTEST_FOUND AND GMOCK_FOUND)
         push_history_latency_no_reader
         push_history_latency_no_writer
         push_network_latency
-        push_network_latency_no_source_locator
+        push_network_latency_no_participant
+        push_network_latency_wrong_participant_format
         push_network_latency_no_destination_locator
         push_publication_throughput
         push_publication_throughput_no_writer

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -1656,29 +1656,29 @@ TEST_F(database_queue_tests, push_network_latency_no_destination_locator)
 
     // Expectation: The insert method is called with appropriate arguments
     InsertDataArgs args([&](
-            const EntityId& domain_id,
-            const EntityId& entity_id,
-            const StatisticsSample& sample)
-        {
+                const EntityId& domain_id,
+                const EntityId& entity_id,
+                const StatisticsSample& sample)
+            {
                 EXPECT_EQ(entity_id, 1);
                 EXPECT_EQ(domain_id, 0);
                 EXPECT_EQ(sample.src_ts, timestamp);
                 EXPECT_EQ(sample.kind, DataKind::NETWORK_LATENCY);
                 EXPECT_EQ(dynamic_cast<const NetworkLatencySample&>(sample).remote_locator, 2);
-        });
+            });
 
     EXPECT_CALL(database, insert(_, _, _)).Times(1)
             .WillOnce(Invoke(&args, &InsertDataArgs::insert));
 
     // Expectation: the remote locator is created and given ID 2
     InsertEntityArgs insert_args([&](
-            std::shared_ptr<Entity> entity)
-        {
-            EXPECT_EQ(entity->kind, EntityKind::LOCATOR);
-            EXPECT_EQ(entity->name, dst_locator_str);
-            EXPECT_EQ(entity->alias, dst_locator_str);
-            return EntityId(1);
-        });
+                std::shared_ptr<Entity> entity)
+            {
+                EXPECT_EQ(entity->kind, EntityKind::LOCATOR);
+                EXPECT_EQ(entity->name, dst_locator_str);
+                EXPECT_EQ(entity->alias, dst_locator_str);
+                return EntityId(1);
+            });
 
     EXPECT_CALL(database, insert(_)).Times(1)
             .WillOnce(Invoke(&insert_args, &InsertEntityArgs::insert));

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -1677,7 +1677,7 @@ TEST_F(database_queue_tests, push_network_latency_no_destination_locator)
                 EXPECT_EQ(entity->kind, EntityKind::LOCATOR);
                 EXPECT_EQ(entity->name, dst_locator_str);
                 EXPECT_EQ(entity->alias, dst_locator_str);
-                return EntityId(1);
+                return EntityId(2);
             });
 
     EXPECT_CALL(database, insert(_)).Times(1)

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -1198,7 +1198,7 @@ TEST_F(database_queue_tests, push_locator)
     std::shared_ptr<Locator> locator =
             std::make_shared<Locator>(locator_name);
 
-    // Expectation: The datareader is created and given ID 1
+    // Expectation: The locator is created and given ID 1
     InsertEntityArgs insert_args([&](
                 std::shared_ptr<Entity> entity)
             {
@@ -1230,7 +1230,7 @@ TEST_F(database_queue_tests, push_locator_throws)
     std::shared_ptr<Locator> locator =
             std::make_shared<Locator>(locator_name);
 
-    // Expectation: The datareader creation throws
+    // Expectation: The locator creation throws
     InsertEntityArgs insert_args([&](
                 std::shared_ptr<Entity> entity) -> EntityId
             {
@@ -1446,8 +1446,8 @@ TEST_F(database_queue_tests, push_network_latency)
     std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 16> src_locator_address = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-    uint32_t src_locator_port = 1024;
-    std::string src_locator_str = "TCPv4:[13.14.15.16]:1024";
+    uint32_t src_locator_port = 0;
+    std::string src_locator_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|d.e.f.10";
     std::array<uint8_t, 16> dst_locator_address = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
     uint32_t dst_locator_port = 2048;
     std::string dst_locator_str = "TCPv4:[4.3.2.1]:2048";
@@ -1474,9 +1474,9 @@ TEST_F(database_queue_tests, push_network_latency)
     data->locator2locator_data(inner_data);
     data->_d(EventKind::NETWORK_LATENCY);
 
-    // Precondition: The source locator exists and has ID 1
-    EXPECT_CALL(database, get_entities_by_name(EntityKind::LOCATOR, src_locator_str)).Times(1)
-            .WillOnce(Return(std::vector<std::pair<EntityId, EntityId>>(1, std::make_pair(EntityId(0), EntityId(1)))));
+    // Precondition: The participant exists and has ID 1
+    EXPECT_CALL(database, get_entity_by_guid(EntityKind::PARTICIPANT, src_locator_str)).Times(1)
+            .WillOnce(Return(std::make_pair(EntityId(0), EntityId(1))));
 
     // Precondition: The destination locator exists and has ID 2
     EXPECT_CALL(database, get_entities_by_name(EntityKind::LOCATOR, dst_locator_str)).Times(1)
@@ -1507,13 +1507,13 @@ TEST_F(database_queue_tests, push_network_latency)
     data_queue.flush();
 }
 
-TEST_F(database_queue_tests, push_network_latency_no_source_locator)
+TEST_F(database_queue_tests, push_network_latency_no_participant)
 {
     std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 16> src_locator_address = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-    uint32_t src_locator_port = 1024;
-    std::string src_locator_str = "TCPv4:[13.14.15.16]:1024";
+    uint32_t src_locator_port = 0;
+    std::string src_locator_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|d.e.f.10";
     std::array<uint8_t, 16> dst_locator_address = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
     uint32_t dst_locator_port = 2048;
     std::string dst_locator_str = "TCPv4:[4.3.2.1]:2048";
@@ -1540,9 +1540,60 @@ TEST_F(database_queue_tests, push_network_latency_no_source_locator)
     data->locator2locator_data(inner_data);
     data->_d(EventKind::NETWORK_LATENCY);
 
-    // Precondition: The source locator does not exist
-    EXPECT_CALL(database, get_entities_by_name(EntityKind::LOCATOR, src_locator_str)).Times(AnyNumber())
-            .WillOnce(Return(std::vector<std::pair<EntityId, EntityId>>()));
+    // Precondition: The participant does not exist
+    EXPECT_CALL(database, get_entity_by_guid(EntityKind::PARTICIPANT, src_locator_str)).Times(AnyNumber())
+            .WillOnce(Throw(BadParameter("Error")));
+
+    // Precondition: The destination locator exists and has ID 2
+    EXPECT_CALL(database, get_entities_by_name(EntityKind::LOCATOR, dst_locator_str)).Times(AnyNumber())
+            .WillOnce(Return(std::vector<std::pair<EntityId, EntityId>>(1, std::make_pair(EntityId(0), EntityId(2)))));
+
+    // Expectation: The insert method is never called, data dropped
+    EXPECT_CALL(database, insert(_, _, _)).Times(0);
+
+    // Expectation: The user is not notified
+    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_data_available(_, _, _)).Times(0);
+
+    // Add to the queue and wait to be processed
+    data_queue.push(timestamp, data);
+    data_queue.flush();
+}
+
+TEST_F(database_queue_tests, push_network_latency_wrong_participant_format)
+{
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
+
+    std::array<uint8_t, 16> src_locator_address = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    uint32_t src_locator_port = 1;
+    std::string src_locator_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|d.e.f.10";
+    std::array<uint8_t, 16> dst_locator_address = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+    uint32_t dst_locator_port = 2048;
+    std::string dst_locator_str = "TCPv4:[4.3.2.1]:2048";
+
+    // Build the source locator
+    DatabaseDataQueue::StatisticsLocator src_locator;
+    src_locator.kind(LOCATOR_KIND_TCPv4);
+    src_locator.port(src_locator_port);
+    src_locator.address(src_locator_address);
+
+    // Build the destination locator
+    DatabaseDataQueue::StatisticsLocator dst_locator;
+    dst_locator.kind(LOCATOR_KIND_TCPv4);
+    dst_locator.port(dst_locator_port);
+    dst_locator.address(dst_locator_address);
+
+    // Build the Statistics data
+    DatabaseDataQueue::StatisticsLocator2LocatorData inner_data;
+    inner_data.data(1.0);
+    inner_data.src_locator(src_locator);
+    inner_data.dst_locator(dst_locator);
+
+    std::shared_ptr<eprosima::fastdds::statistics::Data> data = std::make_shared<eprosima::fastdds::statistics::Data>();
+    data->locator2locator_data(inner_data);
+    data->_d(EventKind::NETWORK_LATENCY);
+
+    // Precondition: The participant is not searched
+    EXPECT_CALL(database, get_entity_by_guid(EntityKind::PARTICIPANT, src_locator_str)).Times(0);
 
     // Precondition: The destination locator exists and has ID 2
     EXPECT_CALL(database, get_entities_by_name(EntityKind::LOCATOR, dst_locator_str)).Times(AnyNumber())
@@ -1564,8 +1615,8 @@ TEST_F(database_queue_tests, push_network_latency_no_destination_locator)
     std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     std::array<uint8_t, 16> src_locator_address = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-    uint32_t src_locator_port = 1024;
-    std::string src_locator_str = "TCPv4:[13.14.15.16]:1024";
+    uint32_t src_locator_port = 0;
+    std::string src_locator_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|d.e.f.10";
     std::array<uint8_t, 16> dst_locator_address = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
     uint32_t dst_locator_port = 2048;
     std::string dst_locator_str = "TCPv4:[4.3.2.1]:2048";
@@ -1592,19 +1643,49 @@ TEST_F(database_queue_tests, push_network_latency_no_destination_locator)
     data->locator2locator_data(inner_data);
     data->_d(EventKind::NETWORK_LATENCY);
 
-    // Precondition: The source locator exists and has ID 1
-    EXPECT_CALL(database, get_entities_by_name(EntityKind::LOCATOR, src_locator_str)).Times(AnyNumber())
-            .WillOnce(Return(std::vector<std::pair<EntityId, EntityId>>(1, std::make_pair(EntityId(0), EntityId(1)))));
+    // Precondition: The participant exists and has ID 1
+    EXPECT_CALL(database, get_entity_by_guid(EntityKind::PARTICIPANT, src_locator_str)).Times(AnyNumber())
+            .WillOnce(Return(std::pair<EntityId, EntityId>(std::make_pair(EntityId(0), EntityId(1)))));
 
-    // Precondition: The destination locator does not exist
+    // Precondition: The destination locator does not exist the first time
+    // Precondition: The destination locator exists and has ID 2
     EXPECT_CALL(database, get_entities_by_name(EntityKind::LOCATOR, dst_locator_str)).Times(AnyNumber())
-            .WillOnce(Return(std::vector<std::pair<EntityId, EntityId>>()));
+            .WillOnce(Return(std::vector<std::pair<EntityId, EntityId>>()))
+            .WillRepeatedly(Return(std::vector<std::pair<EntityId, EntityId>>(1,
+            std::make_pair(EntityId(0), EntityId(2)))));
 
-    // Expectation: The insert method is never called, data dropped
-    EXPECT_CALL(database, insert(_, _, _)).Times(0);
+    // Expectation: The insert method is called with appropriate arguments
+    InsertDataArgs args([&](
+            const EntityId& domain_id,
+            const EntityId& entity_id,
+            const StatisticsSample& sample)
+        {
+                EXPECT_EQ(entity_id, 1);
+                EXPECT_EQ(domain_id, 0);
+                EXPECT_EQ(sample.src_ts, timestamp);
+                EXPECT_EQ(sample.kind, DataKind::NETWORK_LATENCY);
+                EXPECT_EQ(dynamic_cast<const NetworkLatencySample&>(sample).remote_locator, 2);
+        });
 
-    // Expectation: The user is not notified
-    EXPECT_CALL(*details::StatisticsBackendData::get_instance(), on_data_available(_, _, _)).Times(0);
+    EXPECT_CALL(database, insert(_, _, _)).Times(1)
+            .WillOnce(Invoke(&args, &InsertDataArgs::insert));
+
+    // Expectation: the remote locator is created and given ID 2
+    InsertEntityArgs insert_args([&](
+            std::shared_ptr<Entity> entity)
+        {
+            EXPECT_EQ(entity->kind, EntityKind::LOCATOR);
+            EXPECT_EQ(entity->name, dst_locator_str);
+            EXPECT_EQ(entity->alias, dst_locator_str);
+            return EntityId(1);
+        });
+
+    EXPECT_CALL(database, insert(_)).Times(1)
+            .WillOnce(Invoke(&insert_args, &InsertEntityArgs::insert));
+
+    // Expectation: The user is notified
+    EXPECT_CALL(*details::StatisticsBackendData::get_instance(),
+            on_data_available(EntityId(0), EntityId(1), DataKind::NETWORK_LATENCY)).Times(1);
 
     // Add to the queue and wait to be processed
     data_queue.push(timestamp, data);

--- a/test/unittest/Resources/complex_dump.json
+++ b/test/unittest/Resources/complex_dump.json
@@ -641,24 +641,6 @@
     },
     "locators":{
         "0":{
-            "data":{
-                "network_latency_per_locator":{
-                    "0":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
-            },
             "datareaders":[
                 "8"
             ],
@@ -669,24 +651,6 @@
             "alias":"locator_0"
         },
         "18":{
-            "data":{
-                "network_latency_per_locator":{
-                    "18":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
-            },
             "datareaders":[
                 "26"
             ],
@@ -697,24 +661,6 @@
             "alias":"locator_2"
         },
         "9":{
-            "data":{
-                "network_latency_per_locator":{
-                    "9":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
-            },
             "datareaders":[
                 "17"
             ],
@@ -878,6 +824,22 @@
                         },
                         {
                             "count":0,
+                            "src_time":"200"
+                        }
+                    ]
+                },
+                "network_latency_per_locator":{
+                    "9":[
+                        {
+                            "data":1.1,
+                            "src_time":"0"
+                        },
+                        {
+                            "data":1.1,
+                            "src_time":"100"
+                        },
+                        {
+                            "data":1.1,
                             "src_time":"200"
                         }
                     ]
@@ -1053,6 +1015,22 @@
                             "src_time":"200"
                         }
                     ]
+                },
+                "network_latency_per_locator":{
+                    "18":[
+                        {
+                            "data":1.1,
+                            "src_time":"0"
+                        },
+                        {
+                            "data":1.1,
+                            "src_time":"100"
+                        },
+                        {
+                            "data":1.1,
+                            "src_time":"200"
+                        }
+                    ]
                 }
             },
             "datareaders":[
@@ -1222,6 +1200,22 @@
                         },
                         {
                             "count":0,
+                            "src_time":"200"
+                        }
+                    ]
+                },
+                "network_latency_per_locator":{
+                    "0":[
+                        {
+                            "data":1.1,
+                            "src_time":"0"
+                        },
+                        {
+                            "data":1.1,
+                            "src_time":"100"
+                        },
+                        {
+                            "data":1.1,
                             "src_time":"200"
                         }
                     ]

--- a/test/unittest/Resources/complex_dump_erased_domain_1.json
+++ b/test/unittest/Resources/complex_dump_erased_domain_1.json
@@ -438,24 +438,6 @@
     },
     "locators":{
         "0":{
-            "data":{
-                "network_latency_per_locator":{
-                    "0":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
-            },
             "datareaders":[
                 "8"
             ],
@@ -466,24 +448,6 @@
             "alias":"locator_0"
         },
         "18":{
-            "data":{
-                "network_latency_per_locator":{
-                    "18":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
-            },
             "datareaders":[
                 "26"
             ],
@@ -494,24 +458,6 @@
             "alias":"locator_2"
         },
         "9":{
-            "data":{
-                "network_latency_per_locator":{
-                    "9":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
-            },
             "datareaders":[
             ],
             "datawriters":[
@@ -673,6 +619,22 @@
                         },
                         {
                             "count":0,
+                            "src_time":"200"
+                        }
+                    ]
+                },
+                "network_latency_per_locator":{
+                    "18":[
+                        {
+                            "data":1.1,
+                            "src_time":"0"
+                        },
+                        {
+                            "data":1.1,
+                            "src_time":"100"
+                        },
+                        {
+                            "data":1.1,
                             "src_time":"200"
                         }
                     ]
@@ -845,6 +807,22 @@
                         },
                         {
                             "count":0,
+                            "src_time":"200"
+                        }
+                    ]
+                },
+                "network_latency_per_locator":{
+                    "0":[
+                        {
+                            "data":1.1,
+                            "src_time":"0"
+                        },
+                        {
+                            "data":1.1,
+                            "src_time":"100"
+                        },
+                        {
+                            "data":1.1,
                             "src_time":"200"
                         }
                     ]

--- a/test/unittest/Resources/database_dump.json
+++ b/test/unittest/Resources/database_dump.json
@@ -581,52 +581,6 @@
     },
     "locators":{
         "9":{
-            "data":{
-                "network_latency_per_locator":{
-                    "9":[
-                        {
-                            "data":1.0,
-                            "src_time":"1000"
-                        },
-                        {
-                            "data":5.5,
-                            "src_time":"2000"
-                        },
-                        {
-                            "data":1.0,
-                            "src_time":"3000"
-                        },
-                        {
-                            "data":5.5,
-                            "src_time":"4000"
-                        },
-                        {
-                            "data":1.0,
-                            "src_time":"5000"
-                        },
-                        {
-                            "data":5.5,
-                            "src_time":"6000"
-                        },
-                        {
-                            "data":1.0,
-                            "src_time":"7000"
-                        },
-                        {
-                            "data":5.5,
-                            "src_time":"8000"
-                        },
-                        {
-                            "data":1.0,
-                            "src_time":"9000"
-                        },
-                        {
-                            "data":5.5,
-                            "src_time":"10000"
-                        }
-                    ]
-                }
-            },
             "datareaders":[
                 "17"
             ],
@@ -637,10 +591,6 @@
             "alias":"locator_1"
         },
         "18":{
-            "data":{
-                "network_latency_per_locator":{
-                }
-            },
             "datareaders":[
                 "26"
             ],
@@ -1155,6 +1105,50 @@
                             "src_time":"10000"
                         }
                     ]
+                },
+                "network_latency_per_locator":{
+                    "9":[
+                        {
+                            "data":1.0,
+                            "src_time":"1000"
+                        },
+                        {
+                            "data":5.5,
+                            "src_time":"2000"
+                        },
+                        {
+                            "data":1.0,
+                            "src_time":"3000"
+                        },
+                        {
+                            "data":5.5,
+                            "src_time":"4000"
+                        },
+                        {
+                            "data":1.0,
+                            "src_time":"5000"
+                        },
+                        {
+                            "data":5.5,
+                            "src_time":"6000"
+                        },
+                        {
+                            "data":1.0,
+                            "src_time":"7000"
+                        },
+                        {
+                            "data":5.5,
+                            "src_time":"8000"
+                        },
+                        {
+                            "data":1.0,
+                            "src_time":"9000"
+                        },
+                        {
+                            "data":5.5,
+                            "src_time":"10000"
+                        }
+                    ]
                 }
             },
             "datareaders":[
@@ -1221,6 +1215,8 @@
                 "rtps_packets_lost":{
                 },
                 "rtps_packets_sent":{
+                },
+                "network_latency_per_locator":{
                 }
             },
             "datareaders":[

--- a/test/unittest/Resources/empty_entities_dump.json
+++ b/test/unittest/Resources/empty_entities_dump.json
@@ -85,6 +85,8 @@
                 "rtps_packets_lost": {},
                 "rtps_bytes_lost": {},
 
+                "network_latency_per_locator": {},
+
                 "last_reported_rtps_bytes_lost":{},
                 "last_reported_rtps_bytes_sent":{},
                 "last_reported_rtps_packets_lost":{},
@@ -183,12 +185,7 @@
             "name": "locator_0",
             "alias": "locator_0",
             "datawriters": ["7"],
-            "datareaders": ["8"],
-
-            "data":
-            {
-                "network_latency_per_locator": {}
-            }
+            "datareaders": ["8"]
         }
     }
 }

--- a/test/unittest/Resources/old_complex_dump.json
+++ b/test/unittest/Resources/old_complex_dump.json
@@ -665,24 +665,6 @@
     },
     "locators":{
         "0":{
-            "data":{
-                "network_latency_per_locator":{
-                    "0":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
-            },
             "datareaders":[
                 "8"
             ],
@@ -693,24 +675,6 @@
             "alias":"locator_0"
         },
         "18":{
-            "data":{
-                "network_latency_per_locator":{
-                    "18":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
-            },
             "datareaders":[
                 "26"
             ],
@@ -721,24 +685,6 @@
             "alias":"locator_2"
         },
         "9":{
-            "data":{
-                "network_latency_per_locator":{
-                    "9":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
-            },
             "datareaders":[
                 "17"
             ],
@@ -902,6 +848,22 @@
                         },
                         {
                             "count":0,
+                            "src_time":"200"
+                        }
+                    ]
+                },
+                "network_latency_per_locator":{
+                    "9":[
+                        {
+                            "data":1.1,
+                            "src_time":"0"
+                        },
+                        {
+                            "data":1.1,
+                            "src_time":"100"
+                        },
+                        {
+                            "data":1.1,
                             "src_time":"200"
                         }
                     ]
@@ -1077,6 +1039,22 @@
                             "src_time":"200"
                         }
                     ]
+                },
+                "network_latency_per_locator":{
+                    "18":[
+                        {
+                            "data":1.1,
+                            "src_time":"0"
+                        },
+                        {
+                            "data":1.1,
+                            "src_time":"100"
+                        },
+                        {
+                            "data":1.1,
+                            "src_time":"200"
+                        }
+                    ]
                 }
             },
             "datareaders":[
@@ -1246,6 +1224,22 @@
                         },
                         {
                             "count":0,
+                            "src_time":"200"
+                        }
+                    ]
+                },
+                "network_latency_per_locator":{
+                    "0":[
+                        {
+                            "data":1.1,
+                            "src_time":"0"
+                        },
+                        {
+                            "data":1.1,
+                            "src_time":"100"
+                        },
+                        {
+                            "data":1.1,
                             "src_time":"200"
                         }
                     ]

--- a/test/unittest/Resources/simple_dump.json
+++ b/test/unittest/Resources/simple_dump.json
@@ -145,6 +145,16 @@
                         }
                     ]
                 },
+                "network_latency_per_locator":
+                {
+                    "0":
+                    [
+                        {
+                            "src_time": "0",
+                            "data": 1.1
+                        }
+                    ]
+                },
 
                 "last_reported_edp_packets":{
                     "count":2,
@@ -333,21 +343,7 @@
             "name": "locator_0",
             "alias": "locator_0",
             "datawriters": ["7"],
-            "datareaders": ["8"],
-
-            "data":
-            {
-                "network_latency_per_locator":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "data": 1.1
-                        }
-                    ]
-                }
-            }
+            "datareaders": ["8"]
         }
     }
 }

--- a/test/unittest/Resources/simple_dump_no_process_participant_link.json
+++ b/test/unittest/Resources/simple_dump_no_process_participant_link.json
@@ -145,6 +145,16 @@
                         }
                     ]
                 },
+                "network_latency_per_locator":
+                {
+                    "0":
+                    [
+                        {
+                            "src_time": "0",
+                            "data": 1.1
+                        }
+                    ]
+                },
 
                 "last_reported_edp_packets":{
                     "count":2,
@@ -333,21 +343,7 @@
             "name": "locator_0",
             "alias": "locator_0",
             "datawriters": ["7"],
-            "datareaders": ["8"],
-
-            "data":
-            {
-                "network_latency_per_locator":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "data": 1.1
-                        }
-                    ]
-                }
-            }
+            "datareaders": ["8"]
         }
     }
 }

--- a/test/unittest/Resources/simple_dump_no_process_participant_link_erased_domain.json
+++ b/test/unittest/Resources/simple_dump_no_process_participant_link_erased_domain.json
@@ -63,21 +63,7 @@
             "name": "locator_0",
             "alias": "locator_0",
             "datawriters": [],
-            "datareaders": [],
-
-            "data":
-            {
-                "network_latency_per_locator":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "data": 1.1
-                        }
-                    ]
-                }
-            }
+            "datareaders": []
         }
     }
 }

--- a/test/unittest/StatisticsBackend/BackendDumpTests.cpp
+++ b/test/unittest/StatisticsBackend/BackendDumpTests.cpp
@@ -130,6 +130,7 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_FALSE(participant->data.rtps_bytes_sent.empty());
             ASSERT_FALSE(participant->data.rtps_packets_lost.empty());
             ASSERT_FALSE(participant->data.rtps_bytes_lost.empty());
+            ASSERT_FALSE(participant->data.network_latency_per_locator.empty());
 
             ASSERT_FALSE(participant->data.last_reported_rtps_packets_sent_count.empty());
             ASSERT_FALSE(participant->data.last_reported_rtps_bytes_sent_count.empty());
@@ -189,12 +190,6 @@ TEST(backend_dump_tests, database_dump_and_clear)
                     std::chrono::system_clock::time_point() &&
                     datareader->data.last_reported_nackfrag_count.count == 0);
         }
-        // Locators
-        for (const auto& it : locators)
-        {
-            auto locator = std::dynamic_pointer_cast<const Locator>(it);
-            ASSERT_FALSE(locator->data.network_latency_per_locator.empty());
-        }
     }
 
     // Check if the output file exists (we do not want to overwrite anything)
@@ -222,6 +217,7 @@ TEST(backend_dump_tests, database_dump_and_clear)
             ASSERT_TRUE(participant->data.rtps_bytes_sent.empty());
             ASSERT_TRUE(participant->data.rtps_packets_lost.empty());
             ASSERT_TRUE(participant->data.rtps_bytes_lost.empty());
+            ASSERT_TRUE(participant->data.network_latency_per_locator.empty());
 
             ASSERT_FALSE(participant->data.last_reported_rtps_packets_sent_count.empty());
             ASSERT_FALSE(participant->data.last_reported_rtps_bytes_sent_count.empty());
@@ -280,12 +276,6 @@ TEST(backend_dump_tests, database_dump_and_clear)
                     datareader->data.last_reported_nackfrag_count.src_ts ==
                     std::chrono::system_clock::time_point() &&
                     datareader->data.last_reported_nackfrag_count.count == 0);
-        }
-        // Locators
-        for (const auto& it : locators)
-        {
-            auto locator = std::dynamic_pointer_cast<const Locator>(it);
-            ASSERT_TRUE(locator->data.network_latency_per_locator.empty());
         }
     }
 

--- a/test/unittest/StatisticsBackend/GetDataTests.cpp
+++ b/test/unittest/StatisticsBackend/GetDataTests.cpp
@@ -101,7 +101,7 @@ GTEST_INSTANTIATE_TEST_MACRO(
     get_data_no_data_tests,
     ::testing::Values(
         std::make_tuple(DataKind::FASTDDS_LATENCY, EntityId(25), EntityId(26)),
-        std::make_tuple(DataKind::NETWORK_LATENCY, EntityId(18), EntityId(18)),
+        std::make_tuple(DataKind::NETWORK_LATENCY, EntityId(24), EntityId(18)),
         std::make_tuple(DataKind::PUBLICATION_THROUGHPUT, EntityId(25), EntityId::invalid()),
         std::make_tuple(DataKind::SUBSCRIPTION_THROUGHPUT, EntityId(26), EntityId::invalid()),
         std::make_tuple(DataKind::RTPS_PACKETS_SENT, EntityId(24), EntityId(18)),
@@ -200,7 +200,7 @@ GTEST_INSTANTIATE_TEST_MACRO(
     ::testing::Values(
         std::make_tuple(DataKind::INVALID, EntityId::invalid(), EntityId::invalid()),
         std::make_tuple(DataKind::FASTDDS_LATENCY, EntityId(16), EntityId(17)),
-        std::make_tuple(DataKind::NETWORK_LATENCY, EntityId(9), EntityId(9)),
+        std::make_tuple(DataKind::NETWORK_LATENCY, EntityId(15), EntityId(9)),
         std::make_tuple(DataKind::PUBLICATION_THROUGHPUT, EntityId(16), EntityId::invalid()),
         std::make_tuple(DataKind::SUBSCRIPTION_THROUGHPUT, EntityId(17), EntityId::invalid()),
         std::make_tuple(DataKind::RTPS_PACKETS_SENT, EntityId(15), EntityId(9)),

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -300,7 +300,7 @@ TEST_F(statistics_backend_tests, get_data_supported_entity_kinds)
              EntityKind::DATAWRITER, EntityKind::DATAREADER)},
 
         {DataKind::NETWORK_LATENCY, std::pair<EntityKind, EntityKind>(
-             EntityKind::LOCATOR, EntityKind::LOCATOR)},
+             EntityKind::PARTICIPANT, EntityKind::LOCATOR)},
 
         {DataKind::PUBLICATION_THROUGHPUT, std::pair<EntityKind, EntityKind>(
              EntityKind::DATAWRITER, EntityKind::INVALID)},

--- a/test/unittest/StatisticsReaderListener/StatisticsReaderListenerTests.cpp
+++ b/test/unittest/StatisticsReaderListener/StatisticsReaderListenerTests.cpp
@@ -352,8 +352,8 @@ TEST_F(statistics_reader_listener_tests, new_history_latency_received)
 TEST_F(statistics_reader_listener_tests, new_network_latency_received)
 {
     std::array<uint8_t, 16> src_locator_address = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-    uint32_t src_locator_port = 1024;
-    std::string src_locator_str = "TCPv4:[13.14.15.16]:1024";
+    uint32_t src_locator_port = 0;
+    std::string src_locator_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|d.e.f.10";
     std::array<uint8_t, 16> dst_locator_address = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
     uint32_t dst_locator_port = 2048;
     std::string dst_locator_str = "TCPv4:[4.3.2.1]:2048";
@@ -382,10 +382,9 @@ TEST_F(statistics_reader_listener_tests, new_network_latency_received)
 
     add_sample_to_reader_history(data, get_default_info());
 
-    // Precondition: The source locator exists and has ID 1
-    EXPECT_CALL(database_, get_entities_by_name(EntityKind::LOCATOR, src_locator_str)).Times(AnyNumber())
-            .WillRepeatedly(Return(std::vector<std::pair<EntityId, EntityId>>(1,
-            std::make_pair(EntityId(0), EntityId(1)))));
+    // Precondition: The participant exists and has ID 1
+    EXPECT_CALL(database_, get_entity_by_guid(EntityKind::PARTICIPANT, src_locator_str)).Times(AnyNumber())
+            .WillRepeatedly(Return(std::pair<EntityId, EntityId>(std::make_pair(EntityId(0), EntityId(1)))));
 
     // Precondition: The destination locator exists and has ID 2
     EXPECT_CALL(database_, get_entities_by_name(EntityKind::LOCATOR, dst_locator_str)).Times(AnyNumber())

--- a/test/unittest/TestUtils/DatabaseUtils.hpp
+++ b/test/unittest/TestUtils/DatabaseUtils.hpp
@@ -335,6 +335,17 @@ public:
 
                 db.insert(domainId, entityId, sample);
             }
+
+            // network_latency
+            {
+                NetworkLatencySample sample;
+
+                sample.src_ts = nanoseconds_to_systemclock(1);
+                sample.data = 1.1;
+                sample.remote_locator = EntityId(writer_locator2->id);
+
+                db.insert(domainId, entityId, sample);
+            }
         }
 
         // datawriters
@@ -449,36 +460,6 @@ public:
 
                 db.insert(domainId, entityId, sample);
             }
-        }
-
-        // locators
-        {
-            // writer_locator
-            {
-                EntityId entityId = writer_locator2->id;
-
-                NetworkLatencySample sample;
-
-                sample.src_ts = nanoseconds_to_systemclock(1);
-                sample.data = 1.1;
-                sample.remote_locator = EntityId(entityId);
-
-                db.insert(EntityId::invalid(), entityId, sample);
-            }
-
-            // reader_locator
-            {
-                EntityId entityId = reader_locator2->id;
-
-                NetworkLatencySample sample;
-
-                sample.src_ts = nanoseconds_to_systemclock(1);
-                sample.data = 1.1;
-                sample.remote_locator = EntityId(entityId);
-
-                db.insert(EntityId::invalid(), entityId, sample);
-            }
-
         }
 
         return entities;


### PR DESCRIPTION


Network Latency is currently reported as a Locator2Locator value. However, source locators are related to the Participant more than to the endpoint. This gives multiple problems in terms of discovering the source locators (they are not reported on discovery, and are found only when data arrives) and presentation (there is no way of linking a source locator to a given user endpoint).

They will be converted to a kind of Entity2Locator data. Instead of changing the data type, the Locator2Locator data type will still be used, but the IP value in the locator will be changed to the GUID of the source participant:

    * The type could be any locator type
    * The port must be zero. If not, we will disregard the data due to wrong format.
    * The IP, which is encoded as a 16 byte sequence, will hold the GUID (which also has 16 bytes)

Required changes

    * Move the network latency data from LocatorData to ParticipantData
    * Database dump and load methods must be updated to the new database schema
    * Test dumps must be updated to the new database schema
    * Review the documentation and update if necessary. Specifically the table with the related entities for each data type
    * Update get_data_supported_entity_kinds as network latency now depends on a source participant and not a source locator