### PR TITLE
queue refactor [12137]

### DIFF
--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -578,14 +578,10 @@ protected:
         /* Add to x_by_y_ collections and to locators_ */
         for (auto& locator_it : endpoint->locators)
         {
-            // See if we already know the locator
+            /* Check that locator exists */
             if (locators_.find(locator_it.first) == locators_.end())
             {
-                // Is a new one, must add and inform the user
-                // The connection to the endpoint is still not done, but that's expected at this moment
-                // In this case, we know for sure that the locator is not in the database
-                locators_[locator_it.first] = locator_it.second;
-                notify_locator_discovery(locator_it.first);
+                throw BadParameter("Locator does not exist in the database");
             }
 
             // Even if it is not new, it may be new to the participant

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -146,10 +146,12 @@ public:
     {
         if (consuming_)
         {
-            std::unique_lock<std::mutex> guard(cv_mutex_);
-            consuming_ = false;
-            guard.unlock();
-            cv_.notify_all();
+            {
+                std::unique_lock<std::mutex> guard(cv_mutex_);
+                consuming_ = false;
+                guard.unlock();
+                cv_.notify_all();
+            }
             consumer_thread_->join();
             consumer_thread_.reset();
             return true;

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -344,6 +344,10 @@ struct EntityDiscoveryInfo
     std::string type_name;
     fastrtps::rtps::RemoteLocatorList locators;
 
+    // Alias
+    std::string alias;
+    bool is_virtual_metatraffic = false;
+
     EntityDiscoveryInfo(
             EntityKind kind)
         : entity_kind(kind)
@@ -356,6 +360,7 @@ struct EntityDiscoveryInfo
     }
 
 protected:
+
     EntityKind entity_kind;
 
 };
@@ -379,69 +384,68 @@ public:
 
 protected:
 
+    EntityId process_participant(
+            const EntityDiscoveryInfo& info);
+
+    EntityId process_datareader(
+            const EntityDiscoveryInfo& info);
+
+    EntityId process_datawriter(
+            const EntityDiscoveryInfo& info);
+
     virtual void process_sample() override
     {
         try
         {
             const EntityDiscoveryInfo& info = front().second;
+            assert (info.kind() == EntityKind::PARTICIPANT ||
+                    info.kind() == EntityKind::DATAREADER ||
+                    info.kind() == EntityKind::DATAWRITER);
 
-            // Physical entities
-            if (EntityKind::HOST  == info.entity->kind ||
-                    EntityKind::USER == info.entity->kind ||
-                    EntityKind::PROCESS == info.entity->kind ||
-                    EntityKind::LOCATOR == info.entity->kind)
+            EntityId entity_id;
+            switch (info.kind())
             {
-                assert(info.discovery_status == details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
-                info.entity->id = database_->insert(info.entity);
-
-                details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                    info.entity->id,
-                    info.entity->kind, info.discovery_status);
+                case EntityKind::PARTICIPANT:
+                    entity_id = process_participant(info);
+                    break;
+                case EntityKind::DATAREADER:
+                    entity_id = process_datareader(info);
+                    break;
+                case EntityKind::DATAWRITER:
+                    entity_id = process_datawriter(info);
+                    break;
+                default:
+                    break;
+                    // Already asserted
             }
-            // Domains are not discovered, they are created on monitor initialization
-            else if (EntityKind::DOMAIN == info.entity->kind)
-            {
-                assert(info.discovery_status == details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
-                info.entity->id = database_->insert(info.entity);
-            }
-            // Domain entities
-            else
-            {
-                // The topic is never updated/undiscovered, is only discovered. So the status is not changed.
-                // It status will only be updated if its endpoints are discovered/undiscovered.
-                if (info.entity->kind == EntityKind::TOPIC)
-                {
-                    assert(
-                        info.discovery_status == details::StatisticsBackendData::DiscoveryStatus::DISCOVERY &&
-                        !info.entity->id.is_valid_and_unique());
-                    info.entity->id = database_->insert(info.entity);
-                }
-                else
-                {
-                    // Insert the entity only if is discovered and is not yet inserted in the database
-                    if (info.discovery_status == details::StatisticsBackendData::DiscoveryStatus::DISCOVERY &&
-                            !info.entity->id.is_valid_and_unique())
-                    {
-                        info.entity->id = database_->insert(info.entity);
-                    }
 
-                    // Update the entity status and check if its references must also change it status
-                    database_->change_entity_status(info.entity->id,
-                            info.discovery_status !=
-                            details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY);
-                }
-
-                details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(info.domain_id,
-                        info.entity->id,
-                        info.entity->kind,
-                        info.discovery_status);
-            }
+            details::StatisticsBackendData::get_instance()->on_domain_entity_discovery(
+                info.domain_id,
+                entity_id,
+                info.kind(),
+                info.discovery_status);
         }
         catch (const eprosima::statistics_backend::Exception& e)
         {
             logError(BACKEND_DATABASE_QUEUE, e.what());
         }
     }
+
+    template<typename T>
+    EntityId process_endpoint_discovery(
+            const T& info);
+
+    std::shared_ptr<database::DDSEndpoint> create_datareader(
+            const eprosima::fastrtps::rtps::GUID_t& guid,
+            const EntityDiscoveryInfo& info,
+            std::shared_ptr<database::DomainParticipant> participant,
+            std::shared_ptr<database::Topic> topic);
+
+    std::shared_ptr<database::DDSEndpoint> create_datawriter(
+            const eprosima::fastrtps::rtps::GUID_t& guid,
+            const EntityDiscoveryInfo& info,
+            std::shared_ptr<database::DomainParticipant> participant,
+            std::shared_ptr<database::Topic> topic);
 
     // Database
     Database* database_;

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -30,6 +30,7 @@
 #include <fastdds/rtps/common/Guid.h>
 #include <fastdds/rtps/common/Locator.h>
 #include <fastdds/rtps/common/SequenceNumber.h>
+#include <fastdds/rtps/common/RemoteLocators.hpp>
 #include <fastdds/dds/log/Log.hpp>
 
 #include <database/database.hpp>
@@ -328,9 +329,35 @@ protected:
 
 struct EntityDiscoveryInfo
 {
-    std::shared_ptr<Entity> entity;
-    EntityId domain_id;
     details::StatisticsBackendData::DiscoveryStatus discovery_status;
+    EntityId domain_id;
+
+    fastrtps::rtps::GUID_t guid;
+    database::Qos qos;
+
+    // Participant data
+    std::string address;
+    std::string participant_name;
+
+    // Enpoint data
+    std::string topic_name;
+    std::string type_name;
+    fastrtps::rtps::RemoteLocatorList locators;
+
+    EntityDiscoveryInfo(
+            EntityKind kind)
+        : entity_kind(kind)
+    {
+    }
+
+    EntityKind kind() const
+    {
+        return entity_kind;
+    }
+
+protected:
+    EntityKind entity_kind;
+
 };
 
 class DatabaseEntityQueue : public DatabaseQueue<EntityDiscoveryInfo>

--- a/src/cpp/subscriber/QosSerializer.cpp
+++ b/src/cpp/subscriber/QosSerializer.cpp
@@ -449,73 +449,73 @@ void serialize<fastdds::dds::ParameterPropertyList_t> (
     serialized[fieldname] = properties;
 }
 
-database::Qos reader_info_to_backend_qos(
-        const fastrtps::rtps::ReaderDiscoveryInfo& reader_info)
+database::Qos reader_proxy_data_to_backend_qos(
+        const fastrtps::rtps::ReaderProxyData& reader_data)
 {
     database::Qos reader;
 
-    serialize(reader_info.info.m_qos.m_durability, durability_tag, reader);
-    serialize(reader_info.info.m_qos.m_deadline, deadline_tag, reader);
-    serialize(reader_info.info.m_qos.m_latencyBudget, latency_budget_tag, reader);
-    serialize(reader_info.info.m_qos.m_liveliness, liveliness_tag, reader);
-    serialize(reader_info.info.m_qos.m_reliability, reliability_tag, reader);
-    serialize(reader_info.info.m_qos.m_ownership, ownership_tag, reader);
-    serialize(reader_info.info.m_qos.m_destinationOrder, destination_order_tag, reader);
-    serialize(reader_info.info.m_qos.m_userData, user_data_tag, reader);
-    serialize(reader_info.info.m_qos.m_timeBasedFilter, time_based_filter_tag, reader);
-    serialize(reader_info.info.m_qos.m_presentation, presentation_tag, reader);
-    serialize(reader_info.info.m_qos.m_partition, partition_tag, reader);
-    serialize(reader_info.info.m_qos.m_topicData, topic_data_tag, reader);
-    serialize(reader_info.info.m_qos.m_groupData, group_data_tag, reader);
-    serialize(reader_info.info.m_qos.m_durabilityService, durability_service_tag, reader);
-    serialize(reader_info.info.m_qos.m_lifespan, lifespan_tag, reader);
-    serialize(reader_info.info.m_qos.representation, representation_tag, reader);
-    serialize(reader_info.info.m_qos.type_consistency, type_consistency_tag, reader);
-    serialize(reader_info.info.m_qos.m_disablePositiveACKs, disable_positive_acks_tag, reader);
-    serialize(reader_info.info.m_qos.data_sharing, data_sharing_tag, reader);
+    serialize(reader_data.m_qos.m_durability, durability_tag, reader);
+    serialize(reader_data.m_qos.m_deadline, deadline_tag, reader);
+    serialize(reader_data.m_qos.m_latencyBudget, latency_budget_tag, reader);
+    serialize(reader_data.m_qos.m_liveliness, liveliness_tag, reader);
+    serialize(reader_data.m_qos.m_reliability, reliability_tag, reader);
+    serialize(reader_data.m_qos.m_ownership, ownership_tag, reader);
+    serialize(reader_data.m_qos.m_destinationOrder, destination_order_tag, reader);
+    serialize(reader_data.m_qos.m_userData, user_data_tag, reader);
+    serialize(reader_data.m_qos.m_timeBasedFilter, time_based_filter_tag, reader);
+    serialize(reader_data.m_qos.m_presentation, presentation_tag, reader);
+    serialize(reader_data.m_qos.m_partition, partition_tag, reader);
+    serialize(reader_data.m_qos.m_topicData, topic_data_tag, reader);
+    serialize(reader_data.m_qos.m_groupData, group_data_tag, reader);
+    serialize(reader_data.m_qos.m_durabilityService, durability_service_tag, reader);
+    serialize(reader_data.m_qos.m_lifespan, lifespan_tag, reader);
+    serialize(reader_data.m_qos.representation, representation_tag, reader);
+    serialize(reader_data.m_qos.type_consistency, type_consistency_tag, reader);
+    serialize(reader_data.m_qos.m_disablePositiveACKs, disable_positive_acks_tag, reader);
+    serialize(reader_data.m_qos.data_sharing, data_sharing_tag, reader);
 
     return reader;
 }
 
-database::Qos writer_info_to_backend_qos(
-        const fastrtps::rtps::WriterDiscoveryInfo& writer_info)
+database::Qos writer_proxy_data_to_backend_qos(
+        const fastrtps::rtps::WriterProxyData& writer_data)
 {
     database::Qos writer;
 
-    serialize(writer_info.info.m_qos.m_durability, durability_tag, writer);
-    serialize(writer_info.info.m_qos.m_durabilityService, durability_service_tag, writer);
-    serialize(writer_info.info.m_qos.m_deadline, deadline_tag, writer);
-    serialize(writer_info.info.m_qos.m_latencyBudget, latency_budget_tag, writer);
-    serialize(writer_info.info.m_qos.m_liveliness, liveliness_tag, writer);
-    serialize(writer_info.info.m_qos.m_reliability, reliability_tag, writer);
-    serialize(writer_info.info.m_qos.m_lifespan, lifespan_tag, writer);
-    serialize(writer_info.info.m_qos.m_userData, user_data_tag, writer);
-    serialize(writer_info.info.m_qos.m_timeBasedFilter, time_based_filter_tag, writer);
-    serialize(writer_info.info.m_qos.m_ownership, ownership_tag, writer);
-    serialize(writer_info.info.m_qos.m_ownershipStrength, ownership_strength_tag, writer);
-    serialize(writer_info.info.m_qos.m_destinationOrder, destination_order_tag, writer);
-    serialize(writer_info.info.m_qos.m_presentation, presentation_tag, writer);
-    serialize(writer_info.info.m_qos.m_partition, partition_tag, writer);
-    serialize(writer_info.info.m_qos.m_topicData, topic_data_tag, writer);
-    serialize(writer_info.info.m_qos.m_groupData, group_data_tag, writer);
-    serialize(writer_info.info.m_qos.m_publishMode, publish_mode_tag, writer);
-    serialize(writer_info.info.m_qos.representation, representation_tag, writer);
-    serialize(writer_info.info.m_qos.m_disablePositiveACKs, disable_positive_acks_tag, writer);
-    serialize(writer_info.info.m_qos.data_sharing, data_sharing_tag, writer);
+    serialize(writer_data.m_qos.m_durability, durability_tag, writer);
+    serialize(writer_data.m_qos.m_durabilityService, durability_service_tag, writer);
+    serialize(writer_data.m_qos.m_deadline, deadline_tag, writer);
+    serialize(writer_data.m_qos.m_latencyBudget, latency_budget_tag, writer);
+    serialize(writer_data.m_qos.m_liveliness, liveliness_tag, writer);
+    serialize(writer_data.m_qos.m_reliability, reliability_tag, writer);
+    serialize(writer_data.m_qos.m_lifespan, lifespan_tag, writer);
+    serialize(writer_data.m_qos.m_userData, user_data_tag, writer);
+    serialize(writer_data.m_qos.m_timeBasedFilter, time_based_filter_tag, writer);
+    serialize(writer_data.m_qos.m_ownership, ownership_tag, writer);
+    serialize(writer_data.m_qos.m_ownershipStrength, ownership_strength_tag, writer);
+    serialize(writer_data.m_qos.m_destinationOrder, destination_order_tag, writer);
+    serialize(writer_data.m_qos.m_presentation, presentation_tag, writer);
+    serialize(writer_data.m_qos.m_partition, partition_tag, writer);
+    serialize(writer_data.m_qos.m_topicData, topic_data_tag, writer);
+    serialize(writer_data.m_qos.m_groupData, group_data_tag, writer);
+    serialize(writer_data.m_qos.m_publishMode, publish_mode_tag, writer);
+    serialize(writer_data.m_qos.representation, representation_tag, writer);
+    serialize(writer_data.m_qos.m_disablePositiveACKs, disable_positive_acks_tag, writer);
+    serialize(writer_data.m_qos.data_sharing, data_sharing_tag, writer);
 
     return writer;
 }
 
-database::Qos participant_info_to_backend_qos(
-        const fastrtps::rtps::ParticipantDiscoveryInfo& participant_info)
+database::Qos participant_proxy_data_to_backend_qos(
+        const fastrtps::rtps::ParticipantProxyData& participant_data)
 {
     database::Qos participant;
 
-    participant[available_builtin_endpoints_tag] = participant_info.info.m_availableBuiltinEndpoints;
-    serialize(participant_info.info.m_leaseDuration, lease_duration_tag, participant);
-    serialize(participant_info.info.m_properties, properties_tag, participant);
-    serialize(participant_info.info.m_userData, user_data_tag, participant);
-    participant[vendor_id_tag] = participant_info.info.m_VendorId;
+    participant[available_builtin_endpoints_tag] = participant_data.m_availableBuiltinEndpoints;
+    serialize(participant_data.m_leaseDuration, lease_duration_tag, participant);
+    serialize(participant_data.m_properties, properties_tag, participant);
+    serialize(participant_data.m_userData, user_data_tag, participant);
+    participant[vendor_id_tag] = participant_data.m_VendorId;
 
     return participant;
 }

--- a/src/cpp/subscriber/QosSerializer.hpp
+++ b/src/cpp/subscriber/QosSerializer.hpp
@@ -21,9 +21,9 @@
 
 #include <string>
 
-#include <fastdds/rtps/reader/ReaderDiscoveryInfo.h>
-#include <fastdds/rtps/writer/WriterDiscoveryInfo.h>
-#include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
+#include <fastdds/rtps/builtin/data/ReaderProxyData.h>
+#include <fastdds/rtps/builtin/data/WriterProxyData.h>
+#include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
 
 #include <database/entities.hpp>
 
@@ -163,14 +163,14 @@ void serialize<fastdds::dds::DataSharingQosPolicy> (
         const std::string& fieldname,
         database::Qos& serialized);
 
-database::Qos reader_info_to_backend_qos(
-        const fastrtps::rtps::ReaderDiscoveryInfo& reader_info);
+database::Qos reader_proxy_data_to_backend_qos(
+        const fastrtps::rtps::ReaderProxyData& reader_data);
 
-database::Qos writer_info_to_backend_qos(
-        const fastrtps::rtps::WriterDiscoveryInfo& writer_info);
+database::Qos writer_proxy_data_to_backend_qos(
+        const fastrtps::rtps::WriterProxyData& writer_data);
 
-database::Qos participant_info_to_backend_qos(
-        const fastrtps::rtps::ParticipantDiscoveryInfo& writer_info);
+database::Qos participant_proxy_data_to_backend_qos(
+        const fastrtps::rtps::ParticipantProxyData& participant_data);
 
 
 } // namespace subscriber

--- a/src/cpp/subscriber/StatisticsParticipantListener.cpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.cpp
@@ -167,7 +167,10 @@ void StatisticsParticipantListener::on_participant_discovery(
         }
     }
 
+    entity_queue_->push(timestamp, discovery_info);
+
     // Create metatraffic entities
+    if (info.status == ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT)
     {
         // Create metatraffic endpoint and locator on the metatraffic topic.
         {
@@ -197,6 +200,7 @@ void StatisticsParticipantListener::on_participant_discovery(
             datawriter_discovery_info.domain_id = domain_id_;
             datawriter_discovery_info.topic_name = metatraffic_prefix + "TOPIC";
             datawriter_discovery_info.type_name = metatraffic_prefix + "TYPE";
+            datawriter_discovery_info.guid = info.info.m_guid;
             datawriter_discovery_info.qos = meta_traffic_qos;
             datawriter_discovery_info.alias = metatraffic_alias;
             datawriter_discovery_info.is_virtual_metatraffic = true;
@@ -205,8 +209,6 @@ void StatisticsParticipantListener::on_participant_discovery(
             entity_queue_->push(timestamp, datawriter_discovery_info);
         }
     }
-
-    entity_queue_->push(timestamp, discovery_info);
 
     // Wait until the entity queue is processed and restart the data queue
     entity_queue_->flush();

--- a/src/cpp/subscriber/StatisticsParticipantListener.cpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.cpp
@@ -170,7 +170,7 @@ void StatisticsParticipantListener::on_participant_discovery(
     entity_queue_->push(timestamp, discovery_info);
 
     // Create metatraffic entities
-    if (info.status == ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT)
+    if (details::StatisticsBackendData::DiscoveryStatus::UPDATE != discovery_info.discovery_status)
     {
         // Create metatraffic endpoint and locator on the metatraffic topic.
         {
@@ -204,8 +204,7 @@ void StatisticsParticipantListener::on_participant_discovery(
             datawriter_discovery_info.qos = meta_traffic_qos;
             datawriter_discovery_info.alias = metatraffic_alias;
             datawriter_discovery_info.is_virtual_metatraffic = true;
-            datawriter_discovery_info.discovery_status =
-                    details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
+            datawriter_discovery_info.discovery_status = discovery_info.discovery_status;
             entity_queue_->push(timestamp, datawriter_discovery_info);
         }
     }

--- a/src/cpp/subscriber/StatisticsParticipantListener.cpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.cpp
@@ -26,7 +26,7 @@
 #include <fastdds/rtps/common/EntityId_t.hpp>
 
 #include "database/database_queue.hpp"
-#include "QosSerializer.hpp"
+#include "subscriber/QosSerializer.hpp"
 
 
 namespace eprosima {
@@ -54,166 +54,6 @@ inline bool is_statistics_builtin(
         const fastrtps::rtps::EntityId_t& entity_id)
 {
     return 0x60 == (0xE0 & entity_id.value[3]);
-}
-
-template<typename T>
-void StatisticsParticipantListener::process_endpoint_discovery(
-        T&& info)
-{
-    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
-
-    // Get the domain from the database
-    // This may throw if the domain does not exist
-    // The database MUST contain the domain, or something went wrong upstream
-    std::shared_ptr<database::Domain> domain = std::const_pointer_cast<database::Domain>(
-        std::static_pointer_cast<const database::Domain>(database_->get_entity(domain_id_)));
-
-    // Get the participant from the database
-    GUID_t endpoint_guid = info.info.guid();
-    GUID_t participant_guid(endpoint_guid.guidPrefix, c_EntityId_RTPSParticipant);
-    std::pair<EntityId, EntityId> participant_id;
-    try
-    {
-        participant_id = database_->get_entity_by_guid(EntityKind::PARTICIPANT, to_string(participant_guid));
-    }
-    catch (const Exception&)
-    {
-        logError(STATISTICS_BACKEND, "endpoint " << to_string(endpoint_guid) + " discovered on Participant " + to_string(
-                    participant_guid)
-                + " but there is no such Participant in the database");
-        return;
-    }
-    std::shared_ptr<database::DomainParticipant> participant =
-            std::const_pointer_cast<database::DomainParticipant>(
-        std::static_pointer_cast<const database::DomainParticipant>(database_->get_entity(
-            participant_id.second)));
-
-    assert(participant_id.first == domain_id_);
-
-    // Check whether the topic is already in the database
-    std::shared_ptr<database::Topic> topic;
-    auto topic_ids = database_->get_entities_by_name(EntityKind::TOPIC, info.info.topicName().to_string());
-
-    // Check if any of these topics is in the current domain AND shares the data type
-    for (const auto& topic_id : topic_ids)
-    {
-        if (topic_id.first == domain_id_)
-        {
-            topic = std::const_pointer_cast<database::Topic>(
-                std::static_pointer_cast<const database::Topic>(database_->get_entity(topic_id.second)));
-
-            if (topic->data_type == info.info.typeName().to_string())
-            {
-                //Found the correct topic
-                break;
-            }
-            else
-            {
-                // The data type is not the same, so it must be another topic
-                topic.reset();
-            }
-        }
-    }
-
-    // If no such topic exists, create a new one
-    if (!topic)
-    {
-        topic = std::make_shared<database::Topic>(
-            info.info.topicName().to_string(),
-            info.info.typeName().to_string(),
-            domain);
-
-        database::EntityDiscoveryInfo entity_discovery_info;
-        entity_discovery_info.domain_id = domain_id_;
-        entity_discovery_info.entity = topic;
-        entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
-        entity_queue_->push(timestamp, entity_discovery_info);
-    }
-
-    // Create the endpoint
-    auto endpoint = create_endpoint(endpoint_guid, info, participant, topic);
-
-    /* Start processing the locator info */
-
-    // Routine to process one locator from the locator list of the endpoint
-    auto process_locators = [&](const Locator_t& dds_locator)
-            {
-                std::shared_ptr<database::Locator> locator;
-
-                // Look for an existing locator
-                // There can only be one
-                auto locator_ids = database_->get_entities_by_name(EntityKind::LOCATOR, to_string(dds_locator));
-                assert(locator_ids.empty() || locator_ids.size() == 1);
-
-                if (!locator_ids.empty())
-                {
-                    // The locator exists.
-                    locator = std::const_pointer_cast<database::Locator>(
-                        std::static_pointer_cast<const database::Locator>(database_->get_entity(locator_ids.front().
-                                second)));
-                }
-                else
-                {
-                    // The locator is not in the database. Add the new one.
-                    locator = std::make_shared<database::Locator>(to_string(dds_locator));
-                    locator->id = database_->generate_entity_id();
-                }
-
-                endpoint->locators[locator->id] = locator;
-            };
-
-    for (const auto& dds_locator : info.info.remote_locators().unicast)
-    {
-        process_locators(dds_locator);
-    }
-    for (const auto& dds_locator : info.info.remote_locators().multicast)
-    {
-        process_locators(dds_locator);
-    }
-
-    // Push the endpoint
-    database::EntityDiscoveryInfo entity_discovery_info;
-    entity_discovery_info.domain_id = domain_id_;
-    entity_discovery_info.entity = endpoint;
-    entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
-    entity_queue_->push(timestamp, entity_discovery_info);
-}
-
-template<>
-std::shared_ptr<database::DDSEndpoint> StatisticsParticipantListener::create_endpoint(
-        const GUID_t& guid,
-        const fastrtps::rtps::WriterDiscoveryInfo& info,
-        std::shared_ptr<database::DomainParticipant> participant,
-        std::shared_ptr<database::Topic> topic)
-{
-    std::stringstream name;
-    name << "DataWriter_" << info.info.topicName().to_string() << "_" << info.info.guid().entityId;
-
-    return std::make_shared<database::DataWriter>(
-        name.str(),
-        writer_info_to_backend_qos(info),
-        to_string(guid),
-        participant,
-        topic);
-}
-
-template<>
-std::shared_ptr<database::DDSEndpoint> StatisticsParticipantListener::create_endpoint(
-        const GUID_t& guid,
-        const fastrtps::rtps::ReaderDiscoveryInfo& info,
-
-        std::shared_ptr<database::DomainParticipant> participant,
-        std::shared_ptr<database::Topic> topic)
-{
-    std::stringstream name;
-    name << "DataReader_" << info.info.topicName().to_string() << "_" << info.info.guid().entityId;
-
-    return std::make_shared<database::DataReader>(
-        name.str(),
-        reader_info_to_backend_qos(info),
-        to_string(guid),
-        participant,
-        topic);
 }
 
 StatisticsParticipantListener::StatisticsParticipantListener(
@@ -283,23 +123,6 @@ std::string get_address(
     return "localhost";
 }
 
-// Return the participant_id
-std::string get_participant_id(
-        const GUID_t& guid)
-{
-    // The participant_id can be obtained from the last 4 octets in the GUID prefix
-    std::stringstream buffer;
-    buffer << std::hex << std::setfill('0');
-    for (int i = 0; i < 3; i++)
-    {
-        buffer << std::setw(2) << static_cast<unsigned>(guid.guidPrefix.value[i + 8]);
-        buffer << ".";
-    }
-    buffer << std::setw(2) << static_cast<unsigned>(guid.guidPrefix.value[3 + 8]);
-
-    return buffer.str();
-}
-
 void StatisticsParticipantListener::on_participant_discovery(
         DomainParticipant* /*participant*/,
         ParticipantDiscoveryInfo&& info)
@@ -314,207 +137,76 @@ void StatisticsParticipantListener::on_participant_discovery(
             std::to_string(domain_id_.value()) + "___";
     const std::string metatraffic_alias = "_metatraffic_";
 
-    // The participant is already in the database
-    try
+    // Build the discovery info for the queue
+    database::EntityDiscoveryInfo discovery_info(EntityKind::PARTICIPANT);
+    discovery_info.domain_id = domain_id_;
+    discovery_info.guid = info.info.m_guid;
+    discovery_info.qos = subscriber::participant_proxy_data_to_backend_qos(info.info);
+
+    discovery_info.address = get_address(info.info);
+    discovery_info.participant_name = info.info.m_participantName.to_string();
+
+    switch (info.status)
     {
-        EntityId participant_id = database_->get_entity_by_guid(EntityKind::PARTICIPANT, to_string(info.info.m_guid))
-                        .second;
-
-        // Build discovery info
-        database::EntityDiscoveryInfo entity_discovery_info;
-        entity_discovery_info.domain_id = domain_id_;
-        std::shared_ptr<database::DomainParticipant> participant = std::const_pointer_cast<database::DomainParticipant>(
-            std::static_pointer_cast<const database::DomainParticipant>(database_->get_entity(participant_id)));
-        entity_discovery_info.entity = participant;
-
-        switch (info.status)
+        case ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT:
         {
-            case ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT:
-            {
-                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
-                break;
-            }
-            case ParticipantDiscoveryInfo::CHANGED_QOS_PARTICIPANT:
-                // TODO [ILG] : Process these messages and save the updated QoS
-                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UPDATE;
-                break;
-
-            case ParticipantDiscoveryInfo::REMOVED_PARTICIPANT:
-            case ParticipantDiscoveryInfo::DROPPED_PARTICIPANT:
-            {
-                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY;
-                break;
-            }
+            discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
+            break;
         }
-
-        if (details::StatisticsBackendData::DiscoveryStatus::UPDATE != entity_discovery_info.discovery_status)
+        case ParticipantDiscoveryInfo::CHANGED_QOS_PARTICIPANT:
         {
-            // Need to activate the meta traffic endpoint too
-            // Check if is the metatraffic endpoint already exists
-            if (nullptr == participant->meta_traffic_endpoint)
-            {
-                logError(STATISTICS_BACKEND, "Participant " << to_string(
-                            info.info.m_guid) + " without meta-traffic endpoint")
-            }
-            else
-            {
-                database::EntityDiscoveryInfo endpoint_discovery_info;
-                endpoint_discovery_info.domain_id = domain_id_;
-                endpoint_discovery_info.entity = participant->meta_traffic_endpoint;
-                endpoint_discovery_info.discovery_status = entity_discovery_info.discovery_status;
-                entity_queue_->push(timestamp, endpoint_discovery_info);
-            }
+            // TODO [ILG] : Process these messages and save the updated QoS
+            discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UPDATE;
+            break;
         }
-
-        entity_queue_->push(timestamp, entity_discovery_info);
-    }
-    // The participant is not in the database
-    catch (BadParameter&)
-    {
-        if (info.status == ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT)
+        case ParticipantDiscoveryInfo::REMOVED_PARTICIPANT:
+        case ParticipantDiscoveryInfo::DROPPED_PARTICIPANT:
         {
-            // Get the domain from the database
-            // This may throw if the domain does not exist
-            // The database MUST contain the domain, or something went wrong upstream
-            std::shared_ptr<database::Domain> domain = std::const_pointer_cast<database::Domain>(
-                std::static_pointer_cast<const database::Domain>(database_->get_entity(domain_id_)));
-
-            std::string name = info.info.m_participantName.to_string();
-
-            // If the user does not provide a specific name for the participant, give it a descriptive name
-            if (name.empty())
-            {
-                // The name will be constructed as IP:participant_id
-                name = get_address(info.info) + ":" + get_participant_id(info.info.m_guid);
-            }
-
-            // Create the participant and push it to the queue
-            GUID_t participant_guid = info.info.m_guid;
-            auto participant = std::make_shared<database::DomainParticipant>(
-                name,
-                participant_info_to_backend_qos(info),
-                to_string(participant_guid),
-                std::shared_ptr<database::Process>(),
-                domain);
-
-            // Build discovery info
-            database::EntityDiscoveryInfo participant_discovery_info;
-            participant_discovery_info.domain_id = domain_id_;
-            participant_discovery_info.entity = participant;
-            participant_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
-            entity_queue_->push(timestamp, participant_discovery_info);
-
-            // Create metatraffic entities
-            {
-                std::shared_ptr<database::Topic> metatraffic_topic;
-
-                // Check if is the metatraffic topic already exists
-                std::vector<std::pair<EntityId, EntityId>> metatraffic_topic_ids =
-                        database_->get_entities_by_name(EntityKind::TOPIC, metatraffic_prefix + "TOPIC");
-
-                for (const auto& topic_id : metatraffic_topic_ids)
-                {
-                    if (topic_id.first == domain_id_)
-                    {
-                        metatraffic_topic = std::const_pointer_cast<database::Topic>(
-                            std::static_pointer_cast<const database::Topic>(database_->get_entity(topic_id.second)));
-                        break;
-                    }
-                }
-                if (nullptr == metatraffic_topic)
-                {
-                    // Create the metatraffic topic
-                    metatraffic_topic = std::make_shared<database::Topic>(
-                        metatraffic_prefix + "TOPIC",
-                        metatraffic_prefix + "TYPE",
-                        domain);
-                    metatraffic_topic->alias = metatraffic_alias;
-
-                    // Push it to the queue
-                    database::EntityDiscoveryInfo topic_discovery_info;
-                    topic_discovery_info.domain_id = domain_id_;
-                    topic_discovery_info.entity = metatraffic_topic;
-                    topic_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
-                    entity_queue_->push(timestamp, topic_discovery_info);
-                }
-
-                // Create metatraffic endpoint and locator on the metatraffic topic.
-                {
-                    // The endpoint QoS cannot be empty. We can use this to give a description to the user.
-                    database::Qos meta_traffic_qos = {
-                        {"description", "This is a virtual placeholder endpoint with no real counterpart"}};
-                    auto datawriter = std::make_shared<database::DataWriter>(
-                        metatraffic_prefix + "ENDPOINT_" + to_string(participant_guid),
-                        meta_traffic_qos,
-                        to_string(participant_guid),
-                        participant,
-                        metatraffic_topic);
-                    datawriter->alias = metatraffic_alias;
-
-                    // Mark it as the meta traffic one
-                    datawriter->is_virtual_metatraffic = true;
-
-                    // Routine to process one locator from the locator list of the particpant
-                    auto process_locators = [&](const Locator_t& dds_locator)
-                            {
-                                // Look for the locator
-                                auto locator_ids =
-                                        database_->get_entities_by_name(EntityKind::LOCATOR,
-                                                to_string(dds_locator));
-                                if (locator_ids.empty())
-                                {
-                                    // The locator is not in the database. Add the new one.
-                                    std::shared_ptr<database::Locator> locator =
-                                            std::make_shared<database::Locator>(to_string(dds_locator));
-
-                                    locator->id = database_->generate_entity_id();
-                                    datawriter->locators[locator->id] = locator;
-                                }
-                                else
-                                {
-                                    // The locator exists. Add the existing one.
-                                    auto existing = std::const_pointer_cast<database::Locator>(
-                                        std::static_pointer_cast<const database::Locator>(database_->get_entity(
-                                            locator_ids.
-                                                    front().second)));
-                                    datawriter->locators[existing->id] = existing;
-                                }
-                            };
-
-                    for (auto dds_locator : info.info.metatraffic_locators.unicast)
-                    {
-                        process_locators(dds_locator);
-                    }
-                    for (auto dds_locator : info.info.metatraffic_locators.multicast)
-                    {
-                        process_locators(dds_locator);
-                    }
-                    for (auto dds_locator : info.info.default_locators.unicast)
-                    {
-                        process_locators(dds_locator);
-                    }
-                    for (auto dds_locator : info.info.default_locators.multicast)
-                    {
-                        process_locators(dds_locator);
-                    }
-
-                    // Push it to the queue
-                    database::EntityDiscoveryInfo datawriter_discovery_info;
-                    datawriter_discovery_info.domain_id = domain_id_;
-                    datawriter_discovery_info.entity = datawriter;
-                    datawriter_discovery_info.discovery_status =
-                            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
-                    entity_queue_->push(timestamp, datawriter_discovery_info);
-                }
-            }
-        }
-        else
-        {
-            // Start the data consumer again before reporting error
-            data_queue_->start_consumer();
-            throw BadParameter("Update or undiscover a participant which is not in the database");
+            discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY;
+            break;
         }
     }
+
+    // Create metatraffic entities
+    {
+        // Create metatraffic endpoint and locator on the metatraffic topic.
+        {
+            // The endpoint QoS cannot be empty. We can use this to give a description to the user.
+            database::Qos meta_traffic_qos = {
+                {"description", "This is a virtual placeholder endpoint with no real counterpart"}};
+            // Push it to the queue
+            database::EntityDiscoveryInfo datawriter_discovery_info(EntityKind::DATAWRITER);
+
+            for (auto dds_locator : info.info.metatraffic_locators.unicast)
+            {
+                datawriter_discovery_info.locators.add_unicast_locator(dds_locator);
+            }
+            for (auto dds_locator : info.info.metatraffic_locators.multicast)
+            {
+                datawriter_discovery_info.locators.add_multicast_locator(dds_locator);
+            }
+            for (auto dds_locator : info.info.default_locators.unicast)
+            {
+                datawriter_discovery_info.locators.add_unicast_locator(dds_locator);
+            }
+            for (auto dds_locator : info.info.default_locators.multicast)
+            {
+                datawriter_discovery_info.locators.add_multicast_locator(dds_locator);
+            }
+
+            datawriter_discovery_info.domain_id = domain_id_;
+            datawriter_discovery_info.topic_name = metatraffic_prefix + "TOPIC";
+            datawriter_discovery_info.type_name = metatraffic_prefix + "TYPE";
+            datawriter_discovery_info.qos = meta_traffic_qos;
+            datawriter_discovery_info.alias = metatraffic_alias;
+            datawriter_discovery_info.is_virtual_metatraffic = true;
+            datawriter_discovery_info.discovery_status =
+                    details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
+            entity_queue_->push(timestamp, datawriter_discovery_info);
+        }
+    }
+
+    entity_queue_->push(timestamp, discovery_info);
 
     // Wait until the entity queue is processed and restart the data queue
     entity_queue_->flush();
@@ -536,53 +228,37 @@ void StatisticsParticipantListener::on_subscriber_discovery(
 
     std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
-    // The subscriber is already in the database
-    try
+    // Build the discovery info for the queue
+    database::EntityDiscoveryInfo discovery_info(EntityKind::DATAREADER);
+    discovery_info.domain_id = domain_id_;
+    discovery_info.guid = info.info.guid();
+    discovery_info.qos = subscriber::reader_proxy_data_to_backend_qos(info.info);
+
+    discovery_info.topic_name = info.info.topicName().to_string();
+    discovery_info.type_name = info.info.typeName().to_string();
+    discovery_info.locators = info.info.remote_locators();
+
+    switch (info.status)
     {
-        EntityId datareader_id =
-                database_->get_entity_by_guid(EntityKind::DATAREADER, to_string(info.info.guid())).second;
-
-        // Build discovery info
-        database::EntityDiscoveryInfo entity_discovery_info;
-        entity_discovery_info.domain_id = domain_id_;
-        entity_discovery_info.entity = std::const_pointer_cast<database::DataReader>(
-            std::static_pointer_cast<const database::DataReader>(database_->get_entity(datareader_id)));
-
-        switch (info.status)
+        case ReaderDiscoveryInfo::DISCOVERED_READER:
         {
-            case ReaderDiscoveryInfo::DISCOVERED_READER:
-            {
-                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
-                break;
-            }
-            case ReaderDiscoveryInfo::CHANGED_QOS_READER:
-                // TODO [ILG] : Process these messages and save the updated QoS and/or Locators
-                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UPDATE;
-                break;
-
-            case ReaderDiscoveryInfo::REMOVED_READER:
-            {
-                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY;
-                break;
-            }
+            discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
+            break;
         }
-
-        entity_queue_->push(timestamp, entity_discovery_info);
-    }
-    // The subscriber is not in the database
-    catch (BadParameter&)
-    {
-        if (info.status == ReaderDiscoveryInfo::DISCOVERED_READER)
+        case ReaderDiscoveryInfo::CHANGED_QOS_READER:
         {
-            process_endpoint_discovery(info);
+            // TODO [ILG] : Process these messages and save the updated QoS
+            discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UPDATE;
+            break;
         }
-        else
+        case ReaderDiscoveryInfo::REMOVED_READER:
         {
-            // Start the data consumer again before reporting error
-            data_queue_->start_consumer();
-            throw BadParameter("Update or undiscover a subscriber which is not in the database");
+            discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY;
+            break;
         }
     }
+
+    entity_queue_->push(timestamp, discovery_info);
 
     // Wait until the entity queue is processed and restart the data queue
     entity_queue_->flush();
@@ -602,53 +278,37 @@ void StatisticsParticipantListener::on_publisher_discovery(
 
     std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
-    // The publisher is already in the database
-    try
+    // Build the discovery info for the queue
+    database::EntityDiscoveryInfo discovery_info(EntityKind::DATAWRITER);
+    discovery_info.domain_id = domain_id_;
+    discovery_info.guid = info.info.guid();
+    discovery_info.qos = subscriber::writer_proxy_data_to_backend_qos(info.info);
+
+    discovery_info.topic_name = info.info.topicName().to_string();
+    discovery_info.type_name = info.info.typeName().to_string();
+    discovery_info.locators = info.info.remote_locators();
+
+    switch (info.status)
     {
-        EntityId datawriter_id =
-                database_->get_entity_by_guid(EntityKind::DATAWRITER, to_string(info.info.guid())).second;
-
-        // Build discovery info
-        database::EntityDiscoveryInfo entity_discovery_info;
-        entity_discovery_info.domain_id = domain_id_;
-        entity_discovery_info.entity = std::const_pointer_cast<database::DataWriter>(
-            std::static_pointer_cast<const database::DataWriter>(database_->get_entity(datawriter_id)));
-
-        switch (info.status)
+        case WriterDiscoveryInfo::DISCOVERED_WRITER:
         {
-            case WriterDiscoveryInfo::DISCOVERED_WRITER:
-            {
-                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
-                break;
-            }
-            case WriterDiscoveryInfo::CHANGED_QOS_WRITER:
-                // TODO [ILG] : Process these messages and save the updated QoS and/or Locators
-                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UPDATE;
-                break;
-
-            case WriterDiscoveryInfo::REMOVED_WRITER:
-            {
-                entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY;
-                break;
-            }
+            discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
+            break;
         }
-
-        entity_queue_->push(timestamp, entity_discovery_info);
-    }
-    // The publisher is not in the database
-    catch (BadParameter&)
-    {
-        if (info.status == WriterDiscoveryInfo::DISCOVERED_WRITER)
+        case WriterDiscoveryInfo::CHANGED_QOS_WRITER:
         {
-            process_endpoint_discovery(info);
+            // TODO [ILG] : Process these messages and save the updated QoS
+            discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UPDATE;
+            break;
         }
-        else
+        case WriterDiscoveryInfo::REMOVED_WRITER:
         {
-            // Start the data consumer again before reporting error
-            data_queue_->start_consumer();
-            throw BadParameter("Update or undiscover a publichser which is not in the database");
+            discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY;
+            break;
         }
     }
+
+    entity_queue_->push(timestamp, discovery_info);
 
     // Wait until the entity queue is processed and restart the data queue
     entity_queue_->flush();

--- a/src/cpp/subscriber/StatisticsParticipantListener.hpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.hpp
@@ -89,36 +89,11 @@ public:
 
 protected:
 
-    template<typename T>
-    void process_endpoint_discovery(
-            T&& info);
-
-    template<typename T>
-    std::shared_ptr<database::DDSEndpoint> create_endpoint(
-            const eprosima::fastrtps::rtps::GUID_t& guid,
-            const T& qos,
-            std::shared_ptr<database::DomainParticipant> participant,
-            std::shared_ptr<database::Topic> topic);
-
     EntityId domain_id_;                            ///< The DomainId this listener is monitoring
     database::Database* database_;                  ///< Reference to the statistics database. Injected on construction
     database::DatabaseEntityQueue* entity_queue_;   ///< Reference to the statistics entity queue. Injected on construction
     database::DatabaseDataQueue* data_queue_;       ///< Reference to the statistics data queue. Injected on construction
 };
-
-template<>
-std::shared_ptr<database::DDSEndpoint> StatisticsParticipantListener::create_endpoint(
-        const eprosima::fastrtps::rtps::GUID_t& guid,
-        const fastrtps::rtps::ReaderDiscoveryInfo& info,
-        std::shared_ptr<database::DomainParticipant> participant,
-        std::shared_ptr<database::Topic> topic);
-
-template<>
-std::shared_ptr<database::DDSEndpoint> StatisticsParticipantListener::create_endpoint(
-        const eprosima::fastrtps::rtps::GUID_t& guid,
-        const fastrtps::rtps::WriterDiscoveryInfo& info,
-        std::shared_ptr<database::DomainParticipant> participant,
-        std::shared_ptr<database::Topic> topic);
 
 
 } //namespace database

--- a/test/unittest/Database/DatabaseDumpTests.cpp
+++ b/test/unittest/Database/DatabaseDumpTests.cpp
@@ -67,6 +67,7 @@ constexpr const int16_t MAGNITUDE_DEFAULT = 0;
 
 // at least pass microseconds tenths to avoid windows system_clock resolution issue
 #define TIME_DEFAULT(x) nanoseconds_to_systemclock(100 * (x))
+#define PART_GUID_DEFAULT(x) "01.0f.00.00.00.00.00.00.00.00.00.0" + std::to_string(x) + "|0.0.1.0"
 #define GUID_DEFAULT(x) "01.0f.00.00.00.00.00.00.00.00.00.0" + std::to_string(x) + "|0.0.0.0"
 
 void initialize_empty_entities(
@@ -83,7 +84,7 @@ void initialize_empty_entities(
     std::shared_ptr<Topic> topic = std::make_shared<Topic>(std::string(TOPIC_DEFAULT_NAME(
                         index)), DATA_TYPE_DEFAULT, domain);
     std::shared_ptr<DomainParticipant> participant = std::make_shared<DomainParticipant>(std::string(
-                        PARTICIPANT_DEFAULT_NAME(index)), QOS_DEFAULT, GUID_DEFAULT(index), nullptr, domain);
+                        PARTICIPANT_DEFAULT_NAME(index)), QOS_DEFAULT, PART_GUID_DEFAULT(index), nullptr, domain);
     std::shared_ptr<DataWriter> dw = std::make_shared<DataWriter>(std::string(
                         DATAWRITER_DEFAULT_NAME(index)), QOS_DEFAULT, GUID_DEFAULT(index), participant, topic);
     std::shared_ptr<DataReader> dr = std::make_shared<DataReader>(std::string(
@@ -376,7 +377,7 @@ void initialize_empty_entities_unlinked(
     std::shared_ptr<Topic> topic = std::make_shared<Topic>(std::string(TOPIC_DEFAULT_NAME(
                         index)), DATA_TYPE_DEFAULT, domain);
     std::shared_ptr<DomainParticipant> participant = std::make_shared<DomainParticipant>(std::string(
-                        PARTICIPANT_DEFAULT_NAME(index)), QOS_DEFAULT, GUID_DEFAULT(index), nullptr, domain);
+                        PARTICIPANT_DEFAULT_NAME(index)), QOS_DEFAULT, PART_GUID_DEFAULT(index), nullptr, domain);
     std::shared_ptr<DataWriter> dw = std::make_shared<DataWriter>(std::string(
                         DATAWRITER_DEFAULT_NAME(index)), QOS_DEFAULT, GUID_DEFAULT(index), participant, topic);
     std::shared_ptr<DataReader> dr = std::make_shared<DataReader>(std::string(

--- a/test/unittest/Database/DatabaseDumpTests.cpp
+++ b/test/unittest/Database/DatabaseDumpTests.cpp
@@ -90,8 +90,8 @@ void initialize_empty_entities(
                         DATAREADER_DEFAULT_NAME(index)), QOS_DEFAULT, GUID_DEFAULT(index), participant, topic);
     std::shared_ptr<Locator> locator = std::make_shared<Locator>(std::string(LOCATOR_DEFAULT_NAME(index)));
 
-    locator->id = db.generate_entity_id();
-
+    locator->id = db.insert(locator);
+    ASSERT_NE(locator->id, EntityId::invalid());
     dw->locators[locator->id] = locator;
     dr->locators[locator->id] = locator;
 
@@ -383,8 +383,8 @@ void initialize_empty_entities_unlinked(
                         DATAREADER_DEFAULT_NAME(index)), QOS_DEFAULT, GUID_DEFAULT(index), participant, topic);
     std::shared_ptr<Locator> locator = std::make_shared<Locator>(std::string(LOCATOR_DEFAULT_NAME(index)));
 
-    locator->id = db.generate_entity_id();
-
+    locator->id = db.insert(locator);
+    ASSERT_NE(locator->id, EntityId::invalid());
     dw->locators[locator->id] = locator;
     dr->locators[locator->id] = locator;
 

--- a/test/unittest/Database/DatabaseStatusTests.cpp
+++ b/test/unittest/Database/DatabaseStatusTests.cpp
@@ -1078,7 +1078,7 @@ TEST_F(database_status_tests, endpoints)
     // The new entities will be active
     auto datawriter1 = std::make_shared<DataWriter>("datawriter1", "qos", "21.22.23.24", participant, topic);
     auto writer_locator1 = std::make_shared<Locator>("writer_locator1");
-    writer_locator1->id = db.generate_entity_id();
+    writer_locator1->id = db.insert(writer_locator1);
     datawriter1->locators[writer_locator1->id] = writer_locator1;
     db.insert(datawriter1);
     ASSERT_TRUE(datawriter1->active);
@@ -1086,7 +1086,7 @@ TEST_F(database_status_tests, endpoints)
 
     auto datareader1 = std::make_shared<DataReader>("datareader1", "qos", "11.12.13.14", participant, topic);
     auto reader_locator1 = std::make_shared<Locator>("reader_locator1");
-    reader_locator1->id = db.generate_entity_id();
+    reader_locator1->id = db.insert(reader_locator1);
     datareader1->locators[reader_locator1->id] = reader_locator1;
     db.insert(datareader1);
     ASSERT_TRUE(datareader1->active);

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -503,7 +503,7 @@ void insert_ddsendpoint_two_equal_locators()
 
     // Create two equal locator for the endpoint
     auto locator1 = std::make_shared<Locator>("test_locator");
-    locator1->id = db.generate_entity_id();
+    locator1->id = db.insert(locator1);
     auto locator2 = std::make_shared<Locator>("test_locator");
     locator2->id = db.generate_entity_id();
 
@@ -644,7 +644,7 @@ TEST_F(database_tests, insert_host)
 
     /* Check that the host is inserted correctly */
     std::map<EntityId, std::shared_ptr<Host>> hosts = db.hosts();
-    ASSERT_EQ(hosts.size(), 1);
+    ASSERT_EQ(hosts.size(), 1u);
     ASSERT_NE(hosts.find(host_id), hosts.end());
     ASSERT_EQ(host_name, hosts[host_id]->name);
     ASSERT_EQ(host_name, hosts[host_id]->alias);
@@ -663,7 +663,7 @@ TEST_F(database_tests, insert_host_two)
 
     /* Check that the hosts are inserted correctly */
     std::map<EntityId, std::shared_ptr<Host>> hosts = db.hosts();
-    ASSERT_EQ(hosts.size(), 2);
+    ASSERT_EQ(hosts.size(), 2u);
     ASSERT_NE(hosts.find(host_id), hosts.end());
     ASSERT_NE(hosts.find(host_id_2), hosts.end());
     ASSERT_EQ(host_name, hosts[host_id]->name);
@@ -713,12 +713,12 @@ TEST_F(database_tests, insert_user_valid)
     EntityId user_id = db.insert(user);
 
     /* Check that the user is correctly inserted in host */
-    ASSERT_EQ(host->users.size(), 1);
+    ASSERT_EQ(host->users.size(), 1u);
     ASSERT_EQ(host->users[user_id].get(), user.get());
 
     /* Check that the user is correctly inserted users_ */
     std::map<EntityId, std::shared_ptr<User>> users = db.users();
-    ASSERT_EQ(users.size(), 1);
+    ASSERT_EQ(users.size(), 1u);
     ASSERT_NE(users.find(user_id), users.end());
     ASSERT_EQ(user_name, users[user_id]->name);
     ASSERT_EQ(user_name, users[user_id]->alias);
@@ -740,13 +740,13 @@ TEST_F(database_tests, insert_user_two_valid)
     EntityId user_id_2 = db.insert(user_2);
 
     /* Check that the users are correctly inserted in host */
-    ASSERT_EQ(host->users.size(), 2);
+    ASSERT_EQ(host->users.size(), 2u);
     ASSERT_EQ(host->users[user_id].get(), user.get());
     ASSERT_EQ(host->users[user_id_2].get(), user_2.get());
 
     /* Check that the users are correctly inserted users_ */
     std::map<EntityId, std::shared_ptr<User>> users = db.users();
-    ASSERT_EQ(users.size(), 2);
+    ASSERT_EQ(users.size(), 2u);
     ASSERT_NE(users.find(user_id), users.end());
     ASSERT_NE(users.find(user_id_2), users.end());
     ASSERT_EQ(user_name, users[user_id]->name);
@@ -829,12 +829,12 @@ TEST_F(database_tests, insert_process_valid)
     EntityId process_id = db.insert(process);
 
     /* Check that the process is correctly inserted in user */
-    ASSERT_EQ(user->processes.size(), 1);
+    ASSERT_EQ(user->processes.size(), 1u);
     ASSERT_EQ(user->processes[process_id].get(), process.get());
 
     /* Check that the process is correctly inserted processes_s */
     auto processes = db.processes();
-    ASSERT_EQ(processes.size(), 1);
+    ASSERT_EQ(processes.size(), 1u);
     ASSERT_NE(processes.find(process_id), processes.end());
     ASSERT_EQ(process_name, processes[process_id]->name);
     ASSERT_EQ(process_name, processes[process_id]->alias);
@@ -863,13 +863,13 @@ TEST_F(database_tests, insert_process_two_valid)
     EntityId process_id_2 = db.insert(process_2);
 
     /* Check that the processes are correctly inserted in user */
-    ASSERT_EQ(user->processes.size(), 2);
+    ASSERT_EQ(user->processes.size(), 2u);
     ASSERT_EQ(user->processes[process_id].get(), process.get());
     ASSERT_EQ(user->processes[process_id_2].get(), process_2.get());
 
     /* Check that the processes are correctly inserted processes_ */
     auto processes = db.processes();
-    ASSERT_EQ(processes.size(), 2);
+    ASSERT_EQ(processes.size(), 2u);
     ASSERT_NE(processes.find(process_id), processes.end());
     ASSERT_NE(processes.find(process_id_2), processes.end());
     ASSERT_EQ(process_name, processes[process_id]->name);
@@ -964,13 +964,13 @@ TEST_F(database_tests, insert_process_two_same_user_diff_pid)
     auto process_id_2 = db.insert(process_2);
 
     /* Check that the processes are correctly inserted in user */
-    ASSERT_EQ(user->processes.size(), 2);
+    ASSERT_EQ(user->processes.size(), 2u);
     ASSERT_EQ(user->processes[process_id].get(), process.get());
     ASSERT_EQ(user->processes[process_id_2].get(), process_2.get());
 
     /* Check that the processes are correctly inserted processes_ */
     auto processes = db.processes();
-    ASSERT_EQ(processes.size(), 2);
+    ASSERT_EQ(processes.size(), 2u);
     ASSERT_NE(processes.find(process_id), processes.end());
     ASSERT_NE(processes.find(process_id_2), processes.end());
     ASSERT_EQ(process_pid, processes[process_id]->pid);
@@ -1044,14 +1044,14 @@ TEST_F(database_tests, insert_process_two_diff_host_same_pid)
     auto process_id_2 = db.insert(process_2);
 
     /* Check that the processes are correctly inserted in user */
-    ASSERT_EQ(user->processes.size(), 1);
-    ASSERT_EQ(user_2->processes.size(), 1);
+    ASSERT_EQ(user->processes.size(), 1u);
+    ASSERT_EQ(user_2->processes.size(), 1u);
     ASSERT_EQ(user->processes[process_id].get(), process.get());
     ASSERT_EQ(user_2->processes[process_id_2].get(), process_2.get());
 
     /* Check that the processes are correctly inserted processes_ */
     auto processes = db.processes();
-    ASSERT_EQ(processes.size(), 2);
+    ASSERT_EQ(processes.size(), 2u);
     ASSERT_NE(processes.find(process_id), processes.end());
     ASSERT_NE(processes.find(process_id_2), processes.end());
     ASSERT_EQ(process_pid, processes[process_id]->pid);
@@ -1068,7 +1068,7 @@ TEST_F(database_tests, insert_domain_valid)
 
     /* Check that the domain is inserted correctly */
     auto domains = db.domains();
-    ASSERT_EQ(domains.size(), 1);
+    ASSERT_EQ(domains.size(), 1u);
     ASSERT_NE(domains.find(domain_id), domains.end());
     ASSERT_EQ(domain_name, domains[domain_id]->name);
     ASSERT_EQ(domain_name, domains[domain_id]->alias);
@@ -1087,7 +1087,7 @@ TEST_F(database_tests, insert_domain_two_valid)
 
     /* Check that the domains are inserted correctly */
     auto domains = db.domains();
-    ASSERT_EQ(domains.size(), 2);
+    ASSERT_EQ(domains.size(), 2u);
     ASSERT_NE(domains.find(domain_id), domains.end());
     ASSERT_NE(domains.find(domain_id_2), domains.end());
     ASSERT_EQ(domain_name, domains[domain_id]->name);
@@ -1137,13 +1137,13 @@ TEST_F(database_tests, insert_topic_valid)
     EntityId topic_id = db.insert(topic);
 
     /* Check that the topic is correctly inserted in domain */
-    ASSERT_EQ(domain->topics.size(), 1);
+    ASSERT_EQ(domain->topics.size(), 1u);
     ASSERT_EQ(domain->topics[topic_id].get(), topic.get());
 
     /* Check that the topic is inserted correctly inserted in topic_ */
     auto topics = db.topics();
-    ASSERT_EQ(topics.size(), 1);
-    ASSERT_EQ(topics[domain_id].size(), 1);
+    ASSERT_EQ(topics.size(), 1u);
+    ASSERT_EQ(topics[domain_id].size(), 1u);
     ASSERT_NE(topics[domain_id].find(topic_id), topics[domain_id].end());
     ASSERT_EQ(topic_name, topics[domain_id][topic_id]->name);
     ASSERT_EQ(topic_name, topics[domain_id][topic_id]->alias);
@@ -1169,14 +1169,14 @@ TEST_F(database_tests, insert_topic_two_valid)
     EntityId topic_id_2 = db.insert(topic_2);
 
     /* Check that the topics are correctly inserted in domain */
-    ASSERT_EQ(domain->topics.size(), 2);
+    ASSERT_EQ(domain->topics.size(), 2u);
     ASSERT_EQ(domain->topics[topic_id].get(), topic.get());
     ASSERT_EQ(domain->topics[topic_id_2].get(), topic_2.get());
 
     /* Check that the topics are correctly inserted in topic_ */
     auto topics = db.topics();
-    ASSERT_EQ(topics.size(), 1);
-    ASSERT_EQ(topics[domain_id].size(), 2);
+    ASSERT_EQ(topics.size(), 1u);
+    ASSERT_EQ(topics[domain_id].size(), 2u);
     ASSERT_NE(topics[domain_id].find(topic_id), topics[domain_id].end());
     ASSERT_NE(topics[domain_id].find(topic_id_2), topics[domain_id].end());
     ASSERT_EQ(topic_name, topics[domain_id][topic_id]->name);
@@ -1256,14 +1256,14 @@ TEST_F(database_tests, insert_topic_two_same_domain_same_name)
     EntityId topic_id_2 = db.insert(topic_2);
 
     /* Check that the topics are correctly inserted in domain */
-    ASSERT_EQ(domain->topics.size(), 2);
+    ASSERT_EQ(domain->topics.size(), 2u);
     ASSERT_EQ(domain->topics[topic_id].get(), topic.get());
     ASSERT_EQ(domain->topics[topic_id_2].get(), topic_2.get());
 
     /* Check that the topics are correctly inserted in topic_ */
     auto topics = db.topics();
-    ASSERT_EQ(topics.size(), 1);
-    ASSERT_EQ(topics[domain_id].size(), 2);
+    ASSERT_EQ(topics.size(), 1u);
+    ASSERT_EQ(topics[domain_id].size(), 2u);
     ASSERT_NE(topics[domain_id].find(topic_id), topics[domain_id].end());
     ASSERT_NE(topics[domain_id].find(topic_id_2), topics[domain_id].end());
     ASSERT_EQ(topic_name, topics[domain_id][topic_id]->name);
@@ -1309,14 +1309,14 @@ TEST_F(database_tests, insert_topic_two_same_domain_diff_name_same_type)
     EntityId topic_id_2 = db.insert(topic_2);
 
     /* Check that the topics are correctly inserted in domain */
-    ASSERT_EQ(domain->topics.size(), 2);
+    ASSERT_EQ(domain->topics.size(), 2u);
     ASSERT_EQ(domain->topics[topic_id].get(), topic.get());
     ASSERT_EQ(domain->topics[topic_id_2].get(), topic_2.get());
 
     /* Check that the topics are correctly inserted in topic_ */
     auto topics = db.topics();
-    ASSERT_EQ(topics.size(), 1);
-    ASSERT_EQ(topics[domain_id].size(), 2);
+    ASSERT_EQ(topics.size(), 1u);
+    ASSERT_EQ(topics[domain_id].size(), 2u);
     ASSERT_NE(topics[domain_id].find(topic_id), topics[domain_id].end());
     ASSERT_NE(topics[domain_id].find(topic_id_2), topics[domain_id].end());
     ASSERT_EQ(topic_name, topics[domain_id][topic_id]->name);
@@ -1350,13 +1350,13 @@ TEST_F(database_tests, insert_participant_valid)
     auto participant_id = db.insert(participant);
 
     /* Check that the participant is correctly inserted in domain */
-    ASSERT_EQ(domain->participants.size(), 1);
+    ASSERT_EQ(domain->participants.size(), 1u);
     ASSERT_EQ(domain->participants[participant_id].get(), participant.get());
 
     /* Check that the participant is inserted correctly inserted in participants_ */
     auto participants = db.participants();
-    ASSERT_EQ(participants.size(), 1);
-    ASSERT_EQ(participants[domain_id].size(), 1);
+    ASSERT_EQ(participants.size(), 1u);
+    ASSERT_EQ(participants[domain_id].size(), 1u);
     ASSERT_NE(participants[domain_id].find(participant_id), participants[domain_id].end());
     ASSERT_EQ(part_name, participants[domain_id][participant_id]->name);
     ASSERT_EQ(part_name, participants[domain_id][participant_id]->alias);
@@ -1393,14 +1393,14 @@ TEST_F(database_tests, insert_participant_two_valid)
     auto participant_id_2 = db.insert(participant_2);
 
     /* Check that the participants are correctly inserted in domain */
-    ASSERT_EQ(domain->participants.size(), 2);
+    ASSERT_EQ(domain->participants.size(), 2u);
     ASSERT_EQ(domain->participants[participant_id].get(), participant.get());
     ASSERT_EQ(domain->participants[participant_id_2].get(), participant_2.get());
 
     /* Check that the participants are inserted correctly inserted in participants_ */
     auto participants = db.participants();
-    ASSERT_EQ(participants.size(), 1);
-    ASSERT_EQ(participants[domain_id].size(), 2);
+    ASSERT_EQ(participants.size(), 1u);
+    ASSERT_EQ(participants[domain_id].size(), 2u);
     ASSERT_NE(participants[domain_id].find(participant_id), participants[domain_id].end());
     ASSERT_NE(participants[domain_id].find(participant_id_2), participants[domain_id].end());
     ASSERT_EQ(part_name, participants[domain_id][participant_id]->name);
@@ -1644,7 +1644,7 @@ TEST_F(database_tests, insert_locator)
 
     /* Check that the locator is inserted correctly */
     std::map<EntityId, std::shared_ptr<Locator>> locators = db.locators();
-    ASSERT_EQ(locators.size(), 1);
+    ASSERT_EQ(locators.size(), 1u);
     ASSERT_NE(locators.find(host_id), locators.end());
     ASSERT_EQ(locator_name, locators[locator_id]->name);
     ASSERT_EQ(locator_name, locators[locator_id]->alias);
@@ -1663,7 +1663,7 @@ TEST_F(database_tests, insert_locator_two)
 
     /* Check that the locators are inserted correctly */
     std::map<EntityId, std::shared_ptr<Locator>> locators = db.locators();
-    ASSERT_EQ(locators.size(), 2);
+    ASSERT_EQ(locators.size(), 2u);
     ASSERT_NE(locators.find(locator_id), locators.end());
     ASSERT_NE(locators.find(locator_id_2), locators.end());
     ASSERT_EQ(locator_name, locators[locator_id]->name);
@@ -1729,19 +1729,19 @@ TEST_F(database_tests, link_participant_with_process_unlinked)
     ASSERT_NO_THROW(db.link_participant_with_process(participant_id, process_id));
 
     /* Check that the participant is correctly inserted in process */
-    ASSERT_EQ(process->participants.size(), 1);
+    ASSERT_EQ(process->participants.size(), 1u);
     ASSERT_EQ(process->participants[participant_id].get(), participant.get());
 
     /* Check that domain is inserted correctly in domains_by_process_ */
     auto domains_by_process = db.domains_by_process();
-    ASSERT_EQ(domains_by_process.size(), 1);
-    ASSERT_EQ(domains_by_process[process_id].size(), 1);
+    ASSERT_EQ(domains_by_process.size(), 1u);
+    ASSERT_EQ(domains_by_process[process_id].size(), 1u);
     ASSERT_EQ(domains_by_process[process_id][domain_id].get(), domain.get());
 
     /* Check that domain is inserted correctly in processes_by_domain_ */
     auto processes_by_domain = db.processes_by_domain();
-    ASSERT_EQ(processes_by_domain.size(), 1);
-    ASSERT_EQ(processes_by_domain[domain_id].size(), 1);
+    ASSERT_EQ(processes_by_domain.size(), 1u);
+    ASSERT_EQ(processes_by_domain[domain_id].size(), 1u);
     ASSERT_EQ(processes_by_domain[domain_id][process_id].get(), process.get());
 }
 
@@ -1845,7 +1845,7 @@ TEST_F(database_tests, insert_sample_network_latency)
     sample_2.data = 13;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
 
-    ASSERT_EQ(participant->data.network_latency_per_locator[reader_locator->id].size(), 2);
+    ASSERT_EQ(participant->data.network_latency_per_locator[reader_locator->id].size(), 2u);
     ASSERT_EQ(participant->data.network_latency_per_locator[reader_locator->id][0],
             static_cast<EntityDataSample>(sample));
     ASSERT_EQ(participant->data.network_latency_per_locator[reader_locator->id][1],
@@ -1870,7 +1870,7 @@ TEST_F(database_tests, insert_sample_publication_throughput)
     sample_2.data = 13;
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
 
-    ASSERT_EQ(writer->data.publication_throughput.size(), 2);
+    ASSERT_EQ(writer->data.publication_throughput.size(), 2u);
     ASSERT_EQ(writer->data.publication_throughput[0], static_cast<EntityDataSample>(sample));
     ASSERT_EQ(writer->data.publication_throughput[1], static_cast<EntityDataSample>(sample_2));
 }
@@ -1892,7 +1892,7 @@ TEST_F(database_tests, insert_sample_subscription_throughput)
     sample_2.data = 13;
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_2));
 
-    ASSERT_EQ(reader->data.subscription_throughput.size(), 2);
+    ASSERT_EQ(reader->data.subscription_throughput.size(), 2u);
     ASSERT_EQ(reader->data.subscription_throughput[0], static_cast<EntityDataSample>(sample));
     ASSERT_EQ(reader->data.subscription_throughput[1], static_cast<EntityDataSample>(sample_2));
 }
@@ -1916,8 +1916,8 @@ TEST_F(database_tests, insert_sample_rtps_packets_sent)
     sample_2.count = 13;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
 
-    ASSERT_EQ(participant->data.rtps_packets_sent.size(), 1);
-    ASSERT_EQ(participant->data.rtps_packets_sent[writer_locator->id].size(), 2);
+    ASSERT_EQ(participant->data.rtps_packets_sent.size(), 1u);
+    ASSERT_EQ(participant->data.rtps_packets_sent[writer_locator->id].size(), 2u);
     ASSERT_EQ(participant->data.rtps_packets_sent[writer_locator->id][0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(participant->data.rtps_packets_sent[writer_locator->id][1],
             static_cast<EntityCountSample>(sample_2) - static_cast<EntityCountSample>(sample));
@@ -1944,8 +1944,8 @@ TEST_F(database_tests, insert_sample_rtps_packets_sent_unknown_remote_locator)
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample));
     ASSERT_NO_THROW(db.get_entity(remote_id));
 
-    ASSERT_EQ(participant->data.rtps_packets_sent.size(), 1);
-    ASSERT_EQ(participant->data.rtps_packets_sent[remote_id].size(), 1);
+    ASSERT_EQ(participant->data.rtps_packets_sent.size(), 1u);
+    ASSERT_EQ(participant->data.rtps_packets_sent[remote_id].size(), 1u);
     ASSERT_EQ(participant->data.rtps_packets_sent[remote_id][0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(participant->data.last_reported_rtps_packets_sent_count[remote_id].count, sample.count);
 }
@@ -1964,8 +1964,8 @@ TEST_F(database_tests, insert_sample_rtps_bytes_sent)
     sample_2.magnitude_order = 3;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
 
-    ASSERT_EQ(participant->data.rtps_bytes_sent.size(), 1);
-    ASSERT_EQ(participant->data.rtps_bytes_sent[writer_locator->id].size(), 2);
+    ASSERT_EQ(participant->data.rtps_bytes_sent.size(), 1u);
+    ASSERT_EQ(participant->data.rtps_bytes_sent[writer_locator->id].size(), 2u);
     ASSERT_EQ(participant->data.rtps_bytes_sent[writer_locator->id][0], static_cast<ByteCountSample>(sample));
     ASSERT_EQ(participant->data.rtps_bytes_sent[writer_locator->id][1],
             static_cast<ByteCountSample>(sample_2) - static_cast<ByteCountSample>(sample));
@@ -1995,8 +1995,8 @@ TEST_F(database_tests, insert_sample_rtps_bytes_sent_unknown_remote_locator)
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample));
     ASSERT_NO_THROW(db.get_entity(remote_id));
 
-    ASSERT_EQ(participant->data.rtps_bytes_sent.size(), 1);
-    ASSERT_EQ(participant->data.rtps_bytes_sent[remote_id].size(), 1);
+    ASSERT_EQ(participant->data.rtps_bytes_sent.size(), 1u);
+    ASSERT_EQ(participant->data.rtps_bytes_sent[remote_id].size(), 1u);
     ASSERT_EQ(participant->data.rtps_bytes_sent[remote_id][0], static_cast<ByteCountSample>(sample));
     ASSERT_EQ(participant->data.last_reported_rtps_bytes_sent_count[remote_id].count, sample.count);
     ASSERT_EQ(participant->data.last_reported_rtps_bytes_sent_count[remote_id].magnitude_order, sample.magnitude_order);
@@ -2014,8 +2014,8 @@ TEST_F(database_tests, insert_sample_rtps_packets_lost)
     sample_2.count = 13;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
 
-    ASSERT_EQ(participant->data.rtps_packets_lost.size(), 1);
-    ASSERT_EQ(participant->data.rtps_packets_lost[writer_locator->id].size(), 2);
+    ASSERT_EQ(participant->data.rtps_packets_lost.size(), 1u);
+    ASSERT_EQ(participant->data.rtps_packets_lost[writer_locator->id].size(), 2u);
     ASSERT_EQ(participant->data.rtps_packets_lost[writer_locator->id][0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(participant->data.rtps_packets_lost[writer_locator->id][1],
             static_cast<EntityCountSample>(sample_2) - static_cast<EntityCountSample>(sample));
@@ -2041,8 +2041,8 @@ TEST_F(database_tests, insert_sample_rtps_packets_lost_unknown_remote_locator)
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample));
     ASSERT_NO_THROW(db.get_entity(remote_id));
 
-    ASSERT_EQ(participant->data.rtps_packets_lost.size(), 1);
-    ASSERT_EQ(participant->data.rtps_packets_lost[remote_id].size(), 1);
+    ASSERT_EQ(participant->data.rtps_packets_lost.size(), 1u);
+    ASSERT_EQ(participant->data.rtps_packets_lost[remote_id].size(), 1u);
     ASSERT_EQ(participant->data.rtps_packets_lost[remote_id][0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(participant->data.last_reported_rtps_packets_lost_count[remote_id].count, sample.count);
 }
@@ -2061,8 +2061,8 @@ TEST_F(database_tests, insert_sample_rtps_bytes_lost)
     sample_2.magnitude_order = 3;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
 
-    ASSERT_EQ(participant->data.rtps_bytes_lost.size(), 1);
-    ASSERT_EQ(participant->data.rtps_bytes_lost[writer_locator->id].size(), 2);
+    ASSERT_EQ(participant->data.rtps_bytes_lost.size(), 1u);
+    ASSERT_EQ(participant->data.rtps_bytes_lost[writer_locator->id].size(), 2u);
     ASSERT_EQ(participant->data.rtps_bytes_lost[writer_locator->id][0], static_cast<ByteCountSample>(sample));
     ASSERT_EQ(participant->data.rtps_bytes_lost[writer_locator->id][1],
             static_cast<ByteCountSample>(sample_2) - static_cast<ByteCountSample>(sample));
@@ -2092,8 +2092,8 @@ TEST_F(database_tests, insert_sample_rtps_bytes_lost_unknown_remote_locator)
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample));
     ASSERT_NO_THROW(db.get_entity(remote_id));
 
-    ASSERT_EQ(participant->data.rtps_bytes_lost.size(), 1);
-    ASSERT_EQ(participant->data.rtps_bytes_lost[remote_id].size(), 1);
+    ASSERT_EQ(participant->data.rtps_bytes_lost.size(), 1u);
+    ASSERT_EQ(participant->data.rtps_bytes_lost[remote_id].size(), 1u);
     ASSERT_EQ(participant->data.rtps_bytes_lost[remote_id][0], static_cast<ByteCountSample>(sample));
     ASSERT_EQ(participant->data.last_reported_rtps_bytes_lost_count[remote_id].count, sample.count);
     ASSERT_EQ(participant->data.last_reported_rtps_bytes_lost_count[remote_id].magnitude_order, sample.magnitude_order);
@@ -2109,7 +2109,7 @@ TEST_F(database_tests, insert_sample_resent_data)
     sample_2.count = 13;
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
 
-    ASSERT_EQ(writer->data.resent_datas.size(), 2);
+    ASSERT_EQ(writer->data.resent_datas.size(), 2u);
     ASSERT_EQ(writer->data.resent_datas[0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(writer->data.resent_datas[1],
             static_cast<EntityCountSample>(sample_2) - static_cast<EntityCountSample>(sample));
@@ -2133,7 +2133,7 @@ TEST_F(database_tests, insert_sample_heartbeat_count)
     sample_2.count = 13;
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
 
-    ASSERT_EQ(writer->data.heartbeat_count.size(), 2);
+    ASSERT_EQ(writer->data.heartbeat_count.size(), 2u);
     ASSERT_EQ(writer->data.heartbeat_count[0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(writer->data.heartbeat_count[1],
             static_cast<EntityCountSample>(sample_2) - static_cast<EntityCountSample>(sample));
@@ -2157,7 +2157,7 @@ TEST_F(database_tests, insert_sample_acknack_count)
     sample_2.count = 13;
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_2));
 
-    ASSERT_EQ(reader->data.acknack_count.size(), 2);
+    ASSERT_EQ(reader->data.acknack_count.size(), 2u);
     ASSERT_EQ(reader->data.acknack_count[0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(reader->data.acknack_count[1],
             static_cast<EntityCountSample>(sample_2) - static_cast<EntityCountSample>(sample));
@@ -2181,7 +2181,7 @@ TEST_F(database_tests, insert_sample_nackfrag_count)
     sample_2.count = 13;
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_2));
 
-    ASSERT_EQ(reader->data.nackfrag_count.size(), 2);
+    ASSERT_EQ(reader->data.nackfrag_count.size(), 2u);
     ASSERT_EQ(reader->data.nackfrag_count[0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(reader->data.nackfrag_count[1],
             static_cast<EntityCountSample>(sample_2) - static_cast<EntityCountSample>(sample));
@@ -2205,7 +2205,7 @@ TEST_F(database_tests, insert_sample_gap_count)
     sample_2.count = 13;
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
 
-    ASSERT_EQ(writer->data.gap_count.size(), 2);
+    ASSERT_EQ(writer->data.gap_count.size(), 2u);
     ASSERT_EQ(writer->data.gap_count[0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(writer->data.gap_count[1],
             static_cast<EntityCountSample>(sample_2) - static_cast<EntityCountSample>(sample));
@@ -2229,7 +2229,7 @@ TEST_F(database_tests, insert_sample_data_count)
     sample_2.count = 13;
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
 
-    ASSERT_EQ(writer->data.data_count.size(), 2);
+    ASSERT_EQ(writer->data.data_count.size(), 2u);
     ASSERT_EQ(writer->data.data_count[0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(writer->data.data_count[1],
             static_cast<EntityCountSample>(sample_2) - static_cast<EntityCountSample>(sample));
@@ -2253,7 +2253,7 @@ TEST_F(database_tests, insert_sample_pdp_packets)
     sample_2.count = 13;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
 
-    ASSERT_EQ(participant->data.pdp_packets.size(), 2);
+    ASSERT_EQ(participant->data.pdp_packets.size(), 2u);
     ASSERT_EQ(participant->data.pdp_packets[0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(participant->data.pdp_packets[1],
             static_cast<EntityCountSample>(sample_2) - static_cast<EntityCountSample>(sample));
@@ -2277,7 +2277,7 @@ TEST_F(database_tests, insert_sample_edp_packets)
     sample_2.count = 13;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
 
-    ASSERT_EQ(participant->data.edp_packets.size(), 2);
+    ASSERT_EQ(participant->data.edp_packets.size(), 2u);
     ASSERT_EQ(participant->data.edp_packets[0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(participant->data.edp_packets[1],
             static_cast<EntityCountSample>(sample_2) - static_cast<EntityCountSample>(sample));
@@ -2305,8 +2305,8 @@ TEST_F(database_tests, insert_sample_discovery_time)
     sample_2.discovered = true;
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
 
-    ASSERT_EQ(participant->data.discovered_entity.size(), 1);
-    ASSERT_EQ(participant->data.discovered_entity[writer_id].size(), 2);
+    ASSERT_EQ(participant->data.discovered_entity.size(), 1u);
+    ASSERT_EQ(participant->data.discovered_entity[writer_id].size(), 2u);
     ASSERT_EQ(participant->data.discovered_entity[writer_id][0], static_cast<DiscoveryTimeSample>(sample));
     ASSERT_EQ(participant->data.discovered_entity[writer_id][1], static_cast<DiscoveryTimeSample>(sample_2));
 }
@@ -2332,7 +2332,7 @@ TEST_F(database_tests, insert_sample_sample_datas)
     sample_2.count = 13;
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
 
-    ASSERT_EQ(writer->data.sample_datas.size(), 2);
+    ASSERT_EQ(writer->data.sample_datas.size(), 2u);
     ASSERT_EQ(writer->data.sample_datas[sample.sequence_number][0], static_cast<EntityCountSample>(sample));
     ASSERT_EQ(writer->data.sample_datas[sample_2.sequence_number][0], static_cast<EntityCountSample>(sample_2));
 
@@ -2342,8 +2342,8 @@ TEST_F(database_tests, insert_sample_sample_datas)
     sample_3.count = 16;
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_3));
 
-    ASSERT_EQ(writer->data.sample_datas.size(), 2);
-    ASSERT_EQ(writer->data.sample_datas[sample.sequence_number].size(), 1);
+    ASSERT_EQ(writer->data.sample_datas.size(), 2u);
+    ASSERT_EQ(writer->data.sample_datas[sample.sequence_number].size(), 1u);
     ASSERT_EQ(writer->data.sample_datas[sample.sequence_number][0], static_cast<EntityCountSample>(sample_3));
 }
 
@@ -2483,7 +2483,7 @@ TEST_F(database_tests, get_entities_by_name_host)
 {
     /* Check that the inserted entity is retrieved correctly */
     auto hosts = db.get_entities_by_name(EntityKind::HOST, host_name);
-    EXPECT_EQ(hosts.size(), 1);
+    EXPECT_EQ(hosts.size(), 1u);
     EXPECT_FALSE(hosts[0].first.is_valid_and_unique());
     EXPECT_EQ(hosts[0].second, host_id);
 }
@@ -2491,14 +2491,14 @@ TEST_F(database_tests, get_entities_by_name_host)
 TEST_F(database_tests, get_entities_by_name_host_wrong_name)
 {
     auto hosts = db.get_entities_by_name(EntityKind::HOST, "wrong_name");
-    EXPECT_EQ(hosts.size(), 0);
+    EXPECT_EQ(hosts.size(), 0u);
 }
 
 TEST_F(database_tests, get_entities_by_name_user)
 {
     /* Check that the inserted entity is retrieved correctly */
     auto users = db.get_entities_by_name(EntityKind::USER, user_name);
-    EXPECT_EQ(users.size(), 1);
+    EXPECT_EQ(users.size(), 1u);
     EXPECT_FALSE(users[0].first.is_valid_and_unique());
     EXPECT_EQ(users[0].second, user_id);
 
@@ -2510,7 +2510,7 @@ TEST_F(database_tests, get_entities_by_name_user)
     std::vector<EntityId> ids = {user_id, user_id_2};
     users = db.get_entities_by_name(EntityKind::USER, user_name);
 
-    EXPECT_EQ(users.size(), 2);
+    EXPECT_EQ(users.size(), 2u);
     for (size_t i = 0; i < users.size(); i++)
     {
         EXPECT_FALSE(users[i].first.is_valid_and_unique());
@@ -2521,14 +2521,14 @@ TEST_F(database_tests, get_entities_by_name_user)
 TEST_F(database_tests, get_entities_by_name_user_wrong_name)
 {
     auto users = db.get_entities_by_name(EntityKind::USER, "wrong_name");
-    EXPECT_EQ(users.size(), 0);
+    EXPECT_EQ(users.size(), 0u);
 }
 
 TEST_F(database_tests, get_entities_by_name_process)
 {
     /* Check that the inserted entity is retrieved correctly */
     auto processes = db.get_entities_by_name(EntityKind::PROCESS, process_name);
-    EXPECT_EQ(processes.size(), 1);
+    EXPECT_EQ(processes.size(), 1u);
     EXPECT_FALSE(processes[0].first.is_valid_and_unique());
     EXPECT_EQ(processes[0].second, process_id);
 
@@ -2538,7 +2538,7 @@ TEST_F(database_tests, get_entities_by_name_process)
     std::vector<EntityId> ids = {process_id, process_id_2};
     processes = db.get_entities_by_name(EntityKind::PROCESS, process_name);
 
-    EXPECT_EQ(processes.size(), 2);
+    EXPECT_EQ(processes.size(), 2u);
     for (size_t i = 0; i < processes.size(); i++)
     {
         EXPECT_FALSE(processes[i].first.is_valid_and_unique());
@@ -2549,14 +2549,14 @@ TEST_F(database_tests, get_entities_by_name_process)
 TEST_F(database_tests, get_entities_by_name_process_wrong_name)
 {
     auto processes = db.get_entities_by_name(EntityKind::PROCESS, "wrong_name");
-    EXPECT_EQ(processes.size(), 0);
+    EXPECT_EQ(processes.size(), 0u);
 }
 
 TEST_F(database_tests, get_entities_by_name_domain)
 {
     /* Check that the inserted entity is retrieved correctly */
     auto domains = db.get_entities_by_name(EntityKind::DOMAIN, domain_name);
-    EXPECT_EQ(domains.size(), 1);
+    EXPECT_EQ(domains.size(), 1u);
     EXPECT_EQ(domains[0].first, domain_id);
     EXPECT_EQ(domains[0].second, domain_id);
 }
@@ -2564,14 +2564,14 @@ TEST_F(database_tests, get_entities_by_name_domain)
 TEST_F(database_tests, get_entities_by_name_domain_wrong_name)
 {
     auto domains = db.get_entities_by_name(EntityKind::DOMAIN, "wrong_name");
-    EXPECT_EQ(domains.size(), 0);
+    EXPECT_EQ(domains.size(), 0u);
 }
 
 TEST_F(database_tests, get_entities_by_name_participant)
 {
     /* Check that the inserted entity is retrieved correctly */
     auto participants = db.get_entities_by_name(EntityKind::PARTICIPANT, participant_name);
-    EXPECT_EQ(participants.size(), 1);
+    EXPECT_EQ(participants.size(), 1u);
     EXPECT_EQ(participants[0].first, domain_id);
     EXPECT_EQ(participants[0].second, participant_id);
 
@@ -2582,7 +2582,7 @@ TEST_F(database_tests, get_entities_by_name_participant)
     std::vector<EntityId> ids = {participant_id, participant_id_2};
     participants = db.get_entities_by_name(EntityKind::PARTICIPANT, participant_name);
 
-    EXPECT_EQ(participants.size(), 2);
+    EXPECT_EQ(participants.size(), 2u);
     for (size_t i = 0; i < participants.size(); i++)
     {
         EXPECT_TRUE(participants[i].first.is_valid_and_unique());
@@ -2593,14 +2593,14 @@ TEST_F(database_tests, get_entities_by_name_participant)
 TEST_F(database_tests, get_entities_by_name_participant_wrong_name)
 {
     auto participants = db.get_entities_by_name(EntityKind::PARTICIPANT, "wrong_name");
-    EXPECT_EQ(participants.size(), 0);
+    EXPECT_EQ(participants.size(), 0u);
 }
 
 TEST_F(database_tests, get_entities_by_name_topic)
 {
     /* Check that the inserted entity is retrieved correctly */
     auto topics = db.get_entities_by_name(EntityKind::TOPIC, topic_name);
-    EXPECT_EQ(topics.size(), 1);
+    EXPECT_EQ(topics.size(), 1u);
     EXPECT_EQ(topics[0].first, domain_id);
     EXPECT_EQ(topics[0].second, topic_id);
 
@@ -2612,7 +2612,7 @@ TEST_F(database_tests, get_entities_by_name_topic)
     std::vector<EntityId> ids = {topic_id, topic_id_2};
     topics = db.get_entities_by_name(EntityKind::TOPIC, topic_name);
 
-    EXPECT_EQ(topics.size(), 2);
+    EXPECT_EQ(topics.size(), 2u);
     for (size_t i = 0; i < topics.size(); i++)
     {
         EXPECT_TRUE(topics[i].first.is_valid_and_unique());
@@ -2623,14 +2623,14 @@ TEST_F(database_tests, get_entities_by_name_topic)
 TEST_F(database_tests, get_entities_by_name_topic_wrong_name)
 {
     auto topics = db.get_entities_by_name(EntityKind::TOPIC, "wrong_name");
-    EXPECT_EQ(topics.size(), 0);
+    EXPECT_EQ(topics.size(), 0u);
 }
 
 TEST_F(database_tests, get_entities_by_name_datawriter)
 {
     /* Check that the inserted entity is retrieved correctly */
     auto datawriters = db.get_entities_by_name(EntityKind::DATAWRITER, writer_name);
-    EXPECT_EQ(datawriters.size(), 1);
+    EXPECT_EQ(datawriters.size(), 1u);
     EXPECT_EQ(datawriters[0].first, domain_id);
     EXPECT_EQ(datawriters[0].second, writer_id);
 
@@ -2641,7 +2641,7 @@ TEST_F(database_tests, get_entities_by_name_datawriter)
     std::vector<EntityId> ids = {writer_id, writer_id_2};
     datawriters = db.get_entities_by_name(EntityKind::DATAWRITER, writer_name);
 
-    EXPECT_EQ(datawriters.size(), 2);
+    EXPECT_EQ(datawriters.size(), 2u);
     for (size_t i = 0; i < datawriters.size(); i++)
     {
         EXPECT_TRUE(datawriters[i].first.is_valid_and_unique());
@@ -2652,14 +2652,14 @@ TEST_F(database_tests, get_entities_by_name_datawriter)
 TEST_F(database_tests, get_entities_by_name_datawriter_wrong_name)
 {
     auto datawriters = db.get_entities_by_name(EntityKind::DATAWRITER, "wrong_name");
-    EXPECT_EQ(datawriters.size(), 0);
+    EXPECT_EQ(datawriters.size(), 0u);
 }
 
 TEST_F(database_tests, get_entities_by_name_datareader)
 {
     /* Check that the inserted entity is retrieved correctly */
     auto datareaders = db.get_entities_by_name(EntityKind::DATAREADER, reader_name);
-    EXPECT_EQ(datareaders.size(), 1);
+    EXPECT_EQ(datareaders.size(), 1u);
     EXPECT_EQ(datareaders[0].first, domain_id);
     EXPECT_EQ(datareaders[0].second, reader_id);
 
@@ -2670,7 +2670,7 @@ TEST_F(database_tests, get_entities_by_name_datareader)
     std::vector<EntityId> ids = {reader_id, reader_id_2};
     datareaders = db.get_entities_by_name(EntityKind::DATAREADER, reader_name);
 
-    EXPECT_EQ(datareaders.size(), 2);
+    EXPECT_EQ(datareaders.size(), 2u);
     for (size_t i = 0; i < datareaders.size(); i++)
     {
         EXPECT_TRUE(datareaders[i].first.is_valid_and_unique());
@@ -2681,13 +2681,13 @@ TEST_F(database_tests, get_entities_by_name_datareader)
 TEST_F(database_tests, get_entities_by_name_datareader_wrong_name)
 {
     auto datareaders = db.get_entities_by_name(EntityKind::DATAREADER, "wrong_name");
-    EXPECT_EQ(datareaders.size(), 0);
+    EXPECT_EQ(datareaders.size(), 0u);
 }
 
 TEST_F(database_tests, get_entities_by_name_locator)
 {
     auto locators = db.get_entities_by_name(EntityKind::LOCATOR, writer_locator_name);
-    EXPECT_EQ(locators.size(), 1);
+    EXPECT_EQ(locators.size(), 1u);
     EXPECT_FALSE(locators[0].first.is_valid_and_unique());
     EXPECT_EQ(locators[0].second, writer_locator->id);
 }
@@ -2695,7 +2695,7 @@ TEST_F(database_tests, get_entities_by_name_locator)
 TEST_F(database_tests, get_entities_by_name_locator_wrong_name)
 {
     auto locators = db.get_entities_by_name(EntityKind::LOCATOR, "wrong_name");
-    EXPECT_EQ(locators.size(), 0);
+    EXPECT_EQ(locators.size(), 0u);
 }
 
 TEST_F(database_tests, get_entities_by_name_invalid)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -57,7 +57,7 @@ void insert_ddsendpoint_valid()
         endpoint_name, db.test_qos, endpoint_guid, participant, topic);
     // Create a locator for the endpoint
     auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
+    locator->id = db.insert(locator);
     endpoint->locators[locator->id] = locator;
     auto endpoint_id = db.insert(endpoint);
 
@@ -126,7 +126,7 @@ void insert_ddsendpoint_two_valid()
     auto endpoint = std::make_shared<T>(
         endpoint_name, db.test_qos, endpoint_guid, participant, topic);
     auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
+    locator->id = db.insert(locator);
     endpoint->locators[locator->id] = locator;
     auto endpoint_id = db.insert(endpoint);
 
@@ -135,7 +135,7 @@ void insert_ddsendpoint_two_valid()
     auto endpoint_2 = std::make_shared<T>(
         endpoint_name_2, db.test_qos, endpoint_guid_2, participant, topic);
     auto locator_2 = std::make_shared<Locator>("test_locator_2");
-    locator_2->id = db.generate_entity_id();
+    locator_2->id = db.insert(locator_2);
     endpoint_2->locators[locator_2->id] = locator_2;
     auto endpoint_id_2 = db.insert(endpoint_2);
 
@@ -227,7 +227,7 @@ void insert_ddsendpoint_duplicated()
     auto endpoint = std::make_shared<T>(
         "test_endpoint", db.test_qos, "test_guid", participant, topic);
     auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
+    locator->id = db.insert(locator);
     endpoint->locators[locator->id] = locator;
     db.insert(endpoint);
     ASSERT_THROW(db.insert(endpoint), BadParameter);
@@ -258,7 +258,7 @@ void insert_ddsendpoint_wrong_participant()
     auto endpoint = std::make_shared<T>(
         "test_endpoint", db.test_qos, "test_guid", participant_2, topic);
     auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
+    locator->id = db.insert(locator);
     endpoint->locators[locator->id] = locator;
     ASSERT_THROW(db.insert(endpoint), BadParameter);
 }
@@ -287,7 +287,7 @@ void insert_ddsendpoint_wrong_topic()
     auto endpoint = std::make_shared<T>(
         "test_endpoint", db.test_qos, "test_guid", participant, topic_2);
     auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
+    locator->id = db.insert(locator);
     endpoint->locators[locator->id] = locator;
     ASSERT_THROW(db.insert(endpoint), BadParameter);
 }
@@ -315,7 +315,7 @@ void insert_ddsendpoint_empty_name()
     auto endpoint = std::make_shared<T>(
         "", db.test_qos, "test_guid", participant, topic);
     auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
+    locator->id = db.insert(locator);
     endpoint->locators[locator->id] = locator;
     ASSERT_THROW(db.insert(endpoint), BadParameter);
 }
@@ -343,7 +343,7 @@ void insert_ddsendpoint_empty_qos()
     auto endpoint = std::make_shared<T>(
         "test_endpoint", Qos(), "test_guid", participant, topic);
     auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
+    locator->id = db.insert(locator);
     endpoint->locators[locator->id] = locator;
     ASSERT_THROW(db.insert(endpoint), BadParameter);
 }
@@ -371,7 +371,7 @@ void insert_ddsendpoint_empty_guid()
     auto endpoint = std::make_shared<T>(
         "test_endpoint", db.test_qos, "", participant, topic);
     auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
+    locator->id = db.insert(locator);
     endpoint->locators[locator->id] = locator;
     ASSERT_THROW(db.insert(endpoint), BadParameter);
 }
@@ -425,7 +425,7 @@ void insert_ddsendpoint_two_same_domain_same_guid()
     auto endpoint = std::make_shared<T>(
         "test_endpoint", db.test_qos, endpoint_guid, participant, topic);
     auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
+    locator->id = db.insert(locator);
     endpoint->locators[locator->id] = locator;
     db.insert(endpoint);
 
@@ -466,7 +466,7 @@ void insert_ddsendpoint_two_diff_domain_same_guid()
     auto endpoint = std::make_shared<T>(
         "test_endpoint", db.test_qos, endpoint_guid, participant, topic);
     auto locator = std::make_shared<Locator>("test_locator");
-    locator->id = db.generate_entity_id();
+    locator->id = db.insert(locator);
     endpoint->locators[locator->id] = locator;
     db.insert(endpoint);
 
@@ -574,12 +574,12 @@ public:
         topic.reset(new Topic(topic_name, topic_type, domain));
         topic_id = db.insert(topic);
         writer_locator.reset(new Locator(writer_locator_name));
-        writer_locator->id = db.generate_entity_id();
+        writer_locator->id = db.insert(writer_locator);
         writer.reset(new DataWriter(writer_name, db.test_qos, writer_guid, participant, topic));
         writer->locators[writer_locator->id] = writer_locator;
         writer_id = db.insert(writer);
         reader_locator.reset(new Locator(reader_locator_name));
-        reader_locator->id = db.generate_entity_id();
+        reader_locator->id = db.insert(reader_locator);
         reader.reset(new DataReader(reader_name, db.test_qos, reader_guid, participant, topic));
         reader->locators[reader_locator->id] = reader_locator;
         reader_id = db.insert(reader);

--- a/test/unittest/DatabaseQueue/CMakeLists.txt
+++ b/test/unittest/DatabaseQueue/CMakeLists.txt
@@ -20,6 +20,7 @@ if(GTEST_FOUND AND GMOCK_FOUND)
     add_executable(database_queue_tests DatabaseQueueTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/exception/Exception.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/exception/Exception.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/subscriber/QosSerializer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/topic_types/types.cxx
     ${PROJECT_SOURCE_DIR}/src/cpp/types/EntityId.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/database/data.cpp
@@ -49,25 +50,13 @@ if(GTEST_FOUND AND GMOCK_FOUND)
 
     set(DATABASEQUEUE_TEST_LIST
         start_stop_flush
-        push_host
-        push_host_throws
-        push_user
-        push_user_throws
-        push_process
-        push_process_throws
-        push_domain
-        push_domain_throws
-        push_participant_process_exists
-        push_participant_no_process_exists
-        push_participant_throws
-        push_topic
-        push_topic_throws
+        push_participant
         push_datawriter
-        push_datawriter_throws
+        push_datawriter_topic_does_not_exist
+        push_datawriter_locator_does_not_exist
         push_datareader
-        push_datareader_throws
-        push_locator
-        push_locator_throws
+        push_datareader_topic_does_not_exist
+        push_datareader_locator_does_not_exist
         push_history_latency
         push_history_latency_no_reader
         push_history_latency_no_writer

--- a/test/unittest/QosSerializer/QosSerializerTests.cpp
+++ b/test/unittest/QosSerializer/QosSerializerTests.cpp
@@ -599,90 +599,89 @@ TEST(qos_serializer_tests, parameter_property_list_qos_policy)
 
 TEST(qos_serializer_tests, writer_info_serializer)
 {
-    eprosima::fastrtps::rtps::WriterDiscoveryInfo info(
-        eprosima::fastrtps::rtps::WriterProxyData(10, 10));
+    eprosima::fastrtps::rtps::WriterProxyData info(10, 10);
     Qos serialized;
     Qos expected;
 
     // We will use default values here, specific values for each QoS
     // have been tested in other test
-    serialized = eprosima::statistics_backend::subscriber::writer_info_to_backend_qos(info);
+    serialized = eprosima::statistics_backend::subscriber::writer_proxy_data_to_backend_qos(info);
 
     Qos serialized_durability;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_durability, durability_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_durability, durability_tag,
             serialized_durability);
     expected[durability_tag] = serialized_durability[durability_tag];
     Qos serialized_durabilityService;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_durabilityService, durability_service_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_durabilityService, durability_service_tag,
             serialized_durabilityService);
     expected[durability_service_tag] = serialized_durabilityService[durability_service_tag];
     Qos serialized_deadline;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_deadline, deadline_tag, serialized_deadline);
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_deadline, deadline_tag, serialized_deadline);
     expected[deadline_tag] = serialized_deadline[deadline_tag];
     Qos serialized_latencyBudget;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_latencyBudget, latency_budget_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_latencyBudget, latency_budget_tag,
             serialized_latencyBudget);
     expected[latency_budget_tag] = serialized_latencyBudget[latency_budget_tag];
     Qos serialized_liveliness;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_liveliness, liveliness_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_liveliness, liveliness_tag,
             serialized_liveliness);
     expected[liveliness_tag] = serialized_liveliness[liveliness_tag];
     Qos serialized_reliability;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_reliability, reliability_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_reliability, reliability_tag,
             serialized_reliability);
     expected[reliability_tag] = serialized_reliability[reliability_tag];
     Qos serialized_lifespan;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_lifespan, lifespan_tag, serialized_lifespan);
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_lifespan, lifespan_tag, serialized_lifespan);
     expected[lifespan_tag] = serialized_lifespan[lifespan_tag];
     Qos serialized_userData;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_userData, user_data_tag, serialized_userData);
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_userData, user_data_tag, serialized_userData);
     expected[user_data_tag] = serialized_userData[user_data_tag];
     Qos serialized_timeBasedFilter;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_timeBasedFilter, time_based_filter_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_timeBasedFilter, time_based_filter_tag,
             serialized_timeBasedFilter);
     expected[time_based_filter_tag] = serialized_timeBasedFilter[time_based_filter_tag];
     Qos serialized_ownership;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_ownership, ownership_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_ownership, ownership_tag,
             serialized_ownership);
     expected[ownership_tag] = serialized_ownership[ownership_tag];
     Qos serialized_ownershipStrength;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_ownershipStrength, ownership_strength_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_ownershipStrength, ownership_strength_tag,
             serialized_ownershipStrength);
     expected[ownership_strength_tag] = serialized_ownershipStrength[ownership_strength_tag];
     Qos serialized_destinationOrder;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_destinationOrder, destination_order_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_destinationOrder, destination_order_tag,
             serialized_destinationOrder);
     expected[destination_order_tag] = serialized_destinationOrder[destination_order_tag];
     Qos serialized_presentation;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_presentation, presentation_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_presentation, presentation_tag,
             serialized_presentation);
     expected[presentation_tag] = serialized_presentation[presentation_tag];
     Qos serialized_partition;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_partition, partition_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_partition, partition_tag,
             serialized_partition);
     expected[partition_tag] = serialized_partition[partition_tag];
     Qos serialized_topicData;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_topicData, topic_data_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_topicData, topic_data_tag,
             serialized_topicData);
     expected[topic_data_tag] = serialized_topicData[topic_data_tag];
     Qos serialized_groupData;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_groupData, group_data_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_groupData, group_data_tag,
             serialized_groupData);
     expected[group_data_tag] = serialized_groupData[group_data_tag];
     Qos serialized_publishMode;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_publishMode, publish_mode_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_publishMode, publish_mode_tag,
             serialized_publishMode);
     expected[publish_mode_tag] = serialized_publishMode[publish_mode_tag];
     Qos serialized_representation;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.representation, representation_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.representation, representation_tag,
             serialized_representation);
     expected[representation_tag] = serialized_representation[representation_tag];
     Qos serialized_m_disablePositiveACKs;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_disablePositiveACKs,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_disablePositiveACKs,
             disable_positive_acks_tag, serialized_m_disablePositiveACKs);
     expected[disable_positive_acks_tag] = serialized_m_disablePositiveACKs[disable_positive_acks_tag];
     Qos serialized_data_sharing;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.data_sharing, data_sharing_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.data_sharing, data_sharing_tag,
             serialized_data_sharing);
     expected[data_sharing_tag] = serialized_data_sharing[data_sharing_tag];
 
@@ -691,86 +690,85 @@ TEST(qos_serializer_tests, writer_info_serializer)
 
 TEST(qos_serializer_tests, reader_info_serializer)
 {
-    eprosima::fastrtps::rtps::ReaderDiscoveryInfo info(
-        eprosima::fastrtps::rtps::ReaderProxyData(10, 10));
+    eprosima::fastrtps::rtps::ReaderProxyData info(10, 10);
     Qos serialized;
     Qos expected;
 
     // We will use default values here, specific values for each QoS
     // have been tested in other test
-    serialized = eprosima::statistics_backend::subscriber::reader_info_to_backend_qos(info);
+    serialized = eprosima::statistics_backend::subscriber::reader_proxy_data_to_backend_qos(info);
 
     Qos serialized_durability;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_durability, durability_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_durability, durability_tag,
             serialized_durability);
     expected[durability_tag] = serialized_durability[durability_tag];
     Qos serialized_durabilityService;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_durabilityService, durability_service_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_durabilityService, durability_service_tag,
             serialized_durabilityService);
     expected[durability_service_tag] = serialized_durabilityService[durability_service_tag];
     Qos serialized_deadline;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_deadline, deadline_tag, serialized_deadline);
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_deadline, deadline_tag, serialized_deadline);
     expected[deadline_tag] = serialized_deadline[deadline_tag];
     Qos serialized_latencyBudget;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_latencyBudget, latency_budget_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_latencyBudget, latency_budget_tag,
             serialized_latencyBudget);
     expected[latency_budget_tag] = serialized_latencyBudget[latency_budget_tag];
     Qos serialized_liveliness;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_liveliness, liveliness_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_liveliness, liveliness_tag,
             serialized_liveliness);
     expected[liveliness_tag] = serialized_liveliness[liveliness_tag];
     Qos serialized_reliability;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_reliability, reliability_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_reliability, reliability_tag,
             serialized_reliability);
     expected[reliability_tag] = serialized_reliability[reliability_tag];
     Qos serialized_lifespan;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_lifespan, lifespan_tag, serialized_lifespan);
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_lifespan, lifespan_tag, serialized_lifespan);
     expected[lifespan_tag] = serialized_lifespan[lifespan_tag];
     Qos serialized_userData;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_userData, user_data_tag, serialized_userData);
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_userData, user_data_tag, serialized_userData);
     expected[user_data_tag] = serialized_userData[user_data_tag];
     Qos serialized_timeBasedFilter;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_timeBasedFilter, time_based_filter_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_timeBasedFilter, time_based_filter_tag,
             serialized_timeBasedFilter);
     expected[time_based_filter_tag] = serialized_timeBasedFilter[time_based_filter_tag];
     Qos serialized_ownership;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_ownership, ownership_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_ownership, ownership_tag,
             serialized_ownership);
     expected[ownership_tag] = serialized_ownership[ownership_tag];
     Qos serialized_destinationOrder;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_destinationOrder, destination_order_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_destinationOrder, destination_order_tag,
             serialized_destinationOrder);
     expected[destination_order_tag] = serialized_destinationOrder[destination_order_tag];
     Qos serialized_presentation;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_presentation, presentation_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_presentation, presentation_tag,
             serialized_presentation);
     expected[presentation_tag] = serialized_presentation[presentation_tag];
     Qos serialized_partition;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_partition, partition_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_partition, partition_tag,
             serialized_partition);
     expected[partition_tag] = serialized_partition[partition_tag];
     Qos serialized_topicData;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_topicData, topic_data_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_topicData, topic_data_tag,
             serialized_topicData);
     expected[topic_data_tag] = serialized_topicData[topic_data_tag];
     Qos serialized_groupData;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_groupData, group_data_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_groupData, group_data_tag,
             serialized_groupData);
     expected[group_data_tag] = serialized_groupData[group_data_tag];
     Qos serialized_representation;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.representation, representation_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.representation, representation_tag,
             serialized_representation);
     expected[representation_tag] = serialized_representation[representation_tag];
     Qos serialized_m_disablePositiveACKs;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.m_disablePositiveACKs,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.m_disablePositiveACKs,
             disable_positive_acks_tag, serialized_m_disablePositiveACKs);
     expected[disable_positive_acks_tag] = serialized_m_disablePositiveACKs[disable_positive_acks_tag];
     Qos serialized_data_sharing;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.data_sharing, data_sharing_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.data_sharing, data_sharing_tag,
             serialized_data_sharing);
     expected[data_sharing_tag] = serialized_data_sharing[data_sharing_tag];
     Qos serialized_type_consistency;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_qos.type_consistency, type_consistency_tag,
+    eprosima::statistics_backend::subscriber::serialize(info.m_qos.type_consistency, type_consistency_tag,
             serialized_type_consistency);
     expected[type_consistency_tag] = serialized_type_consistency[type_consistency_tag];
 
@@ -785,23 +783,22 @@ TEST(qos_serializer_tests, participant_info_serializer)
     eprosima::fastrtps::rtps::ParticipantProxyData data(attributes);
     data.m_VendorId = eprosima::fastrtps::rtps::c_VendorId_eProsima;
     data.m_availableBuiltinEndpoints = 101;
-    eprosima::fastrtps::rtps::ParticipantDiscoveryInfo info(data);
     Qos serialized;
     Qos expected;
 
     // We will use default values here, specific values for each QoS
     // have been tested in other test
-    serialized = eprosima::statistics_backend::subscriber::participant_info_to_backend_qos(info);
+    serialized = eprosima::statistics_backend::subscriber::participant_proxy_data_to_backend_qos(data);
 
     Qos serialized_leaseDuration;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_leaseDuration, lease_duration_tag,
+    eprosima::statistics_backend::subscriber::serialize(data.m_leaseDuration, lease_duration_tag,
             serialized_leaseDuration);
     expected[lease_duration_tag] = serialized_leaseDuration[lease_duration_tag];
     Qos serialized_properties;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_properties, properties_tag, serialized_properties);
+    eprosima::statistics_backend::subscriber::serialize(data.m_properties, properties_tag, serialized_properties);
     expected[properties_tag] = serialized_properties[properties_tag];
     Qos serialized_userData;
-    eprosima::statistics_backend::subscriber::serialize(info.info.m_userData, user_data_tag, serialized_userData);
+    eprosima::statistics_backend::subscriber::serialize(data.m_userData, user_data_tag, serialized_userData);
     expected[user_data_tag] = serialized_userData[user_data_tag];
 
     expected[available_builtin_endpoints_tag] = 101;

--- a/test/unittest/Resources/complex_dump.json
+++ b/test/unittest/Resources/complex_dump.json
@@ -1,1388 +1,1384 @@
 {
-    "description": "DB dump with 3 entities of each kind, and 3 data in each data kind for each entity",
-
-    "datareaders":{
-        "17":{
-            "data":{
-                "acknack_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_acknack_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_nackfrag_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "nackfrag_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "subscription_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ]
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.01|0.0.0.0",
-            "locators":[
-                "9"
-            ],
-            "name":"datareader_1",
-            "alias":"datareader_1",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"15",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"14",
-            "virtual_metatraffic":false
+  "description": "DB dump with 3 entities of each kind, and 3 data in each data kind for each entity",
+  "datareaders": {
+    "17": {
+      "data": {
+        "acknack_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_acknack_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "26":{
-            "data":{
-                "acknack_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_acknack_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_nackfrag_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "nackfrag_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "subscription_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ]
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
-            "locators":[
-                "18"
-            ],
-            "name":"datareader_2",
-            "alias":"datareader_2",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"24",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"23",
-            "virtual_metatraffic":false
+        "last_reported_nackfrag_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "8":{
-            "data":{
-                "acknack_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_acknack_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_nackfrag_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "nackfrag_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "subscription_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ]
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "locators":[
-                "0"
-            ],
-            "name":"datareader_0",
-            "alias":"datareader_0",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"6",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"5",
-            "virtual_metatraffic":false
-        }
+        "nackfrag_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "subscription_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ]
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.01|0.0.0.0",
+      "locators": [
+        "9"
+      ],
+      "name": "datareader_1",
+      "alias": "datareader_1",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "15",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "14",
+      "virtual_metatraffic": false
     },
-    "datawriters":{
-        "16":{
-            "data":{
-                "data_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "gap_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "heartbeat_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "history2history_latency":{
-                    "17":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "last_reported_data_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_gap_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_heartbeat_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_resent_datas":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "publication_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ],
-                "resent_datas":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "samples_datas":{
-                    "3":
-                    [
-                        {
-                            "src_time": "200",
-                            "count": 2
-                        }
-                    ]
-                }
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.01|0.0.0.0",
-            "locators":[
-                "9"
-            ],
-            "name":"datawriter_1",
-            "alias":"datawriter_1",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"15",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"14",
-            "virtual_metatraffic":false
+    "26": {
+      "data": {
+        "acknack_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_acknack_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "25":{
-            "data":{
-                "data_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "gap_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "heartbeat_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "history2history_latency":{
-                    "26":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "last_reported_data_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_gap_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_heartbeat_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_resent_datas":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "publication_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ],
-                "resent_datas":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "samples_datas":{
-                    "3":
-                    [
-                        {
-                            "src_time": "200",
-                            "count": 2
-                        }
-                    ]
-                }
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
-            "locators":[
-                "18"
-            ],
-            "name":"datawriter_2",
-            "alias":"datawriter_2",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"24",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"23",
-            "virtual_metatraffic":false
+        "last_reported_nackfrag_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "7":{
-            "data":{
-                "data_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "gap_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "heartbeat_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "history2history_latency":{
-                    "8":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "last_reported_data_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_gap_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_heartbeat_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_resent_datas":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "publication_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ],
-                "resent_datas":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "samples_datas":{
-                    "3":
-                    [
-                        {
-                            "src_time": "200",
-                            "count": 2
-                        }
-                    ]
-                }
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "locators":[
-                "0"
-            ],
-            "name":"datawriter_0",
-            "alias":"datawriter_0",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"6",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"5",
-            "virtual_metatraffic":false
-        }
+        "nackfrag_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "subscription_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ]
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
+      "locators": [
+        "18"
+      ],
+      "name": "datareader_2",
+      "alias": "datareader_2",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "24",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "23",
+      "virtual_metatraffic": false
     },
-    "domains":{
-        "13":{
-            "name":"121",
-            "alias":"domain_1",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "15"
-            ],
-            "topics":[
-                "14"
-            ]
+    "8": {
+      "data": {
+        "acknack_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_acknack_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "22":{
-            "name":"122",
-            "alias":"domain_2",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "24"
-            ],
-            "topics":[
-                "23"
-            ]
+        "last_reported_nackfrag_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "4":{
-            "name":"120",
-            "alias":"domain_0",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "6"
-            ],
-            "topics":[
-                "5"
-            ]
-        }
-    },
-    "hosts":{
-        "1":{
-            "name":"host_0",
-            "alias":"host_0",
-            "metatraffic":false,
-            "alive":true,
-            "users":[
-                "2"
-            ]
-        },
-        "10":{
-            "name":"host_1",
-            "alias":"host_1",
-            "metatraffic":false,
-            "alive":true,
-            "users":[
-                "11"
-            ]
-        },
-        "19":{
-            "name":"host_2",
-            "alias":"host_2",
-            "metatraffic":false,
-            "alive":true,
-            "users":[
-                "20"
-            ]
-        }
-    },
-    "locators":{
-        "0":{
-            "datareaders":[
-                "8"
-            ],
-            "datawriters":[
-                "7"
-            ],
-            "name":"locator_0",
-            "alias":"locator_0",
-            "metatraffic":false,
-            "alive":true
-        },
-        "18":{
-            "datareaders":[
-                "26"
-            ],
-            "datawriters":[
-                "25"
-            ],
-            "name":"locator_2",
-            "alias":"locator_2",
-            "metatraffic":false,
-            "alive":true
-        },
-        "9":{
-            "datareaders":[
-                "17"
-            ],
-            "datawriters":[
-                "16"
-            ],
-            "name":"locator_1",
-            "alias":"locator_1",
-            "metatraffic":false,
-            "alive":true
-        }
-    },
-    "participants":{
-        "15":{
-            "data":{
-                "discovery_time":{
-                    "15":[
-                        {
-                            "src_time":"100",
-                            "time": "0",
-                            "remote_id": "15",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"200",
-                            "time":"100",
-                            "remote_id": "15",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"300",
-                            "time":"200",
-                            "remote_id": "15",
-                            "discovered": true
-                        }
-                    ]
-                },
-                "edp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_edp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_pdp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_rtps_bytes_lost":{
-                    "9":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_bytes_sent":{
-                    "9":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_lost":{
-                    "9":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_sent":{
-                    "9":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "pdp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "rtps_bytes_lost":{
-                    "9":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_bytes_sent":{
-                    "9":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_lost":{
-                    "9":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_sent":{
-                    "9":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "network_latency_per_locator":{
-                    "9":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
+        "nackfrag_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "subscription_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ]
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "locators": [
+        "0"
+      ],
+      "name": "datareader_0",
+      "alias": "datareader_0",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "6",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "5",
+      "virtual_metatraffic": false
+    }
+  },
+  "datawriters": {
+    "16": {
+      "data": {
+        "data_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "gap_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "heartbeat_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "history2history_latency": {
+          "17": [
+            {
+              "data": 1.1,
+              "src_time": "0"
             },
-            "datareaders":[
-                "17"
-            ],
-            "datawriters":[
-                "16"
-            ],
-            "domain":"13",
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.01|0.0.0.0",
-            "name":"participant_1",
-            "alias":"participant_1",
-            "metatraffic":false,
-            "alive":true,
-            "process":"12",
-            "qos":{
-                "qos":"empty"
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
             }
+          ]
         },
-        "24":{
-            "data":{
-                "discovery_time":{
-                    "24":[
-                        {
-                            "src_time":"100",
-                            "time": "0",
-                            "remote_id": "24",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"200",
-                            "time":"100",
-                            "remote_id": "24",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"300",
-                            "time":"200",
-                            "remote_id": "24",
-                            "discovered": true
-                        }
-                    ]
-                },
-                "edp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_edp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_pdp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_rtps_bytes_lost":{
-                    "18":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_bytes_sent":{
-                    "18":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_lost":{
-                    "18":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_sent":{
-                    "18":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "pdp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "rtps_bytes_lost":{
-                    "18":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_bytes_sent":{
-                    "18":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_lost":{
-                    "18":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_sent":{
-                    "18":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "network_latency_per_locator":{
-                    "18":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
-            },
-            "datareaders":[
-                "26"
-            ],
-            "datawriters":[
-                "25"
-            ],
-            "domain":"22",
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
-            "name":"participant_2",
-            "alias":"participant_2",
-            "metatraffic":false,
-            "alive":true,
-            "process":"21",
-            "qos":{
-                "qos":"empty"
+        "last_reported_data_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_gap_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_heartbeat_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_resent_datas": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "publication_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ],
+        "resent_datas": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "samples_datas": {
+          "3": [
+            {
+              "src_time": "200",
+              "count": 2
             }
-        },
-        "6":{
-            "data":{
-                "discovery_time":{
-                    "6":[
-                        {
-                            "src_time":"100",
-                            "time": "0",
-                            "remote_id": "6",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"200",
-                            "time":"100",
-                            "remote_id": "6",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"300",
-                            "time":"200",
-                            "remote_id": "6",
-                            "discovered": true
-                        }
-                    ]
-                },
-                "edp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_edp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_pdp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_rtps_bytes_lost":{
-                    "0":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_bytes_sent":{
-                    "0":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_lost":{
-                    "0":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_sent":{
-                    "0":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "pdp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "rtps_bytes_lost":{
-                    "0":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_bytes_sent":{
-                    "0":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_lost":{
-                    "0":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_sent":{
-                    "0":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "network_latency_per_locator":{
-                    "0":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
+          ]
+        }
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.01|0.0.0.0",
+      "locators": [
+        "9"
+      ],
+      "name": "datawriter_1",
+      "alias": "datawriter_1",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "15",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "14",
+      "virtual_metatraffic": false
+    },
+    "25": {
+      "data": {
+        "data_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "gap_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "heartbeat_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "history2history_latency": {
+          "26": [
+            {
+              "data": 1.1,
+              "src_time": "0"
             },
-            "datareaders":[
-                "8"
-            ],
-            "datawriters":[
-                "7"
-            ],
-            "domain":"4",
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "name":"participant_0",
-            "alias":"participant_0",
-            "metatraffic":false,
-            "alive":true,
-            "process":"3",
-            "qos":{
-                "qos":"empty"
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
             }
+          ]
+        },
+        "last_reported_data_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_gap_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_heartbeat_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_resent_datas": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "publication_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ],
+        "resent_datas": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "samples_datas": {
+          "3": [
+            {
+              "src_time": "200",
+              "count": 2
+            }
+          ]
         }
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
+      "locators": [
+        "18"
+      ],
+      "name": "datawriter_2",
+      "alias": "datawriter_2",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "24",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "23",
+      "virtual_metatraffic": false
     },
-    "processes":{
-        "12":{
-            "name":"process_1",
-            "alias":"process_1",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "15"
-            ],
-            "pid":"36000",
-            "user":"11"
+    "7": {
+      "data": {
+        "data_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "gap_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "heartbeat_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "history2history_latency": {
+          "8": [
+            {
+              "data": 1.1,
+              "src_time": "0"
+            },
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
+            }
+          ]
         },
-        "21":{
-            "name":"process_2",
-            "alias":"process_2",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "24"
-            ],
-            "pid":"36000",
-            "user":"20"
+        "last_reported_data_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "3":{
-            "name":"process_0",
-            "alias":"process_0",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "6"
-            ],
-            "pid":"36000",
-            "user":"2"
+        "last_reported_gap_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_heartbeat_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_resent_datas": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "publication_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ],
+        "resent_datas": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "samples_datas": {
+          "3": [
+            {
+              "src_time": "200",
+              "count": 2
+            }
+          ]
         }
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "locators": [
+        "0"
+      ],
+      "name": "datawriter_0",
+      "alias": "datawriter_0",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "6",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "5",
+      "virtual_metatraffic": false
+    }
+  },
+  "domains": {
+    "13": {
+      "name": "121",
+      "alias": "domain_1",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "15"
+      ],
+      "topics": [
+        "14"
+      ]
     },
-    "topics":{
-        "14":{
-            "data_type":"data_type",
-            "datareaders":[
-                "17"
-            ],
-            "datawriters":[
-                "16"
-            ],
-            "domain":"13",
-            "name":"topic_1",
-            "alias":"topic_1",
-            "metatraffic":false,
-            "alive":true
+    "22": {
+      "name": "122",
+      "alias": "domain_2",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "24"
+      ],
+      "topics": [
+        "23"
+      ]
+    },
+    "4": {
+      "name": "120",
+      "alias": "domain_0",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "6"
+      ],
+      "topics": [
+        "5"
+      ]
+    }
+  },
+  "hosts": {
+    "1": {
+      "name": "host_0",
+      "alias": "host_0",
+      "metatraffic": false,
+      "alive": true,
+      "users": [
+        "2"
+      ]
+    },
+    "10": {
+      "name": "host_1",
+      "alias": "host_1",
+      "metatraffic": false,
+      "alive": true,
+      "users": [
+        "11"
+      ]
+    },
+    "19": {
+      "name": "host_2",
+      "alias": "host_2",
+      "metatraffic": false,
+      "alive": true,
+      "users": [
+        "20"
+      ]
+    }
+  },
+  "locators": {
+    "0": {
+      "datareaders": [
+        "8"
+      ],
+      "datawriters": [
+        "7"
+      ],
+      "name": "locator_0",
+      "alias": "locator_0",
+      "metatraffic": false,
+      "alive": true
+    },
+    "18": {
+      "datareaders": [
+        "26"
+      ],
+      "datawriters": [
+        "25"
+      ],
+      "name": "locator_2",
+      "alias": "locator_2",
+      "metatraffic": false,
+      "alive": true
+    },
+    "9": {
+      "datareaders": [
+        "17"
+      ],
+      "datawriters": [
+        "16"
+      ],
+      "name": "locator_1",
+      "alias": "locator_1",
+      "metatraffic": false,
+      "alive": true
+    }
+  },
+  "participants": {
+    "15": {
+      "data": {
+        "discovery_time": {
+          "15": [
+            {
+              "src_time": "100",
+              "time": "0",
+              "remote_id": "15",
+              "discovered": true
+            },
+            {
+              "src_time": "200",
+              "time": "100",
+              "remote_id": "15",
+              "discovered": true
+            },
+            {
+              "src_time": "300",
+              "time": "200",
+              "remote_id": "15",
+              "discovered": true
+            }
+          ]
         },
-        "23":{
-            "data_type":"data_type",
-            "datareaders":[
-                "26"
-            ],
-            "datawriters":[
-                "25"
-            ],
-            "domain":"22",
-            "name":"topic_2",
-            "alias":"topic_2",
-            "metatraffic":false,
-            "alive":true
+        "edp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_edp_packets": {
+          "count": 2,
+          "src_time": "200"
         },
-        "5":{
-            "data_type":"data_type",
-            "datareaders":[
-                "8"
-            ],
-            "datawriters":[
-                "7"
-            ],
-            "domain":"4",
-            "name":"topic_0",
-            "alias":"topic_0",
-            "metatraffic":false,
-            "alive":true
+        "last_reported_pdp_packets": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_rtps_bytes_lost": {
+          "9": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_bytes_sent": {
+          "9": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_lost": {
+          "9": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_sent": {
+          "9": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "pdp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "rtps_bytes_lost": {
+          "9": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_bytes_sent": {
+          "9": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_lost": {
+          "9": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_sent": {
+          "9": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "network_latency_per_locator": {
+          "9": [
+            {
+              "data": 1.1,
+              "src_time": "0"
+            },
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
+            }
+          ]
         }
+      },
+      "datareaders": [
+        "17"
+      ],
+      "datawriters": [
+        "16"
+      ],
+      "domain": "13",
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.01|0.0.1.0",
+      "name": "participant_1",
+      "alias": "participant_1",
+      "metatraffic": false,
+      "alive": true,
+      "process": "12",
+      "qos": {
+        "qos": "empty"
+      }
     },
-    "users":{
-        "11":{
-            "host":"10",
-            "name":"user_1",
-            "alias":"user_1",
-            "metatraffic":false,
-            "alive":true,
-            "processes":[
-                "12"
-            ]
+    "24": {
+      "data": {
+        "discovery_time": {
+          "24": [
+            {
+              "src_time": "100",
+              "time": "0",
+              "remote_id": "24",
+              "discovered": true
+            },
+            {
+              "src_time": "200",
+              "time": "100",
+              "remote_id": "24",
+              "discovered": true
+            },
+            {
+              "src_time": "300",
+              "time": "200",
+              "remote_id": "24",
+              "discovered": true
+            }
+          ]
         },
-        "2":{
-            "host":"1",
-            "name":"user_0",
-            "alias":"user_0",
-            "metatraffic":false,
-            "alive":true,
-            "processes":[
-                "3"
-            ]
+        "edp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_edp_packets": {
+          "count": 2,
+          "src_time": "200"
         },
-        "20":{
-            "host":"19",
-            "name":"user_2",
-            "alias":"user_2",
-            "metatraffic":false,
-            "alive":true,
-            "processes":[
-                "21"
-            ]
+        "last_reported_pdp_packets": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_rtps_bytes_lost": {
+          "18": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_bytes_sent": {
+          "18": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_lost": {
+          "18": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_sent": {
+          "18": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "pdp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "rtps_bytes_lost": {
+          "18": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_bytes_sent": {
+          "18": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_lost": {
+          "18": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_sent": {
+          "18": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "network_latency_per_locator": {
+          "18": [
+            {
+              "data": 1.1,
+              "src_time": "0"
+            },
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
+            }
+          ]
         }
+      },
+      "datareaders": [
+        "26"
+      ],
+      "datawriters": [
+        "25"
+      ],
+      "domain": "22",
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.02|0.0.1.0",
+      "name": "participant_2",
+      "alias": "participant_2",
+      "metatraffic": false,
+      "alive": true,
+      "process": "21",
+      "qos": {
+        "qos": "empty"
+      }
     },
-    "version":"0.0"
+    "6": {
+      "data": {
+        "discovery_time": {
+          "6": [
+            {
+              "src_time": "100",
+              "time": "0",
+              "remote_id": "6",
+              "discovered": true
+            },
+            {
+              "src_time": "200",
+              "time": "100",
+              "remote_id": "6",
+              "discovered": true
+            },
+            {
+              "src_time": "300",
+              "time": "200",
+              "remote_id": "6",
+              "discovered": true
+            }
+          ]
+        },
+        "edp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_edp_packets": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_pdp_packets": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_rtps_bytes_lost": {
+          "0": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_bytes_sent": {
+          "0": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_lost": {
+          "0": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_sent": {
+          "0": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "pdp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "rtps_bytes_lost": {
+          "0": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_bytes_sent": {
+          "0": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_lost": {
+          "0": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_sent": {
+          "0": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "network_latency_per_locator": {
+          "0": [
+            {
+              "data": 1.1,
+              "src_time": "0"
+            },
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
+            }
+          ]
+        }
+      },
+      "datareaders": [
+        "8"
+      ],
+      "datawriters": [
+        "7"
+      ],
+      "domain": "4",
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.1.0",
+      "name": "participant_0",
+      "alias": "participant_0",
+      "metatraffic": false,
+      "alive": true,
+      "process": "3",
+      "qos": {
+        "qos": "empty"
+      }
+    }
+  },
+  "processes": {
+    "12": {
+      "name": "process_1",
+      "alias": "process_1",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "15"
+      ],
+      "pid": "36000",
+      "user": "11"
+    },
+    "21": {
+      "name": "process_2",
+      "alias": "process_2",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "24"
+      ],
+      "pid": "36000",
+      "user": "20"
+    },
+    "3": {
+      "name": "process_0",
+      "alias": "process_0",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "6"
+      ],
+      "pid": "36000",
+      "user": "2"
+    }
+  },
+  "topics": {
+    "14": {
+      "data_type": "data_type",
+      "datareaders": [
+        "17"
+      ],
+      "datawriters": [
+        "16"
+      ],
+      "domain": "13",
+      "name": "topic_1",
+      "alias": "topic_1",
+      "metatraffic": false,
+      "alive": true
+    },
+    "23": {
+      "data_type": "data_type",
+      "datareaders": [
+        "26"
+      ],
+      "datawriters": [
+        "25"
+      ],
+      "domain": "22",
+      "name": "topic_2",
+      "alias": "topic_2",
+      "metatraffic": false,
+      "alive": true
+    },
+    "5": {
+      "data_type": "data_type",
+      "datareaders": [
+        "8"
+      ],
+      "datawriters": [
+        "7"
+      ],
+      "domain": "4",
+      "name": "topic_0",
+      "alias": "topic_0",
+      "metatraffic": false,
+      "alive": true
+    }
+  },
+  "users": {
+    "11": {
+      "host": "10",
+      "name": "user_1",
+      "alias": "user_1",
+      "metatraffic": false,
+      "alive": true,
+      "processes": [
+        "12"
+      ]
+    },
+    "2": {
+      "host": "1",
+      "name": "user_0",
+      "alias": "user_0",
+      "metatraffic": false,
+      "alive": true,
+      "processes": [
+        "3"
+      ]
+    },
+    "20": {
+      "host": "19",
+      "name": "user_2",
+      "alias": "user_2",
+      "metatraffic": false,
+      "alive": true,
+      "processes": [
+        "21"
+      ]
+    }
+  },
+  "version": "0.0"
 }

--- a/test/unittest/Resources/complex_dump_erased_domain_1.json
+++ b/test/unittest/Resources/complex_dump_erased_domain_1.json
@@ -1,972 +1,966 @@
 {
-    "description": "DB dump with 3 entities of each kind, and 3 data in each data kind for each entity",
-
-    "datareaders":{
-        "26":{
-            "data":{
-                "acknack_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_acknack_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_nackfrag_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "nackfrag_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "subscription_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ]
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
-            "locators":[
-                "18"
-            ],
-            "name":"datareader_2",
-            "alias":"datareader_2",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"24",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"23",
-            "virtual_metatraffic":false
+  "description": "DB dump with 3 entities of each kind, and 3 data in each data kind for each entity",
+  "datareaders": {
+    "26": {
+      "data": {
+        "acknack_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_acknack_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "8":{
-            "data":{
-                "acknack_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_acknack_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_nackfrag_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "nackfrag_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "subscription_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ]
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "locators":[
-                "0"
-            ],
-            "name":"datareader_0",
-            "alias":"datareader_0",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"6",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"5",
-            "virtual_metatraffic":false
-        }
+        "last_reported_nackfrag_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "nackfrag_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "subscription_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ]
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
+      "locators": [
+        "18"
+      ],
+      "name": "datareader_2",
+      "alias": "datareader_2",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "24",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "23",
+      "virtual_metatraffic": false
     },
-    "datawriters":{
-        "25":{
-            "data":{
-                "data_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "gap_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "heartbeat_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "history2history_latency":{
-                    "26":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "last_reported_data_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_gap_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_heartbeat_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_resent_datas":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "publication_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ],
-                "resent_datas":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "samples_datas":{
-                    "3":
-                    [
-                        {
-                            "src_time":"200",
-                            "count": 2
-                        }
-                    ]
-                }
+    "8": {
+      "data": {
+        "acknack_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_acknack_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_nackfrag_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "nackfrag_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "subscription_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ]
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "locators": [
+        "0"
+      ],
+      "name": "datareader_0",
+      "alias": "datareader_0",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "6",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "5",
+      "virtual_metatraffic": false
+    }
+  },
+  "datawriters": {
+    "25": {
+      "data": {
+        "data_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "gap_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "heartbeat_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "history2history_latency": {
+          "26": [
+            {
+              "data": 1.1,
+              "src_time": "0"
             },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
-            "locators":[
-                "18"
-            ],
-            "name":"datawriter_2",
-            "alias":"datawriter_2",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"24",
-            "qos":{
-                "qos":"empty"
+            {
+              "data": 1.1,
+              "src_time": "100"
             },
-            "topic":"23",
-            "virtual_metatraffic":false
-        },
-        "7":{
-            "data":{
-                "data_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "gap_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "heartbeat_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "history2history_latency":{
-                    "8":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "last_reported_data_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_gap_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_heartbeat_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_resent_datas":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "publication_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ],
-                "resent_datas":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "samples_datas":{
-                    "3":
-                    [
-                        {
-                            "src_time":"200",
-                            "count": 2
-                        }
-                    ]
-                }
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "locators":[
-                "0"
-            ],
-            "name":"datawriter_0",
-            "alias":"datawriter_0",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"6",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"5",
-            "virtual_metatraffic":false
-        }
-    },
-    "domains":{
-        "22":{
-            "name":"122",
-            "alias":"domain_2",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "24"
-            ],
-            "topics":[
-                "23"
-            ]
-        },
-        "4":{
-            "name":"120",
-            "alias":"domain_0",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "6"
-            ],
-            "topics":[
-                "5"
-            ]
-        }
-    },
-    "hosts":{
-        "1":{
-            "name":"host_0",
-            "alias":"host_0",
-            "metatraffic":false,
-            "alive":true,
-            "users":[
-                "2"
-            ]
-        },
-        "10":{
-            "name":"host_1",
-            "alias":"host_1",
-            "metatraffic":false,
-            "alive":false,
-            "users":[
-                "11"
-            ]
-        },
-        "19":{
-            "name":"host_2",
-            "alias":"host_2",
-            "metatraffic":false,
-            "alive":true,
-            "users":[
-                "20"
-            ]
-        }
-    },
-    "locators":{
-        "0":{
-            "datareaders":[
-                "8"
-            ],
-            "datawriters":[
-                "7"
-            ],
-            "name":"locator_0",
-            "alias":"locator_0",
-            "metatraffic":false,
-            "alive":true
-        },
-        "18":{
-            "datareaders":[
-                "26"
-            ],
-            "datawriters":[
-                "25"
-            ],
-            "name":"locator_2",
-            "alias":"locator_2",
-            "metatraffic":false,
-            "alive":true
-        },
-        "9":{
-            "datareaders":[
-            ],
-            "datawriters":[
-            ],
-            "name":"locator_1",
-            "alias":"locator_1",
-            "metatraffic":false,
-            "alive":true
-        }
-    },
-    "participants":{
-        "24":{
-            "data":{
-                "discovery_time":{
-                    "24":[
-                        {
-                            "src_time":"100",
-                            "time": "0",
-                            "remote_id": "24",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"200",
-                            "time":"100",
-                            "remote_id": "24",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"300",
-                            "time":"200",
-                            "remote_id": "24",
-                            "discovered": true
-                        }
-                    ]
-                },
-                "edp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_edp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_pdp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_rtps_bytes_lost":{
-                    "18":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_bytes_sent":{
-                    "18":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_lost":{
-                    "18":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_sent":{
-                    "18":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "pdp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "rtps_bytes_lost":{
-                    "18":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_bytes_sent":{
-                    "18":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_lost":{
-                    "18":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_sent":{
-                    "18":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "network_latency_per_locator":{
-                    "18":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
-            },
-            "datareaders":[
-                "26"
-            ],
-            "datawriters":[
-                "25"
-            ],
-            "domain":"22",
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
-            "name":"participant_2",
-            "alias":"participant_2",
-            "metatraffic":false,
-            "alive":true,
-            "process":"21",
-            "qos":{
-                "qos":"empty"
+            {
+              "data": 1.1,
+              "src_time": "200"
             }
+          ]
         },
-        "6":{
-            "data":{
-                "discovery_time":{
-                    "6":[
-                        {
-                            "src_time":"100",
-                            "time": "0",
-                            "remote_id": "6",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"200",
-                            "time":"100",
-                            "remote_id": "6",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"300",
-                            "time":"200",
-                            "remote_id": "6",
-                            "discovered": true
-                        }
-                    ]
-                },
-                "edp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_edp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_pdp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_rtps_bytes_lost":{
-                    "0":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_bytes_sent":{
-                    "0":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_lost":{
-                    "0":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_sent":{
-                    "0":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "pdp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "rtps_bytes_lost":{
-                    "0":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_bytes_sent":{
-                    "0":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_lost":{
-                    "0":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_sent":{
-                    "0":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "network_latency_per_locator":{
-                    "0":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
-            },
-            "datareaders":[
-                "8"
-            ],
-            "datawriters":[
-                "7"
-            ],
-            "domain":"4",
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "name":"participant_0",
-            "alias":"participant_0",
-            "metatraffic":false,
-            "alive":true,
-            "process":"3",
-            "qos":{
-                "qos":"empty"
+        "last_reported_data_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_gap_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_heartbeat_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_resent_datas": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "publication_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ],
+        "resent_datas": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "samples_datas": {
+          "3": [
+            {
+              "src_time": "200",
+              "count": 2
             }
+          ]
         }
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
+      "locators": [
+        "18"
+      ],
+      "name": "datawriter_2",
+      "alias": "datawriter_2",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "24",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "23",
+      "virtual_metatraffic": false
     },
-    "processes":{
-        "12":{
-            "name":"process_1",
-            "alias":"process_1",
-            "metatraffic":false,
-            "alive":false,
-            "participants":[
-            ],
-            "pid":"36000",
-            "user":"11"
+    "7": {
+      "data": {
+        "data_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "gap_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "heartbeat_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "history2history_latency": {
+          "8": [
+            {
+              "data": 1.1,
+              "src_time": "0"
+            },
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
+            }
+          ]
         },
-        "21":{
-            "name":"process_2",
-            "alias":"process_2",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "24"
-            ],
-            "pid":"36000",
-            "user":"20"
+        "last_reported_data_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "3":{
-            "name":"process_0",
-            "alias":"process_0",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "6"
-            ],
-            "pid":"36000",
-            "user":"2"
+        "last_reported_gap_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_heartbeat_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_resent_datas": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "publication_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ],
+        "resent_datas": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "samples_datas": {
+          "3": [
+            {
+              "src_time": "200",
+              "count": 2
+            }
+          ]
         }
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "locators": [
+        "0"
+      ],
+      "name": "datawriter_0",
+      "alias": "datawriter_0",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "6",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "5",
+      "virtual_metatraffic": false
+    }
+  },
+  "domains": {
+    "22": {
+      "name": "122",
+      "alias": "domain_2",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "24"
+      ],
+      "topics": [
+        "23"
+      ]
     },
-    "topics":{
-        "23":{
-            "data_type":"data_type",
-            "datareaders":[
-                "26"
-            ],
-            "datawriters":[
-                "25"
-            ],
-            "domain":"22",
-            "name":"topic_2",
-            "alias":"topic_2",
-            "metatraffic":false,
-            "alive":true
+    "4": {
+      "name": "120",
+      "alias": "domain_0",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "6"
+      ],
+      "topics": [
+        "5"
+      ]
+    }
+  },
+  "hosts": {
+    "1": {
+      "name": "host_0",
+      "alias": "host_0",
+      "metatraffic": false,
+      "alive": true,
+      "users": [
+        "2"
+      ]
+    },
+    "10": {
+      "name": "host_1",
+      "alias": "host_1",
+      "metatraffic": false,
+      "alive": false,
+      "users": [
+        "11"
+      ]
+    },
+    "19": {
+      "name": "host_2",
+      "alias": "host_2",
+      "metatraffic": false,
+      "alive": true,
+      "users": [
+        "20"
+      ]
+    }
+  },
+  "locators": {
+    "0": {
+      "datareaders": [
+        "8"
+      ],
+      "datawriters": [
+        "7"
+      ],
+      "name": "locator_0",
+      "alias": "locator_0",
+      "metatraffic": false,
+      "alive": true
+    },
+    "18": {
+      "datareaders": [
+        "26"
+      ],
+      "datawriters": [
+        "25"
+      ],
+      "name": "locator_2",
+      "alias": "locator_2",
+      "metatraffic": false,
+      "alive": true
+    },
+    "9": {
+      "datareaders": [],
+      "datawriters": [],
+      "name": "locator_1",
+      "alias": "locator_1",
+      "metatraffic": false,
+      "alive": true
+    }
+  },
+  "participants": {
+    "24": {
+      "data": {
+        "discovery_time": {
+          "24": [
+            {
+              "src_time": "100",
+              "time": "0",
+              "remote_id": "24",
+              "discovered": true
+            },
+            {
+              "src_time": "200",
+              "time": "100",
+              "remote_id": "24",
+              "discovered": true
+            },
+            {
+              "src_time": "300",
+              "time": "200",
+              "remote_id": "24",
+              "discovered": true
+            }
+          ]
         },
-        "5":{
-            "data_type":"data_type",
-            "datareaders":[
-                "8"
-            ],
-            "datawriters":[
-                "7"
-            ],
-            "domain":"4",
-            "name":"topic_0",
-            "alias":"topic_0",
-            "metatraffic":false,
-            "alive":true
+        "edp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_edp_packets": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_pdp_packets": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_rtps_bytes_lost": {
+          "18": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_bytes_sent": {
+          "18": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_lost": {
+          "18": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_sent": {
+          "18": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "pdp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "rtps_bytes_lost": {
+          "18": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_bytes_sent": {
+          "18": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_lost": {
+          "18": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_sent": {
+          "18": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "network_latency_per_locator": {
+          "18": [
+            {
+              "data": 1.1,
+              "src_time": "0"
+            },
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
+            }
+          ]
         }
+      },
+      "datareaders": [
+        "26"
+      ],
+      "datawriters": [
+        "25"
+      ],
+      "domain": "22",
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.02|0.0.1.0",
+      "name": "participant_2",
+      "alias": "participant_2",
+      "metatraffic": false,
+      "alive": true,
+      "process": "21",
+      "qos": {
+        "qos": "empty"
+      }
     },
-    "users":{
-        "11":{
-            "host":"10",
-            "name":"user_1",
-            "alias":"user_1",
-            "metatraffic":false,
-            "alive":false,
-            "processes":[
-                "12"
-            ]
+    "6": {
+      "data": {
+        "discovery_time": {
+          "6": [
+            {
+              "src_time": "100",
+              "time": "0",
+              "remote_id": "6",
+              "discovered": true
+            },
+            {
+              "src_time": "200",
+              "time": "100",
+              "remote_id": "6",
+              "discovered": true
+            },
+            {
+              "src_time": "300",
+              "time": "200",
+              "remote_id": "6",
+              "discovered": true
+            }
+          ]
         },
-        "2":{
-            "host":"1",
-            "name":"user_0",
-            "alias":"user_0",
-            "metatraffic":false,
-            "alive":true,
-            "processes":[
-                "3"
-            ]
+        "edp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_edp_packets": {
+          "count": 2,
+          "src_time": "200"
         },
-        "20":{
-            "host":"19",
-            "name":"user_2",
-            "alias":"user_2",
-            "metatraffic":false,
-            "alive":true,
-            "processes":[
-                "21"
-            ]
+        "last_reported_pdp_packets": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_rtps_bytes_lost": {
+          "0": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_bytes_sent": {
+          "0": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_lost": {
+          "0": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_sent": {
+          "0": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "pdp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "rtps_bytes_lost": {
+          "0": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_bytes_sent": {
+          "0": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_lost": {
+          "0": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_sent": {
+          "0": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "network_latency_per_locator": {
+          "0": [
+            {
+              "data": 1.1,
+              "src_time": "0"
+            },
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
+            }
+          ]
         }
+      },
+      "datareaders": [
+        "8"
+      ],
+      "datawriters": [
+        "7"
+      ],
+      "domain": "4",
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.1.0",
+      "name": "participant_0",
+      "alias": "participant_0",
+      "metatraffic": false,
+      "alive": true,
+      "process": "3",
+      "qos": {
+        "qos": "empty"
+      }
+    }
+  },
+  "processes": {
+    "12": {
+      "name": "process_1",
+      "alias": "process_1",
+      "metatraffic": false,
+      "alive": false,
+      "participants": [],
+      "pid": "36000",
+      "user": "11"
     },
-    "version":"0.0"
+    "21": {
+      "name": "process_2",
+      "alias": "process_2",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "24"
+      ],
+      "pid": "36000",
+      "user": "20"
+    },
+    "3": {
+      "name": "process_0",
+      "alias": "process_0",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "6"
+      ],
+      "pid": "36000",
+      "user": "2"
+    }
+  },
+  "topics": {
+    "23": {
+      "data_type": "data_type",
+      "datareaders": [
+        "26"
+      ],
+      "datawriters": [
+        "25"
+      ],
+      "domain": "22",
+      "name": "topic_2",
+      "alias": "topic_2",
+      "metatraffic": false,
+      "alive": true
+    },
+    "5": {
+      "data_type": "data_type",
+      "datareaders": [
+        "8"
+      ],
+      "datawriters": [
+        "7"
+      ],
+      "domain": "4",
+      "name": "topic_0",
+      "alias": "topic_0",
+      "metatraffic": false,
+      "alive": true
+    }
+  },
+  "users": {
+    "11": {
+      "host": "10",
+      "name": "user_1",
+      "alias": "user_1",
+      "metatraffic": false,
+      "alive": false,
+      "processes": [
+        "12"
+      ]
+    },
+    "2": {
+      "host": "1",
+      "name": "user_0",
+      "alias": "user_0",
+      "metatraffic": false,
+      "alive": true,
+      "processes": [
+        "3"
+      ]
+    },
+    "20": {
+      "host": "19",
+      "name": "user_2",
+      "alias": "user_2",
+      "metatraffic": false,
+      "alive": true,
+      "processes": [
+        "21"
+      ]
+    }
+  },
+  "version": "0.0"
 }

--- a/test/unittest/Resources/empty_entities_dump.json
+++ b/test/unittest/Resources/empty_entities_dump.json
@@ -1,209 +1,200 @@
 {
-    "description": "DB dump with 1 entity of each kind, only required connections and no data",
-
-    "version": "0.0",
-
-    "hosts":
-    {
-        "1":
-        {
-            "name": "host_0",
-            "alias": "host_0",
-            "metatraffic":false,
-            "alive":true,
-            "users": ["2"]
-        }
-    },
-
-    "users":
-    {
-        "2":
-        {
-            "name": "user_0",
-            "alias": "user_0",
-            "metatraffic":false,
-            "alive":true,
-            "host": "1",
-            "processes": ["3"]
-        }
-    },
-
-    "processes":
-    {
-        "3":
-        {
-            "name": "process_0",
-            "alias": "process_0",
-            "metatraffic":false,
-            "alive":true,
-            "pid": "36000",
-            "user": "2",
-            "participants": ["6"]
-        }
-    },
-
-    "domains":
-    {
-        "4":
-        {
-            "name": "120",
-            "alias": "domain_0",
-            "metatraffic":false,
-            "alive":true,
-            "participants": ["6"],
-            "topics": ["5"]
-        }
-    },
-
-    "topics":
-    {
-        "5":
-        {
-            "name": "topic_0",
-            "alias": "topic_0",
-            "metatraffic":false,
-            "alive":true,
-            "data_type": "data_type",
-            "domain": "4",
-            "datawriters": ["7"],
-            "datareaders": ["8"]
-        }
-    },
-
-    "participants":
-    {
-        "6":
-        {
-            "name": "participant_0",
-            "alias": "participant_0",
-            "metatraffic":false,
-            "alive":true,
-            "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "qos": {"qos":"empty"},
-
-            "process": "3",
-            "domain": "4",
-            "datawriters": ["7"],
-            "datareaders": ["8"],
-
-            "data":
-            {
-                "discovery_time": {},
-                "pdp_packets": [],
-                "edp_packets": [],
-
-                "rtps_packets_sent": {},
-                "rtps_bytes_sent": {},
-                "rtps_packets_lost": {},
-                "rtps_bytes_lost": {},
-
-                "network_latency_per_locator": {},
-
-                "last_reported_rtps_bytes_lost":{},
-                "last_reported_rtps_bytes_sent":{},
-                "last_reported_rtps_packets_lost":{},
-                "last_reported_rtps_packets_sent":{},
-
-                "last_reported_edp_packets":{
-                    "count":0,
-                    "src_time":"0"
-                },
-                "last_reported_pdp_packets":{
-                    "count":0,
-                    "src_time":"0"
-                }
-            }
-        }
-    },
-
-    "datawriters":
-    {
-        "7":
-        {
-            "name": "datawriter_0",
-            "alias": "datawriter_0",
-            "metatraffic":false,
-            "alive":true,
-            "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "qos": {"qos":"empty"},
-
-            "participant": "6",
-            "topic": "5",
-            "locators": ["0"],
-            "virtual_metatraffic":false,
-
-            "data":
-            {
-                "publication_throughput": [],
-                "resent_datas": [],
-                "heartbeat_count": [],
-                "gap_count": [],
-                "data_count": [],
-                "samples_datas": {},
-                "history2history_latency": {},
-                "last_reported_data_count":{
-                    "count":0,
-                    "src_time":"0"
-                },
-                "last_reported_gap_count":{
-                    "count":0,
-                    "src_time":"0"
-                },
-                "last_reported_heartbeat_count":{
-                    "count":0,
-                    "src_time":"0"
-                },
-                "last_reported_resent_datas":{
-                    "count":0,
-                    "src_time":"0"
-                }
-            }
-        }
-    },
-
-    "datareaders":
-    {
-        "8":
-        {
-            "name": "datareader_0",
-            "alias": "datareader_0",
-            "metatraffic":false,
-            "alive":true,
-            "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "qos": {"qos":"empty"},
-
-            "participant": "6",
-            "topic": "5",
-            "locators": ["0"],
-            "virtual_metatraffic":false,
-
-            "data":
-            {
-                "subscription_throughput": [],
-                "acknack_count": [],
-                "nackfrag_count": [],
-                "last_reported_acknack_count":{
-                    "count":0,
-                    "src_time":"0"
-                },
-                "last_reported_nackfrag_count":{
-                    "count":0,
-                    "src_time":"0"
-                }
-            }
-        }
-    },
-
-    "locators":
-    {
-        "0":
-        {
-            "name": "locator_0",
-            "alias": "locator_0",
-            "metatraffic":false,
-            "alive":true,
-            "datawriters": ["7"],
-            "datareaders": ["8"]
-        }
+  "description": "DB dump with 1 entity of each kind, only required connections and no data",
+  "version": "0.0",
+  "hosts": {
+    "1": {
+      "name": "host_0",
+      "alias": "host_0",
+      "metatraffic": false,
+      "alive": true,
+      "users": [
+        "2"
+      ]
     }
+  },
+  "users": {
+    "2": {
+      "name": "user_0",
+      "alias": "user_0",
+      "metatraffic": false,
+      "alive": true,
+      "host": "1",
+      "processes": [
+        "3"
+      ]
+    }
+  },
+  "processes": {
+    "3": {
+      "name": "process_0",
+      "alias": "process_0",
+      "metatraffic": false,
+      "alive": true,
+      "pid": "36000",
+      "user": "2",
+      "participants": [
+        "6"
+      ]
+    }
+  },
+  "domains": {
+    "4": {
+      "name": "120",
+      "alias": "domain_0",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "6"
+      ],
+      "topics": [
+        "5"
+      ]
+    }
+  },
+  "topics": {
+    "5": {
+      "name": "topic_0",
+      "alias": "topic_0",
+      "metatraffic": false,
+      "alive": true,
+      "data_type": "data_type",
+      "domain": "4",
+      "datawriters": [
+        "7"
+      ],
+      "datareaders": [
+        "8"
+      ]
+    }
+  },
+  "participants": {
+    "6": {
+      "name": "participant_0",
+      "alias": "participant_0",
+      "metatraffic": false,
+      "alive": true,
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.1.0",
+      "qos": {
+        "qos": "empty"
+      },
+      "process": "3",
+      "domain": "4",
+      "datawriters": [
+        "7"
+      ],
+      "datareaders": [
+        "8"
+      ],
+      "data": {
+        "discovery_time": {},
+        "pdp_packets": [],
+        "edp_packets": [],
+        "rtps_packets_sent": {},
+        "rtps_bytes_sent": {},
+        "rtps_packets_lost": {},
+        "rtps_bytes_lost": {},
+        "network_latency_per_locator": {},
+        "last_reported_rtps_bytes_lost": {},
+        "last_reported_rtps_bytes_sent": {},
+        "last_reported_rtps_packets_lost": {},
+        "last_reported_rtps_packets_sent": {},
+        "last_reported_edp_packets": {
+          "count": 0,
+          "src_time": "0"
+        },
+        "last_reported_pdp_packets": {
+          "count": 0,
+          "src_time": "0"
+        }
+      }
+    }
+  },
+  "datawriters": {
+    "7": {
+      "name": "datawriter_0",
+      "alias": "datawriter_0",
+      "metatraffic": false,
+      "alive": true,
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "qos": {
+        "qos": "empty"
+      },
+      "participant": "6",
+      "topic": "5",
+      "locators": [
+        "0"
+      ],
+      "virtual_metatraffic": false,
+      "data": {
+        "publication_throughput": [],
+        "resent_datas": [],
+        "heartbeat_count": [],
+        "gap_count": [],
+        "data_count": [],
+        "samples_datas": {},
+        "history2history_latency": {},
+        "last_reported_data_count": {
+          "count": 0,
+          "src_time": "0"
+        },
+        "last_reported_gap_count": {
+          "count": 0,
+          "src_time": "0"
+        },
+        "last_reported_heartbeat_count": {
+          "count": 0,
+          "src_time": "0"
+        },
+        "last_reported_resent_datas": {
+          "count": 0,
+          "src_time": "0"
+        }
+      }
+    }
+  },
+  "datareaders": {
+    "8": {
+      "name": "datareader_0",
+      "alias": "datareader_0",
+      "metatraffic": false,
+      "alive": true,
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "qos": {
+        "qos": "empty"
+      },
+      "participant": "6",
+      "topic": "5",
+      "locators": [
+        "0"
+      ],
+      "virtual_metatraffic": false,
+      "data": {
+        "subscription_throughput": [],
+        "acknack_count": [],
+        "nackfrag_count": [],
+        "last_reported_acknack_count": {
+          "count": 0,
+          "src_time": "0"
+        },
+        "last_reported_nackfrag_count": {
+          "count": 0,
+          "src_time": "0"
+        }
+      }
+    }
+  },
+  "locators": {
+    "0": {
+      "name": "locator_0",
+      "alias": "locator_0",
+      "metatraffic": false,
+      "alive": true,
+      "datawriters": [
+        "7"
+      ],
+      "datareaders": [
+        "8"
+      ]
+    }
+  }
 }

--- a/test/unittest/Resources/empty_entities_dump_unlinked_entities.json
+++ b/test/unittest/Resources/empty_entities_dump_unlinked_entities.json
@@ -1,209 +1,198 @@
 {
-    "description": "DB dump with 1 entity of each kind, only required connections and no data",
-
-    "version": "0.0",
-
-    "hosts":
-    {
-        "1":
-        {
-            "name": "host_0",
-            "alias": "host_0",
-            "metatraffic":false,
-            "alive":false,
-            "users": ["2"]
-        }
-    },
-
-    "users":
-    {
-        "2":
-        {
-            "name": "user_0",
-            "alias": "user_0",
-            "metatraffic":false,
-            "alive":false,
-            "host": "1",
-            "processes": ["3"]
-        }
-    },
-
-    "processes":
-    {
-        "3":
-        {
-            "name": "process_0",
-            "alias": "process_0",
-            "metatraffic":false,
-            "alive":false,
-            "pid": "36000",
-            "user": "2",
-            "participants": []
-        }
-    },
-
-    "domains":
-    {
-        "4":
-        {
-            "name": "120",
-            "alias": "domain_0",
-            "metatraffic":false,
-            "alive":true,
-            "participants": ["6"],
-            "topics": ["5"]
-        }
-    },
-
-    "topics":
-    {
-        "5":
-        {
-            "name": "topic_0",
-            "alias": "topic_0",
-            "metatraffic":false,
-            "alive":true,
-            "data_type": "data_type",
-            "domain": "4",
-            "datawriters": ["7"],
-            "datareaders": ["8"]
-        }
-    },
-
-    "participants":
-    {
-        "6":
-        {
-            "name": "participant_0",
-            "alias": "participant_0",
-            "metatraffic":false,
-            "alive":true,
-            "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "qos": {"qos":"empty"},
-
-            "process": "3",
-            "domain": "4",
-            "datawriters": ["7"],
-            "datareaders": ["8"],
-
-            "data":
-            {
-                "discovery_time": {},
-                "pdp_packets": [],
-                "edp_packets": [],
-
-                "rtps_packets_sent": {},
-                "rtps_bytes_sent": {},
-                "rtps_packets_lost": {},
-                "rtps_bytes_lost": {},
-
-                "network_latency_per_locator": {},
-
-                "last_reported_rtps_bytes_lost":{},
-                "last_reported_rtps_bytes_sent":{},
-                "last_reported_rtps_packets_lost":{},
-                "last_reported_rtps_packets_sent":{},
-
-                "last_reported_edp_packets":{
-                    "count":0,
-                    "src_time":"0"
-                },
-                "last_reported_pdp_packets":{
-                    "count":0,
-                    "src_time":"0"
-                }
-            }
-        }
-    },
-
-    "datawriters":
-    {
-        "7":
-        {
-            "name": "datawriter_0",
-            "alias": "datawriter_0",
-            "metatraffic":false,
-            "alive":true,
-            "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "qos": {"qos":"empty"},
-
-            "participant": "6",
-            "topic": "5",
-            "locators": ["0"],
-            "virtual_metatraffic":false,
-
-            "data":
-            {
-                "publication_throughput": [],
-                "resent_datas": [],
-                "heartbeat_count": [],
-                "gap_count": [],
-                "data_count": [],
-                "samples_datas": {},
-                "history2history_latency": {},
-                "last_reported_data_count":{
-                    "count":0,
-                    "src_time":"0"
-                },
-                "last_reported_gap_count":{
-                    "count":0,
-                    "src_time":"0"
-                },
-                "last_reported_heartbeat_count":{
-                    "count":0,
-                    "src_time":"0"
-                },
-                "last_reported_resent_datas":{
-                    "count":0,
-                    "src_time":"0"
-                }
-            }
-        }
-    },
-
-    "datareaders":
-    {
-        "8":
-        {
-            "name": "datareader_0",
-            "alias": "datareader_0",
-            "metatraffic":false,
-            "alive":true,
-            "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "qos": {"qos":"empty"},
-
-            "participant": "6",
-            "topic": "5",
-            "locators": ["0"],
-            "virtual_metatraffic":false,
-
-            "data":
-            {
-                "subscription_throughput": [],
-                "acknack_count": [],
-                "nackfrag_count": [],
-                "last_reported_acknack_count":{
-                    "count":0,
-                    "src_time":"0"
-                },
-                "last_reported_nackfrag_count":{
-                    "count":0,
-                    "src_time":"0"
-                }
-            }
-        }
-    },
-
-    "locators":
-    {
-        "0":
-        {
-            "name": "locator_0",
-            "alias": "locator_0",
-            "metatraffic":false,
-            "alive":true,
-            "datawriters": ["7"],
-            "datareaders": ["8"]
-        }
+  "description": "DB dump with 1 entity of each kind, only required connections and no data",
+  "version": "0.0",
+  "hosts": {
+    "1": {
+      "name": "host_0",
+      "alias": "host_0",
+      "metatraffic": false,
+      "alive": false,
+      "users": [
+        "2"
+      ]
     }
+  },
+  "users": {
+    "2": {
+      "name": "user_0",
+      "alias": "user_0",
+      "metatraffic": false,
+      "alive": false,
+      "host": "1",
+      "processes": [
+        "3"
+      ]
+    }
+  },
+  "processes": {
+    "3": {
+      "name": "process_0",
+      "alias": "process_0",
+      "metatraffic": false,
+      "alive": false,
+      "pid": "36000",
+      "user": "2",
+      "participants": []
+    }
+  },
+  "domains": {
+    "4": {
+      "name": "120",
+      "alias": "domain_0",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "6"
+      ],
+      "topics": [
+        "5"
+      ]
+    }
+  },
+  "topics": {
+    "5": {
+      "name": "topic_0",
+      "alias": "topic_0",
+      "metatraffic": false,
+      "alive": true,
+      "data_type": "data_type",
+      "domain": "4",
+      "datawriters": [
+        "7"
+      ],
+      "datareaders": [
+        "8"
+      ]
+    }
+  },
+  "participants": {
+    "6": {
+      "name": "participant_0",
+      "alias": "participant_0",
+      "metatraffic": false,
+      "alive": true,
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.1.0",
+      "qos": {
+        "qos": "empty"
+      },
+      "process": "3",
+      "domain": "4",
+      "datawriters": [
+        "7"
+      ],
+      "datareaders": [
+        "8"
+      ],
+      "data": {
+        "discovery_time": {},
+        "pdp_packets": [],
+        "edp_packets": [],
+        "rtps_packets_sent": {},
+        "rtps_bytes_sent": {},
+        "rtps_packets_lost": {},
+        "rtps_bytes_lost": {},
+        "network_latency_per_locator": {},
+        "last_reported_rtps_bytes_lost": {},
+        "last_reported_rtps_bytes_sent": {},
+        "last_reported_rtps_packets_lost": {},
+        "last_reported_rtps_packets_sent": {},
+        "last_reported_edp_packets": {
+          "count": 0,
+          "src_time": "0"
+        },
+        "last_reported_pdp_packets": {
+          "count": 0,
+          "src_time": "0"
+        }
+      }
+    }
+  },
+  "datawriters": {
+    "7": {
+      "name": "datawriter_0",
+      "alias": "datawriter_0",
+      "metatraffic": false,
+      "alive": true,
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "qos": {
+        "qos": "empty"
+      },
+      "participant": "6",
+      "topic": "5",
+      "locators": [
+        "0"
+      ],
+      "virtual_metatraffic": false,
+      "data": {
+        "publication_throughput": [],
+        "resent_datas": [],
+        "heartbeat_count": [],
+        "gap_count": [],
+        "data_count": [],
+        "samples_datas": {},
+        "history2history_latency": {},
+        "last_reported_data_count": {
+          "count": 0,
+          "src_time": "0"
+        },
+        "last_reported_gap_count": {
+          "count": 0,
+          "src_time": "0"
+        },
+        "last_reported_heartbeat_count": {
+          "count": 0,
+          "src_time": "0"
+        },
+        "last_reported_resent_datas": {
+          "count": 0,
+          "src_time": "0"
+        }
+      }
+    }
+  },
+  "datareaders": {
+    "8": {
+      "name": "datareader_0",
+      "alias": "datareader_0",
+      "metatraffic": false,
+      "alive": true,
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "qos": {
+        "qos": "empty"
+      },
+      "participant": "6",
+      "topic": "5",
+      "locators": [
+        "0"
+      ],
+      "virtual_metatraffic": false,
+      "data": {
+        "subscription_throughput": [],
+        "acknack_count": [],
+        "nackfrag_count": [],
+        "last_reported_acknack_count": {
+          "count": 0,
+          "src_time": "0"
+        },
+        "last_reported_nackfrag_count": {
+          "count": 0,
+          "src_time": "0"
+        }
+      }
+    }
+  },
+  "locators": {
+    "0": {
+      "name": "locator_0",
+      "alias": "locator_0",
+      "metatraffic": false,
+      "alive": true,
+      "datawriters": [
+        "7"
+      ],
+      "datareaders": [
+        "8"
+      ]
+    }
+  }
 }

--- a/test/unittest/Resources/old_complex_dump.json
+++ b/test/unittest/Resources/old_complex_dump.json
@@ -1,1412 +1,1408 @@
 {
-    "description": "DB dump with 3 entities of each kind, and 3 data in each data kind for each entity",
-
-    "datareaders":{
-        "17":{
-            "data":{
-                "acknack_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_acknack_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_nackfrag_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "nackfrag_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "subscription_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ]
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.01|0.0.0.0",
-            "locators":[
-                "9"
-            ],
-            "name":"datareader_1",
-            "alias":"datareader_1",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"15",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"14",
-            "virtual_metatraffic":false
+  "description": "DB dump with 3 entities of each kind, and 3 data in each data kind for each entity",
+  "datareaders": {
+    "17": {
+      "data": {
+        "acknack_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_acknack_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "26":{
-            "data":{
-                "acknack_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_acknack_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_nackfrag_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "nackfrag_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "subscription_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ]
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
-            "locators":[
-                "18"
-            ],
-            "name":"datareader_2",
-            "alias":"datareader_2",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"24",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"23",
-            "virtual_metatraffic":false
+        "last_reported_nackfrag_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "8":{
-            "data":{
-                "acknack_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_acknack_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_nackfrag_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "nackfrag_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "subscription_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ]
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "locators":[
-                "0"
-            ],
-            "name":"datareader_0",
-            "alias":"datareader_0",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"6",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"5",
-            "virtual_metatraffic":false
-        }
+        "nackfrag_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "subscription_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ]
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.01|0.0.0.0",
+      "locators": [
+        "9"
+      ],
+      "name": "datareader_1",
+      "alias": "datareader_1",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "15",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "14",
+      "virtual_metatraffic": false
     },
-    "datawriters":{
-        "16":{
-            "data":{
-                "data_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "gap_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "heartbeat_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "history2history_latency":{
-                    "17":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "last_reported_data_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_gap_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_heartbeat_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_resent_datas":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "publication_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ],
-                "resent_datas":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "samples_datas":{
-                    "3":
-                    [
-                        {
-                            "src_time": "0",
-                            "count": 2
-                        },
-                        {
-                            "src_time":"100",
-                            "count": 2
-                        },
-                        {
-                            "src_time":"200",
-                            "count": 2
-                        }
-                    ]
-                }
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.01|0.0.0.0",
-            "locators":[
-                "9"
-            ],
-            "name":"datawriter_1",
-            "alias":"datawriter_1",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"15",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"14",
-            "virtual_metatraffic":false
+    "26": {
+      "data": {
+        "acknack_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_acknack_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "25":{
-            "data":{
-                "data_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "gap_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "heartbeat_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "history2history_latency":{
-                    "26":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "last_reported_data_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_gap_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_heartbeat_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_resent_datas":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "publication_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ],
-                "resent_datas":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "samples_datas":{
-                    "3":
-                    [
-                        {
-                            "src_time": "0",
-                            "count": 2
-                        },
-                        {
-                            "src_time":"100",
-                            "count": 2
-                        },
-                        {
-                            "src_time":"200",
-                            "count": 2
-                        }
-                    ]
-                }
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
-            "locators":[
-                "18"
-            ],
-            "name":"datawriter_2",
-            "alias":"datawriter_2",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"24",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"23",
-            "virtual_metatraffic":false
+        "last_reported_nackfrag_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "7":{
-            "data":{
-                "data_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "gap_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "heartbeat_count":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "history2history_latency":{
-                    "8":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "last_reported_data_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_gap_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_heartbeat_count":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_resent_datas":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "publication_throughput":[
-                    {
-                        "data":1.1,
-                        "src_time":"0"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"100"
-                    },
-                    {
-                        "data":1.1,
-                        "src_time":"200"
-                    }
-                ],
-                "resent_datas":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "samples_datas":{
-                    "3":
-                    [
-                        {
-                            "src_time": "0",
-                            "count": 2
-                        },
-                        {
-                            "src_time": "100",
-                            "count": 2
-                        },
-                        {
-                            "src_time": "200",
-                            "count": 2
-                        }
-                    ]
-                }
-            },
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "locators":[
-                "0"
-            ],
-            "name":"datawriter_0",
-            "alias":"datawriter_0",
-            "metatraffic":false,
-            "alive":true,
-            "participant":"6",
-            "qos":{
-                "qos":"empty"
-            },
-            "topic":"5",
-            "virtual_metatraffic":false
-        }
+        "nackfrag_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "subscription_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ]
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
+      "locators": [
+        "18"
+      ],
+      "name": "datareader_2",
+      "alias": "datareader_2",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "24",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "23",
+      "virtual_metatraffic": false
     },
-    "domains":{
-        "13":{
-            "name":"121",
-            "alias":"domain_1",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "15"
-            ],
-            "topics":[
-                "14"
-            ]
+    "8": {
+      "data": {
+        "acknack_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_acknack_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "22":{
-            "name":"122",
-            "alias":"domain_2",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "24"
-            ],
-            "topics":[
-                "23"
-            ]
+        "last_reported_nackfrag_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "4":{
-            "name":"120",
-            "alias":"domain_0",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "6"
-            ],
-            "topics":[
-                "5"
-            ]
-        }
-    },
-    "hosts":{
-        "1":{
-            "name":"host_0",
-            "alias":"host_0",
-            "metatraffic":false,
-            "alive":true,
-            "users":[
-                "2"
-            ]
-        },
-        "10":{
-            "name":"host_1",
-            "alias":"host_1",
-            "metatraffic":false,
-            "alive":true,
-            "users":[
-                "11"
-            ]
-        },
-        "19":{
-            "name":"host_2",
-            "alias":"host_2",
-            "metatraffic":false,
-            "alive":true,
-            "users":[
-                "20"
-            ]
-        }
-    },
-    "locators":{
-        "0":{
-            "datareaders":[
-                "8"
-            ],
-            "datawriters":[
-                "7"
-            ],
-            "name":"locator_0",
-            "alias":"locator_0",
-            "metatraffic":false,
-            "alive":true
-        },
-        "18":{
-            "datareaders":[
-                "26"
-            ],
-            "datawriters":[
-                "25"
-            ],
-            "name":"locator_2",
-            "alias":"locator_2",
-            "metatraffic":false,
-            "alive":true
-        },
-        "9":{
-            "datareaders":[
-                "17"
-            ],
-            "datawriters":[
-                "16"
-            ],
-            "name":"locator_1",
-            "alias":"locator_1",
-            "metatraffic":false,
-            "alive":true
-        }
-    },
-    "participants":{
-        "15":{
-            "data":{
-                "discovery_time":{
-                    "15":[
-                        {
-                            "src_time":"100",
-                            "time": "0",
-                            "remote_id": "15",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"200",
-                            "time":"100",
-                            "remote_id": "15",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"300",
-                            "time":"200",
-                            "remote_id": "15",
-                            "discovered": true
-                        }
-                    ]
-                },
-                "edp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_edp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_pdp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_rtps_bytes_lost":{
-                    "9":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_bytes_sent":{
-                    "9":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_lost":{
-                    "9":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_sent":{
-                    "9":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "pdp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "rtps_bytes_lost":{
-                    "9":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_bytes_sent":{
-                    "9":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_lost":{
-                    "9":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_sent":{
-                    "9":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "network_latency_per_locator":{
-                    "9":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
+        "nackfrag_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "subscription_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ]
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "locators": [
+        "0"
+      ],
+      "name": "datareader_0",
+      "alias": "datareader_0",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "6",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "5",
+      "virtual_metatraffic": false
+    }
+  },
+  "datawriters": {
+    "16": {
+      "data": {
+        "data_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "gap_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "heartbeat_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "history2history_latency": {
+          "17": [
+            {
+              "data": 1.1,
+              "src_time": "0"
             },
-            "datareaders":[
-                "17"
-            ],
-            "datawriters":[
-                "16"
-            ],
-            "domain":"13",
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.01|0.0.0.0",
-            "name":"participant_1",
-            "alias":"participant_1",
-            "metatraffic":false,
-            "alive":true,
-            "process":"12",
-            "qos":{
-                "qos":"empty"
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
             }
+          ]
         },
-        "24":{
-            "data":{
-                "discovery_time":{
-                    "24":[
-                        {
-                            "src_time":"100",
-                            "time": "0",
-                            "remote_id": "24",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"200",
-                            "time":"100",
-                            "remote_id": "24",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"300",
-                            "time":"200",
-                            "remote_id": "24",
-                            "discovered": true
-                        }
-                    ]
-                },
-                "edp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_edp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_pdp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_rtps_bytes_lost":{
-                    "18":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_bytes_sent":{
-                    "18":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_lost":{
-                    "18":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_sent":{
-                    "18":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "pdp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "rtps_bytes_lost":{
-                    "18":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_bytes_sent":{
-                    "18":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_lost":{
-                    "18":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_sent":{
-                    "18":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "network_latency_per_locator":{
-                    "18":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
+        "last_reported_data_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_gap_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_heartbeat_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_resent_datas": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "publication_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ],
+        "resent_datas": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "samples_datas": {
+          "3": [
+            {
+              "src_time": "0",
+              "count": 2
             },
-            "datareaders":[
-                "26"
-            ],
-            "datawriters":[
-                "25"
-            ],
-            "domain":"22",
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
-            "name":"participant_2",
-            "alias":"participant_2",
-            "metatraffic":false,
-            "alive":true,
-            "process":"21",
-            "qos":{
-                "qos":"empty"
-            }
-        },
-        "6":{
-            "data":{
-                "discovery_time":{
-                    "6":[
-                        {
-                            "src_time":"100",
-                            "time": "0",
-                            "remote_id": "6",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"200",
-                            "time":"100",
-                            "remote_id": "6",
-                            "discovered": true
-                        },
-                        {
-                            "src_time":"300",
-                            "time":"200",
-                            "remote_id": "6",
-                            "discovered": true
-                        }
-                    ]
-                },
-                "edp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "last_reported_edp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_pdp_packets":{
-                    "count":2,
-                    "src_time":"200"
-                },
-                "last_reported_rtps_bytes_lost":{
-                    "0":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_bytes_sent":{
-                    "0":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_lost":{
-                    "0":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "last_reported_rtps_packets_sent":{
-                    "0":{
-                        "count":2,
-                        "src_time":"200"
-                    }
-                },
-                "pdp_packets":[
-                    {
-                        "count":2,
-                        "src_time":"0"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"100"
-                    },
-                    {
-                        "count":0,
-                        "src_time":"200"
-                    }
-                ],
-                "rtps_bytes_lost":{
-                    "0":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_bytes_sent":{
-                    "0":[
-                        {
-                            "count":2,
-                            "magnitude":0,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "magnitude":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_lost":{
-                    "0":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "rtps_packets_sent":{
-                    "0":[
-                        {
-                            "count":2,
-                            "src_time":"0"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"100"
-                        },
-                        {
-                            "count":0,
-                            "src_time":"200"
-                        }
-                    ]
-                },
-                "network_latency_per_locator":{
-                    "0":[
-                        {
-                            "data":1.1,
-                            "src_time":"0"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"100"
-                        },
-                        {
-                            "data":1.1,
-                            "src_time":"200"
-                        }
-                    ]
-                }
+            {
+              "src_time": "100",
+              "count": 2
             },
-            "datareaders":[
-                "8"
-            ],
-            "datawriters":[
-                "7"
-            ],
-            "domain":"4",
-            "guid":"01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "name":"participant_0",
-            "alias":"participant_0",
-            "metatraffic":false,
-            "alive":true,
-            "process":"3",
-            "qos":{
-                "qos":"empty"
+            {
+              "src_time": "200",
+              "count": 2
             }
+          ]
         }
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.01|0.0.0.0",
+      "locators": [
+        "9"
+      ],
+      "name": "datawriter_1",
+      "alias": "datawriter_1",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "15",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "14",
+      "virtual_metatraffic": false
     },
-    "processes":{
-        "12":{
-            "name":"process_1",
-            "alias":"process_1",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "15"
-            ],
-            "pid":"36000",
-            "user":"11"
+    "25": {
+      "data": {
+        "data_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "gap_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "heartbeat_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "history2history_latency": {
+          "26": [
+            {
+              "data": 1.1,
+              "src_time": "0"
+            },
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
+            }
+          ]
         },
-        "21":{
-            "name":"process_2",
-            "alias":"process_2",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "24"
-            ],
-            "pid":"36000",
-            "user":"20"
+        "last_reported_data_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "3":{
-            "name":"process_0",
-            "alias":"process_0",
-            "metatraffic":false,
-            "alive":true,
-            "participants":[
-                "6"
-            ],
-            "pid":"36000",
-            "user":"2"
+        "last_reported_gap_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_heartbeat_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_resent_datas": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "publication_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ],
+        "resent_datas": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "samples_datas": {
+          "3": [
+            {
+              "src_time": "0",
+              "count": 2
+            },
+            {
+              "src_time": "100",
+              "count": 2
+            },
+            {
+              "src_time": "200",
+              "count": 2
+            }
+          ]
         }
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.02|0.0.0.0",
+      "locators": [
+        "18"
+      ],
+      "name": "datawriter_2",
+      "alias": "datawriter_2",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "24",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "23",
+      "virtual_metatraffic": false
     },
-    "topics":{
-        "14":{
-            "data_type":"data_type",
-            "datareaders":[
-                "17"
-            ],
-            "datawriters":[
-                "16"
-            ],
-            "domain":"13",
-            "name":"topic_1",
-            "alias":"topic_1",
-            "metatraffic":false,
-            "alive":true
+    "7": {
+      "data": {
+        "data_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "gap_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "heartbeat_count": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "history2history_latency": {
+          "8": [
+            {
+              "data": 1.1,
+              "src_time": "0"
+            },
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
+            }
+          ]
         },
-        "23":{
-            "data_type":"data_type",
-            "datareaders":[
-                "26"
-            ],
-            "datawriters":[
-                "25"
-            ],
-            "domain":"22",
-            "name":"topic_2",
-            "alias":"topic_2",
-            "metatraffic":false,
-            "alive":true
+        "last_reported_data_count": {
+          "count": 2,
+          "src_time": "200"
         },
-        "5":{
-            "data_type":"data_type",
-            "datareaders":[
-                "8"
-            ],
-            "datawriters":[
-                "7"
-            ],
-            "domain":"4",
-            "name":"topic_0",
-            "alias":"topic_0",
-            "metatraffic":false,
-            "alive":true
+        "last_reported_gap_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_heartbeat_count": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_resent_datas": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "publication_throughput": [
+          {
+            "data": 1.1,
+            "src_time": "0"
+          },
+          {
+            "data": 1.1,
+            "src_time": "100"
+          },
+          {
+            "data": 1.1,
+            "src_time": "200"
+          }
+        ],
+        "resent_datas": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "samples_datas": {
+          "3": [
+            {
+              "src_time": "0",
+              "count": 2
+            },
+            {
+              "src_time": "100",
+              "count": 2
+            },
+            {
+              "src_time": "200",
+              "count": 2
+            }
+          ]
         }
+      },
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "locators": [
+        "0"
+      ],
+      "name": "datawriter_0",
+      "alias": "datawriter_0",
+      "metatraffic": false,
+      "alive": true,
+      "participant": "6",
+      "qos": {
+        "qos": "empty"
+      },
+      "topic": "5",
+      "virtual_metatraffic": false
+    }
+  },
+  "domains": {
+    "13": {
+      "name": "121",
+      "alias": "domain_1",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "15"
+      ],
+      "topics": [
+        "14"
+      ]
     },
-    "users":{
-        "11":{
-            "host":"10",
-            "name":"user_1",
-            "alias":"user_1",
-            "metatraffic":false,
-            "alive":true,
-            "processes":[
-                "12"
-            ]
+    "22": {
+      "name": "122",
+      "alias": "domain_2",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "24"
+      ],
+      "topics": [
+        "23"
+      ]
+    },
+    "4": {
+      "name": "120",
+      "alias": "domain_0",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "6"
+      ],
+      "topics": [
+        "5"
+      ]
+    }
+  },
+  "hosts": {
+    "1": {
+      "name": "host_0",
+      "alias": "host_0",
+      "metatraffic": false,
+      "alive": true,
+      "users": [
+        "2"
+      ]
+    },
+    "10": {
+      "name": "host_1",
+      "alias": "host_1",
+      "metatraffic": false,
+      "alive": true,
+      "users": [
+        "11"
+      ]
+    },
+    "19": {
+      "name": "host_2",
+      "alias": "host_2",
+      "metatraffic": false,
+      "alive": true,
+      "users": [
+        "20"
+      ]
+    }
+  },
+  "locators": {
+    "0": {
+      "datareaders": [
+        "8"
+      ],
+      "datawriters": [
+        "7"
+      ],
+      "name": "locator_0",
+      "alias": "locator_0",
+      "metatraffic": false,
+      "alive": true
+    },
+    "18": {
+      "datareaders": [
+        "26"
+      ],
+      "datawriters": [
+        "25"
+      ],
+      "name": "locator_2",
+      "alias": "locator_2",
+      "metatraffic": false,
+      "alive": true
+    },
+    "9": {
+      "datareaders": [
+        "17"
+      ],
+      "datawriters": [
+        "16"
+      ],
+      "name": "locator_1",
+      "alias": "locator_1",
+      "metatraffic": false,
+      "alive": true
+    }
+  },
+  "participants": {
+    "15": {
+      "data": {
+        "discovery_time": {
+          "15": [
+            {
+              "src_time": "100",
+              "time": "0",
+              "remote_id": "15",
+              "discovered": true
+            },
+            {
+              "src_time": "200",
+              "time": "100",
+              "remote_id": "15",
+              "discovered": true
+            },
+            {
+              "src_time": "300",
+              "time": "200",
+              "remote_id": "15",
+              "discovered": true
+            }
+          ]
         },
-        "2":{
-            "host":"1",
-            "name":"user_0",
-            "alias":"user_0",
-            "metatraffic":false,
-            "alive":true,
-            "processes":[
-                "3"
-            ]
+        "edp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_edp_packets": {
+          "count": 2,
+          "src_time": "200"
         },
-        "20":{
-            "host":"19",
-            "name":"user_2",
-            "alias":"user_2",
-            "metatraffic":false,
-            "alive":true,
-            "processes":[
-                "21"
-            ]
+        "last_reported_pdp_packets": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_rtps_bytes_lost": {
+          "9": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_bytes_sent": {
+          "9": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_lost": {
+          "9": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_sent": {
+          "9": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "pdp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "rtps_bytes_lost": {
+          "9": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_bytes_sent": {
+          "9": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_lost": {
+          "9": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_sent": {
+          "9": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "network_latency_per_locator": {
+          "9": [
+            {
+              "data": 1.1,
+              "src_time": "0"
+            },
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
+            }
+          ]
         }
+      },
+      "datareaders": [
+        "17"
+      ],
+      "datawriters": [
+        "16"
+      ],
+      "domain": "13",
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.01|0.0.1.0",
+      "name": "participant_1",
+      "alias": "participant_1",
+      "metatraffic": false,
+      "alive": true,
+      "process": "12",
+      "qos": {
+        "qos": "empty"
+      }
     },
-    "version":"0.0"
+    "24": {
+      "data": {
+        "discovery_time": {
+          "24": [
+            {
+              "src_time": "100",
+              "time": "0",
+              "remote_id": "24",
+              "discovered": true
+            },
+            {
+              "src_time": "200",
+              "time": "100",
+              "remote_id": "24",
+              "discovered": true
+            },
+            {
+              "src_time": "300",
+              "time": "200",
+              "remote_id": "24",
+              "discovered": true
+            }
+          ]
+        },
+        "edp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_edp_packets": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_pdp_packets": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_rtps_bytes_lost": {
+          "18": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_bytes_sent": {
+          "18": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_lost": {
+          "18": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_sent": {
+          "18": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "pdp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "rtps_bytes_lost": {
+          "18": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_bytes_sent": {
+          "18": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_lost": {
+          "18": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_sent": {
+          "18": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "network_latency_per_locator": {
+          "18": [
+            {
+              "data": 1.1,
+              "src_time": "0"
+            },
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
+            }
+          ]
+        }
+      },
+      "datareaders": [
+        "26"
+      ],
+      "datawriters": [
+        "25"
+      ],
+      "domain": "22",
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.02|0.0.1.0",
+      "name": "participant_2",
+      "alias": "participant_2",
+      "metatraffic": false,
+      "alive": true,
+      "process": "21",
+      "qos": {
+        "qos": "empty"
+      }
+    },
+    "6": {
+      "data": {
+        "discovery_time": {
+          "6": [
+            {
+              "src_time": "100",
+              "time": "0",
+              "remote_id": "6",
+              "discovered": true
+            },
+            {
+              "src_time": "200",
+              "time": "100",
+              "remote_id": "6",
+              "discovered": true
+            },
+            {
+              "src_time": "300",
+              "time": "200",
+              "remote_id": "6",
+              "discovered": true
+            }
+          ]
+        },
+        "edp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "last_reported_edp_packets": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_pdp_packets": {
+          "count": 2,
+          "src_time": "200"
+        },
+        "last_reported_rtps_bytes_lost": {
+          "0": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_bytes_sent": {
+          "0": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_lost": {
+          "0": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "last_reported_rtps_packets_sent": {
+          "0": {
+            "count": 2,
+            "src_time": "200"
+          }
+        },
+        "pdp_packets": [
+          {
+            "count": 2,
+            "src_time": "0"
+          },
+          {
+            "count": 0,
+            "src_time": "100"
+          },
+          {
+            "count": 0,
+            "src_time": "200"
+          }
+        ],
+        "rtps_bytes_lost": {
+          "0": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_bytes_sent": {
+          "0": [
+            {
+              "count": 2,
+              "magnitude": 0,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "magnitude": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_lost": {
+          "0": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "rtps_packets_sent": {
+          "0": [
+            {
+              "count": 2,
+              "src_time": "0"
+            },
+            {
+              "count": 0,
+              "src_time": "100"
+            },
+            {
+              "count": 0,
+              "src_time": "200"
+            }
+          ]
+        },
+        "network_latency_per_locator": {
+          "0": [
+            {
+              "data": 1.1,
+              "src_time": "0"
+            },
+            {
+              "data": 1.1,
+              "src_time": "100"
+            },
+            {
+              "data": 1.1,
+              "src_time": "200"
+            }
+          ]
+        }
+      },
+      "datareaders": [
+        "8"
+      ],
+      "datawriters": [
+        "7"
+      ],
+      "domain": "4",
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.1.0",
+      "name": "participant_0",
+      "alias": "participant_0",
+      "metatraffic": false,
+      "alive": true,
+      "process": "3",
+      "qos": {
+        "qos": "empty"
+      }
+    }
+  },
+  "processes": {
+    "12": {
+      "name": "process_1",
+      "alias": "process_1",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "15"
+      ],
+      "pid": "36000",
+      "user": "11"
+    },
+    "21": {
+      "name": "process_2",
+      "alias": "process_2",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "24"
+      ],
+      "pid": "36000",
+      "user": "20"
+    },
+    "3": {
+      "name": "process_0",
+      "alias": "process_0",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "6"
+      ],
+      "pid": "36000",
+      "user": "2"
+    }
+  },
+  "topics": {
+    "14": {
+      "data_type": "data_type",
+      "datareaders": [
+        "17"
+      ],
+      "datawriters": [
+        "16"
+      ],
+      "domain": "13",
+      "name": "topic_1",
+      "alias": "topic_1",
+      "metatraffic": false,
+      "alive": true
+    },
+    "23": {
+      "data_type": "data_type",
+      "datareaders": [
+        "26"
+      ],
+      "datawriters": [
+        "25"
+      ],
+      "domain": "22",
+      "name": "topic_2",
+      "alias": "topic_2",
+      "metatraffic": false,
+      "alive": true
+    },
+    "5": {
+      "data_type": "data_type",
+      "datareaders": [
+        "8"
+      ],
+      "datawriters": [
+        "7"
+      ],
+      "domain": "4",
+      "name": "topic_0",
+      "alias": "topic_0",
+      "metatraffic": false,
+      "alive": true
+    }
+  },
+  "users": {
+    "11": {
+      "host": "10",
+      "name": "user_1",
+      "alias": "user_1",
+      "metatraffic": false,
+      "alive": true,
+      "processes": [
+        "12"
+      ]
+    },
+    "2": {
+      "host": "1",
+      "name": "user_0",
+      "alias": "user_0",
+      "metatraffic": false,
+      "alive": true,
+      "processes": [
+        "3"
+      ]
+    },
+    "20": {
+      "host": "19",
+      "name": "user_2",
+      "alias": "user_2",
+      "metatraffic": false,
+      "alive": true,
+      "processes": [
+        "21"
+      ]
+    }
+  },
+  "version": "0.0"
 }

--- a/test/unittest/Resources/simple_dump.json
+++ b/test/unittest/Resources/simple_dump.json
@@ -1,367 +1,332 @@
 {
-    "description": "DB dump with 1 entity of each EntityKind and 1 data of each DataKind",
-
-    "version": "0.0",
-
-    "hosts":
-    {
-        "1":
-        {
-            "name": "host_0",
-            "alias": "host_0",
-            "metatraffic":false,
-            "alive":true,
-            "users": ["2"]
-        }
-    },
-
-    "users":
-    {
-        "2":
-        {
-            "name": "user_0",
-            "alias": "user_0",
-            "metatraffic":false,
-            "alive":true,
-            "host": "1",
-            "processes": ["3"]
-        }
-    },
-
-    "processes":
-    {
-        "3":
-        {
-            "name": "process_0",
-            "alias": "process_0",
-            "metatraffic":false,
-            "alive":true,
-            "pid": "36000",
-            "user": "2",
-            "participants": ["6"]
-        }
-    },
-
-    "domains":
-    {
-        "4":
-        {
-            "name": "120",
-            "alias": "domain_0",
-            "metatraffic":false,
-            "alive":true,
-            "participants": ["6"],
-            "topics": ["5"]
-        }
-    },
-
-    "topics":
-    {
-        "5":
-        {
-            "name": "topic_0",
-            "alias": "topic_0",
-            "metatraffic":false,
-            "alive":true,
-            "data_type": "data_type",
-            "domain": "4",
-            "datawriters": ["7"],
-            "datareaders": ["8"]
-        }
-    },
-
-    "participants":
-    {
-        "6":
-        {
-            "name": "participant_0",
-            "alias": "participant_0",
-            "metatraffic":false,
-            "alive":true,
-            "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "qos": {"qos": "empty"},
-
-            "process": "3",
-            "domain": "4",
-            "datawriters": ["7"],
-            "datareaders": ["8"],
-
-            "data":
-            {
-                "discovery_time":
-                {
-                    "6":
-                    [
-                        {
-                            "src_time":"100",
-                            "time": "0",
-                            "remote_id": "6",
-                            "discovered": true
-                        }
-                    ]
-                },
-                "pdp_packets":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-                "edp_packets":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-
-                "rtps_packets_sent":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "count": 2
-                        }
-                    ]
-                },
-                "rtps_bytes_sent":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "magnitude": 0,
-                            "count": 2
-                        }
-                    ]
-                },
-                "rtps_packets_lost":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "count": 2
-                        }
-                    ]
-                },
-                "rtps_bytes_lost":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "magnitude": 0,
-                            "count": 2
-                        }
-                    ]
-                },
-                "network_latency_per_locator":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "data": 1.1
-                        }
-                    ]
-                },
-
-                "last_reported_edp_packets":{
-                    "count":2,
-                    "src_time":"0"
-                },
-                "last_reported_pdp_packets":{
-                    "count":2,
-                    "src_time":"0"
-                },
-                "last_reported_rtps_bytes_lost":{
-                    "0":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"0"
-                    }
-                },
-                "last_reported_rtps_bytes_sent":{
-                    "0":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"0"
-                    }
-                },
-                "last_reported_rtps_packets_lost":{
-                    "0":{
-                        "count":2,
-                        "src_time":"0"
-                    }
-                },
-                "last_reported_rtps_packets_sent":{
-                    "0":{
-                        "count":2,
-                        "src_time":"0"
-                    }
-                }
-            }
-        }
-    },
-
-    "datawriters":
-    {
-        "7":
-        {
-            "name": "datawriter_0",
-            "alias": "datawriter_0",
-            "metatraffic":false,
-            "alive":true,
-            "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "qos": {"qos": "empty"},
-
-            "participant": "6",
-            "topic": "5",
-            "locators": ["0"],
-            "virtual_metatraffic":false,
-
-            "data":
-            {
-                "publication_throughput":
-                [
-                    {
-                        "src_time": "0",
-                        "data": 1.1
-                    }
-                ],
-                "resent_datas":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-                "heartbeat_count":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-                "gap_count":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-                "data_count":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-                "samples_datas":
-                {
-                    "3":
-                    [
-                        {
-                            "src_time": "0",
-                            "count": 2
-                        }
-                    ]
-                },
-                "history2history_latency":
-                {
-                    "8":
-                    [
-                        {
-                            "src_time": "0",
-                            "data": 1.1
-                        }
-                    ]
-                },
-
-                "last_reported_data_count":{
-                    "count":2,
-                    "src_time":"0"
-                },
-                "last_reported_gap_count":{
-                    "count":2,
-                    "src_time":"0"
-                },
-                "last_reported_heartbeat_count":{
-                    "count":2,
-                    "src_time":"0"
-                },
-                "last_reported_resent_datas":{
-                    "count":2,
-                    "src_time":"0"
-                }
-            }
-        }
-    },
-
-    "datareaders":
-    {
-        "8":
-        {
-            "name": "datareader_0",
-            "alias": "datareader_0",
-            "metatraffic":false,
-            "alive":true,
-            "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "qos": {"qos": "empty"},
-
-            "participant": "6",
-            "topic": "5",
-            "locators": ["0"],
-            "virtual_metatraffic":false,
-
-            "data":
-            {
-                "subscription_throughput":
-                [
-                    {
-                        "src_time": "0",
-                        "data": 1.1
-                    }
-                ],
-                "acknack_count":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-                "nackfrag_count":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-
-                "last_reported_acknack_count":{
-                    "count":2,
-                    "src_time":"0"
-                },
-                "last_reported_nackfrag_count":{
-                    "count":2,
-                    "src_time":"0"
-                }
-            }
-        }
-    },
-
-    "locators":
-    {
-        "0":
-        {
-            "name": "locator_0",
-            "alias": "locator_0",
-            "metatraffic":false,
-            "alive":true,
-            "datawriters": ["7"],
-            "datareaders": ["8"]
-        }
+  "description": "DB dump with 1 entity of each EntityKind and 1 data of each DataKind",
+  "version": "0.0",
+  "hosts": {
+    "1": {
+      "name": "host_0",
+      "alias": "host_0",
+      "metatraffic": false,
+      "alive": true,
+      "users": [
+        "2"
+      ]
     }
+  },
+  "users": {
+    "2": {
+      "name": "user_0",
+      "alias": "user_0",
+      "metatraffic": false,
+      "alive": true,
+      "host": "1",
+      "processes": [
+        "3"
+      ]
+    }
+  },
+  "processes": {
+    "3": {
+      "name": "process_0",
+      "alias": "process_0",
+      "metatraffic": false,
+      "alive": true,
+      "pid": "36000",
+      "user": "2",
+      "participants": [
+        "6"
+      ]
+    }
+  },
+  "domains": {
+    "4": {
+      "name": "120",
+      "alias": "domain_0",
+      "metatraffic": false,
+      "alive": true,
+      "participants": [
+        "6"
+      ],
+      "topics": [
+        "5"
+      ]
+    }
+  },
+  "topics": {
+    "5": {
+      "name": "topic_0",
+      "alias": "topic_0",
+      "metatraffic": false,
+      "alive": true,
+      "data_type": "data_type",
+      "domain": "4",
+      "datawriters": [
+        "7"
+      ],
+      "datareaders": [
+        "8"
+      ]
+    }
+  },
+  "participants": {
+    "6": {
+      "name": "participant_0",
+      "alias": "participant_0",
+      "metatraffic": false,
+      "alive": true,
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.1.0",
+      "qos": {
+        "qos": "empty"
+      },
+      "process": "3",
+      "domain": "4",
+      "datawriters": [
+        "7"
+      ],
+      "datareaders": [
+        "8"
+      ],
+      "data": {
+        "discovery_time": {
+          "6": [
+            {
+              "src_time": "100",
+              "time": "0",
+              "remote_id": "6",
+              "discovered": true
+            }
+          ]
+        },
+        "pdp_packets": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "edp_packets": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "rtps_packets_sent": {
+          "0": [
+            {
+              "src_time": "0",
+              "count": 2
+            }
+          ]
+        },
+        "rtps_bytes_sent": {
+          "0": [
+            {
+              "src_time": "0",
+              "magnitude": 0,
+              "count": 2
+            }
+          ]
+        },
+        "rtps_packets_lost": {
+          "0": [
+            {
+              "src_time": "0",
+              "count": 2
+            }
+          ]
+        },
+        "rtps_bytes_lost": {
+          "0": [
+            {
+              "src_time": "0",
+              "magnitude": 0,
+              "count": 2
+            }
+          ]
+        },
+        "network_latency_per_locator": {
+          "0": [
+            {
+              "src_time": "0",
+              "data": 1.1
+            }
+          ]
+        },
+        "last_reported_edp_packets": {
+          "count": 2,
+          "src_time": "0"
+        },
+        "last_reported_pdp_packets": {
+          "count": 2,
+          "src_time": "0"
+        },
+        "last_reported_rtps_bytes_lost": {
+          "0": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "0"
+          }
+        },
+        "last_reported_rtps_bytes_sent": {
+          "0": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "0"
+          }
+        },
+        "last_reported_rtps_packets_lost": {
+          "0": {
+            "count": 2,
+            "src_time": "0"
+          }
+        },
+        "last_reported_rtps_packets_sent": {
+          "0": {
+            "count": 2,
+            "src_time": "0"
+          }
+        }
+      }
+    }
+  },
+  "datawriters": {
+    "7": {
+      "name": "datawriter_0",
+      "alias": "datawriter_0",
+      "metatraffic": false,
+      "alive": true,
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "qos": {
+        "qos": "empty"
+      },
+      "participant": "6",
+      "topic": "5",
+      "locators": [
+        "0"
+      ],
+      "virtual_metatraffic": false,
+      "data": {
+        "publication_throughput": [
+          {
+            "src_time": "0",
+            "data": 1.1
+          }
+        ],
+        "resent_datas": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "heartbeat_count": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "gap_count": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "data_count": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "samples_datas": {
+          "3": [
+            {
+              "src_time": "0",
+              "count": 2
+            }
+          ]
+        },
+        "history2history_latency": {
+          "8": [
+            {
+              "src_time": "0",
+              "data": 1.1
+            }
+          ]
+        },
+        "last_reported_data_count": {
+          "count": 2,
+          "src_time": "0"
+        },
+        "last_reported_gap_count": {
+          "count": 2,
+          "src_time": "0"
+        },
+        "last_reported_heartbeat_count": {
+          "count": 2,
+          "src_time": "0"
+        },
+        "last_reported_resent_datas": {
+          "count": 2,
+          "src_time": "0"
+        }
+      }
+    }
+  },
+  "datareaders": {
+    "8": {
+      "name": "datareader_0",
+      "alias": "datareader_0",
+      "metatraffic": false,
+      "alive": true,
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "qos": {
+        "qos": "empty"
+      },
+      "participant": "6",
+      "topic": "5",
+      "locators": [
+        "0"
+      ],
+      "virtual_metatraffic": false,
+      "data": {
+        "subscription_throughput": [
+          {
+            "src_time": "0",
+            "data": 1.1
+          }
+        ],
+        "acknack_count": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "nackfrag_count": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "last_reported_acknack_count": {
+          "count": 2,
+          "src_time": "0"
+        },
+        "last_reported_nackfrag_count": {
+          "count": 2,
+          "src_time": "0"
+        }
+      }
+    }
+  },
+  "locators": {
+    "0": {
+      "name": "locator_0",
+      "alias": "locator_0",
+      "metatraffic": false,
+      "alive": true,
+      "datawriters": [
+        "7"
+      ],
+      "datareaders": [
+        "8"
+      ]
+    }
+  }
 }

--- a/test/unittest/Resources/simple_dump_no_process_participant_link.json
+++ b/test/unittest/Resources/simple_dump_no_process_participant_link.json
@@ -1,367 +1,330 @@
 {
-    "description": "DB dump with 1 entity of each EntityKind and 1 data of each DataKind. No link between participant and process yet.",
-
-    "version": "0.0",
-
-    "hosts":
-    {
-        "1":
-        {
-            "name": "host_0",
-            "alias": "host_0",
-            "metatraffic":false,
-            "alive":false,
-            "users": ["2"]
-        }
-    },
-
-    "users":
-    {
-        "2":
-        {
-            "name": "user_0",
-            "alias": "user_0",
-            "metatraffic":false,
-            "alive":false,
-            "host": "1",
-            "processes": ["3"]
-        }
-    },
-
-    "processes":
-    {
-        "3":
-        {
-            "name": "process_0",
-            "alias": "process_0",
-            "metatraffic":false,
-            "alive":false,
-            "pid": "36000",
-            "user": "2",
-            "participants": []
-        }
-    },
-
-    "domains":
-    {
-        "4":
-        {
-            "name": "120",
-            "alias": "domain_0",
-            "participants": ["6"],
-            "metatraffic":false,
-            "alive":true,
-            "topics": ["5"]
-        }
-    },
-
-    "topics":
-    {
-        "5":
-        {
-            "name": "topic_0",
-            "alias": "topic_0",
-            "metatraffic":false,
-            "alive":true,
-            "data_type": "data_type",
-            "domain": "4",
-            "datawriters": ["7"],
-            "datareaders": ["8"]
-        }
-    },
-
-    "participants":
-    {
-        "6":
-        {
-            "name": "participant_0",
-            "alias": "participant_0",
-            "metatraffic":false,
-            "alive":true,
-            "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "qos": {"qos": "empty"},
-
-            "process": "-1",
-            "domain": "4",
-            "datawriters": ["7"],
-            "datareaders": ["8"],
-
-            "data":
-            {
-                "discovery_time":
-                {
-                    "6":
-                    [
-                        {
-                            "src_time": "100",
-                            "time": "0",
-                            "remote_id": "6",
-                            "discovered": true
-                        }
-                    ]
-                },
-                "pdp_packets":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-                "edp_packets":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-
-                "rtps_packets_sent":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "count": 2
-                        }
-                    ]
-                },
-                "rtps_bytes_sent":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "magnitude": 0,
-                            "count": 2
-                        }
-                    ]
-                },
-                "rtps_packets_lost":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "count": 2
-                        }
-                    ]
-                },
-                "rtps_bytes_lost":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "magnitude": 0,
-                            "count": 2
-                        }
-                    ]
-                },
-                "network_latency_per_locator":
-                {
-                    "0":
-                    [
-                        {
-                            "src_time": "0",
-                            "data": 1.1
-                        }
-                    ]
-                },
-
-                "last_reported_edp_packets":{
-                    "count":2,
-                    "src_time":"0"
-                },
-                "last_reported_pdp_packets":{
-                    "count":2,
-                    "src_time":"0"
-                },
-                "last_reported_rtps_bytes_lost":{
-                    "0":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"0"
-                    }
-                },
-                "last_reported_rtps_bytes_sent":{
-                    "0":{
-                        "count":2,
-                        "magnitude":0,
-                        "src_time":"0"
-                    }
-                },
-                "last_reported_rtps_packets_lost":{
-                    "0":{
-                        "count":2,
-                        "src_time":"0"
-                    }
-                },
-                "last_reported_rtps_packets_sent":{
-                    "0":{
-                        "count":2,
-                        "src_time":"0"
-                    }
-                }
-            }
-        }
-    },
-
-    "datawriters":
-    {
-        "7":
-        {
-            "name": "datawriter_0",
-            "alias": "datawriter_0",
-            "metatraffic":false,
-            "alive":true,
-            "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "qos": {"qos": "empty"},
-
-            "participant": "6",
-            "topic": "5",
-            "locators": ["0"],
-            "virtual_metatraffic":false,
-
-            "data":
-            {
-                "publication_throughput":
-                [
-                    {
-                        "src_time": "0",
-                        "data": 1.1
-                    }
-                ],
-                "resent_datas":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-                "heartbeat_count":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-                "gap_count":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-                "data_count":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-                "samples_datas":
-                {
-                    "3":
-                    [
-                        {
-                            "src_time": "0",
-                            "count": 2
-                        }
-                    ]
-                },
-                "history2history_latency":
-                {
-                    "8":
-                    [
-                        {
-                            "src_time": "0",
-                            "data": 1.1
-                        }
-                    ]
-                },
-
-                "last_reported_data_count":{
-                    "count":2,
-                    "src_time":"0"
-                },
-                "last_reported_gap_count":{
-                    "count":2,
-                    "src_time":"0"
-                },
-                "last_reported_heartbeat_count":{
-                    "count":2,
-                    "src_time":"0"
-                },
-                "last_reported_resent_datas":{
-                    "count":2,
-                    "src_time":"0"
-                }
-            }
-        }
-    },
-
-    "datareaders":
-    {
-        "8":
-        {
-            "name": "datareader_0",
-            "alias": "datareader_0",
-            "metatraffic":false,
-            "alive":true,
-            "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
-            "qos": {"qos": "empty"},
-
-            "participant": "6",
-            "topic": "5",
-            "locators": ["0"],
-            "virtual_metatraffic":false,
-
-            "data":
-            {
-                "subscription_throughput":
-                [
-                    {
-                        "src_time": "0",
-                        "data": 1.1
-                    }
-                ],
-                "acknack_count":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-                "nackfrag_count":
-                [
-                    {
-                        "src_time": "0",
-                        "count": 2
-                    }
-                ],
-
-                "last_reported_acknack_count":{
-                    "count":2,
-                    "src_time":"0"
-                },
-                "last_reported_nackfrag_count":{
-                    "count":2,
-                    "src_time":"0"
-                }
-            }
-        }
-    },
-
-    "locators":
-    {
-        "0":
-        {
-            "name": "locator_0",
-            "alias": "locator_0",
-            "metatraffic":false,
-            "alive":true,
-            "datawriters": ["7"],
-            "datareaders": ["8"]
-        }
+  "description": "DB dump with 1 entity of each EntityKind and 1 data of each DataKind. No link between participant and process yet.",
+  "version": "0.0",
+  "hosts": {
+    "1": {
+      "name": "host_0",
+      "alias": "host_0",
+      "metatraffic": false,
+      "alive": false,
+      "users": [
+        "2"
+      ]
     }
+  },
+  "users": {
+    "2": {
+      "name": "user_0",
+      "alias": "user_0",
+      "metatraffic": false,
+      "alive": false,
+      "host": "1",
+      "processes": [
+        "3"
+      ]
+    }
+  },
+  "processes": {
+    "3": {
+      "name": "process_0",
+      "alias": "process_0",
+      "metatraffic": false,
+      "alive": false,
+      "pid": "36000",
+      "user": "2",
+      "participants": []
+    }
+  },
+  "domains": {
+    "4": {
+      "name": "120",
+      "alias": "domain_0",
+      "participants": [
+        "6"
+      ],
+      "metatraffic": false,
+      "alive": true,
+      "topics": [
+        "5"
+      ]
+    }
+  },
+  "topics": {
+    "5": {
+      "name": "topic_0",
+      "alias": "topic_0",
+      "metatraffic": false,
+      "alive": true,
+      "data_type": "data_type",
+      "domain": "4",
+      "datawriters": [
+        "7"
+      ],
+      "datareaders": [
+        "8"
+      ]
+    }
+  },
+  "participants": {
+    "6": {
+      "name": "participant_0",
+      "alias": "participant_0",
+      "metatraffic": false,
+      "alive": true,
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.1.0",
+      "qos": {
+        "qos": "empty"
+      },
+      "process": "-1",
+      "domain": "4",
+      "datawriters": [
+        "7"
+      ],
+      "datareaders": [
+        "8"
+      ],
+      "data": {
+        "discovery_time": {
+          "6": [
+            {
+              "src_time": "100",
+              "time": "0",
+              "remote_id": "6",
+              "discovered": true
+            }
+          ]
+        },
+        "pdp_packets": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "edp_packets": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "rtps_packets_sent": {
+          "0": [
+            {
+              "src_time": "0",
+              "count": 2
+            }
+          ]
+        },
+        "rtps_bytes_sent": {
+          "0": [
+            {
+              "src_time": "0",
+              "magnitude": 0,
+              "count": 2
+            }
+          ]
+        },
+        "rtps_packets_lost": {
+          "0": [
+            {
+              "src_time": "0",
+              "count": 2
+            }
+          ]
+        },
+        "rtps_bytes_lost": {
+          "0": [
+            {
+              "src_time": "0",
+              "magnitude": 0,
+              "count": 2
+            }
+          ]
+        },
+        "network_latency_per_locator": {
+          "0": [
+            {
+              "src_time": "0",
+              "data": 1.1
+            }
+          ]
+        },
+        "last_reported_edp_packets": {
+          "count": 2,
+          "src_time": "0"
+        },
+        "last_reported_pdp_packets": {
+          "count": 2,
+          "src_time": "0"
+        },
+        "last_reported_rtps_bytes_lost": {
+          "0": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "0"
+          }
+        },
+        "last_reported_rtps_bytes_sent": {
+          "0": {
+            "count": 2,
+            "magnitude": 0,
+            "src_time": "0"
+          }
+        },
+        "last_reported_rtps_packets_lost": {
+          "0": {
+            "count": 2,
+            "src_time": "0"
+          }
+        },
+        "last_reported_rtps_packets_sent": {
+          "0": {
+            "count": 2,
+            "src_time": "0"
+          }
+        }
+      }
+    }
+  },
+  "datawriters": {
+    "7": {
+      "name": "datawriter_0",
+      "alias": "datawriter_0",
+      "metatraffic": false,
+      "alive": true,
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "qos": {
+        "qos": "empty"
+      },
+      "participant": "6",
+      "topic": "5",
+      "locators": [
+        "0"
+      ],
+      "virtual_metatraffic": false,
+      "data": {
+        "publication_throughput": [
+          {
+            "src_time": "0",
+            "data": 1.1
+          }
+        ],
+        "resent_datas": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "heartbeat_count": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "gap_count": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "data_count": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "samples_datas": {
+          "3": [
+            {
+              "src_time": "0",
+              "count": 2
+            }
+          ]
+        },
+        "history2history_latency": {
+          "8": [
+            {
+              "src_time": "0",
+              "data": 1.1
+            }
+          ]
+        },
+        "last_reported_data_count": {
+          "count": 2,
+          "src_time": "0"
+        },
+        "last_reported_gap_count": {
+          "count": 2,
+          "src_time": "0"
+        },
+        "last_reported_heartbeat_count": {
+          "count": 2,
+          "src_time": "0"
+        },
+        "last_reported_resent_datas": {
+          "count": 2,
+          "src_time": "0"
+        }
+      }
+    }
+  },
+  "datareaders": {
+    "8": {
+      "name": "datareader_0",
+      "alias": "datareader_0",
+      "metatraffic": false,
+      "alive": true,
+      "guid": "01.0f.00.00.00.00.00.00.00.00.00.00|0.0.0.0",
+      "qos": {
+        "qos": "empty"
+      },
+      "participant": "6",
+      "topic": "5",
+      "locators": [
+        "0"
+      ],
+      "virtual_metatraffic": false,
+      "data": {
+        "subscription_throughput": [
+          {
+            "src_time": "0",
+            "data": 1.1
+          }
+        ],
+        "acknack_count": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "nackfrag_count": [
+          {
+            "src_time": "0",
+            "count": 2
+          }
+        ],
+        "last_reported_acknack_count": {
+          "count": 2,
+          "src_time": "0"
+        },
+        "last_reported_nackfrag_count": {
+          "count": 2,
+          "src_time": "0"
+        }
+      }
+    }
+  },
+  "locators": {
+    "0": {
+      "name": "locator_0",
+      "alias": "locator_0",
+      "metatraffic": false,
+      "alive": true,
+      "datawriters": [
+        "7"
+      ],
+      "datareaders": [
+        "8"
+      ]
+    }
+  }
 }

--- a/test/unittest/StatisticsBackend/IsActiveTests.cpp
+++ b/test/unittest/StatisticsBackend/IsActiveTests.cpp
@@ -46,6 +46,7 @@ public:
         domain = db->domains().begin()->second;
         topic = db->topics().begin()->second.begin()->second;
         participant = db->participants().begin()->second.begin()->second;
+        // Jump the metatraffic datawriter.
         datawriter = db->get_dds_endpoints<DataWriter>().begin()->second.begin()->second;
         datareader = db->get_dds_endpoints<DataReader>().begin()->second.begin()->second;
         locator = db->locators().begin()->second;

--- a/test/unittest/StatisticsParticipantListener/StatisticsParticipantListenerTests.cpp
+++ b/test/unittest/StatisticsParticipantListener/StatisticsParticipantListenerTests.cpp
@@ -555,6 +555,10 @@ TEST_F(statistics_participant_listener_tests, new_participant_undiscovered)
     EXPECT_CALL(database, get_entity_by_guid(EntityKind::PARTICIPANT, participant_guid_str_)).Times(AnyNumber())
             .WillRepeatedly(Throw(eprosima::statistics_backend::BadParameter("Error")));
 
+    // Metatraffic endpoint
+    EXPECT_CALL(database, get_entity_by_guid(EntityKind::DATAWRITER, participant_guid_str_)).Times(AnyNumber())
+            .WillRepeatedly(Throw(eprosima::statistics_backend::BadParameter("Error")));
+
     // Start building the discovered reader info
     eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes allocation;
     eprosima::fastrtps::rtps::ParticipantProxyData data(allocation);
@@ -1712,6 +1716,10 @@ TEST_F(statistics_participant_listener_tests, new_participant_undiscovered_parti
             .WillRepeatedly(Return(std::make_pair(EntityId(0), EntityId(1))));
     EXPECT_CALL(database, get_entity(EntityId(1))).Times(AnyNumber())
             .WillRepeatedly(Return(participant_));
+
+    // Metatraffic endpoint
+    EXPECT_CALL(database, get_entity_by_guid(EntityKind::DATAWRITER, participant_guid_str_)).Times(AnyNumber())
+            .WillRepeatedly(Throw(eprosima::statistics_backend::BadParameter("Error")));
 
     // Start building the discovered reader info
     eprosima::fastrtps::rtps::RTPSParticipantAllocationAttributes allocation;

--- a/test/unittest/TestUtils/DatabaseUtils.hpp
+++ b/test/unittest/TestUtils/DatabaseUtils.hpp
@@ -224,7 +224,7 @@ public:
 
         auto datareader1 = std::make_shared<DataReader>("datareader1", "qos", "11.12.13.14", participant2, topic2);
         auto reader_locator1 = std::make_shared<Locator>("reader_locator1");
-        reader_locator1->id = db.generate_entity_id();
+        reader_locator1->id = db.insert(reader_locator1);
         datareader1->locators[reader_locator1->id] = reader_locator1;
         db.insert(datareader1);
         entities[13] = datareader1;
@@ -232,7 +232,7 @@ public:
 
         auto datareader2 = std::make_shared<DataReader>("datareader2", "qos", "15.16.17.18", participant2, topic2);
         auto reader_locator2 = std::make_shared<Locator>("reader_locator2");
-        reader_locator2->id = db.generate_entity_id();
+        reader_locator2->id = db.insert(reader_locator2);
         datareader2->locators[reader_locator1->id] = reader_locator1;
         datareader2->locators[reader_locator2->id] = reader_locator2;
         db.insert(datareader2);
@@ -241,7 +241,7 @@ public:
 
         auto datawriter1 = std::make_shared<DataWriter>("datawriter1", "qos", "21.22.23.24", participant2, topic2);
         auto writer_locator1 = std::make_shared<Locator>("writer_locator1");
-        writer_locator1->id = db.generate_entity_id();
+        writer_locator1->id = db.insert(writer_locator1);
         datawriter1->locators[writer_locator1->id] = writer_locator1;
         db.insert(datawriter1);
         entities[17] = datawriter1;
@@ -249,7 +249,7 @@ public:
 
         auto datawriter2 = std::make_shared<DataWriter>("datawriter2", "qos", "25.26.27.28", participant2, topic2);
         auto writer_locator2 = std::make_shared<Locator>("writer_locator2");
-        writer_locator2->id = db.generate_entity_id();
+        writer_locator2->id = db.insert(writer_locator2);
         datawriter2->locators[writer_locator1->id] = writer_locator1;
         datawriter2->locators[writer_locator2->id] = writer_locator2;
         db.insert(datawriter2);


### PR DESCRIPTION
refactor the queue and the domain listener, so that the listener just passes the info to the queue and the latter is responsible of creating / removing the entities, and checking the preconditions for the entity creation.

This ensures that the precondition checks for an entity are always done after all the previous creations have been processed

Review is best done commit to commit. There are descriptions on the comments of each commit that I hope will help.