### PR TITLE
Use UDP transport by default

### DIFF
--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -234,7 +234,7 @@ EntityId StatisticsBackend::init_monitor(
     // Previous string conversion is needed for string_255
     std::string participant_name = "monitor_domain_" + std::to_string(domain_id);
     participant_qos.name(participant_name);
-    /* Workaround to avoid using SHM transport by default */
+    /* Avoid using SHM transport by default */
     auto udp_transport = std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
     participant_qos.transport().user_transports.push_back(udp_transport);
     participant_qos.transport().use_builtin_transports = false;

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -231,7 +231,7 @@ EntityId StatisticsBackend::init_monitor(
 
     /* Create DomainParticipant */
     DomainParticipantQos participant_qos = DomainParticipantFactory::get_instance()->get_default_participant_qos();
-    // Previous string conversion is needed for string_255
+    /* Previous string conversion is needed for string_255 */
     std::string participant_name = "monitor_domain_" + std::to_string(domain_id);
     participant_qos.name(participant_name);
     /* Avoid using SHM transport by default */

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -31,6 +31,7 @@
 #include <fastdds/dds/topic/qos/TopicQos.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/topic/TopicDescription.hpp>
+#include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 #include <fastdds/statistics/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/statistics/topic_names.hpp>
 
@@ -233,6 +234,10 @@ EntityId StatisticsBackend::init_monitor(
     // Previous string conversion is needed for string_255
     std::string participant_name = "monitor_domain_" + std::to_string(domain_id);
     participant_qos.name(participant_name);
+    /* Workaround to avoid using SHM transport by default */
+    auto udp_transport = std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
+    participant_qos.transport().user_transports.push_back(udp_transport);
+    participant_qos.transport().use_builtin_transports = false;
 
     StatusMask participant_mask = StatusMask::all();
     participant_mask ^= StatusMask::data_on_readers();

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -235,7 +235,8 @@ EntityId StatisticsBackend::init_monitor(
     std::string participant_name = "monitor_domain_" + std::to_string(domain_id);
     participant_qos.name(participant_name);
     /* Avoid using SHM transport by default */
-    auto udp_transport = std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
+    std::shared_ptr<eprosima::fastdds::rtps::UDPv4TransportDescriptor> udp_transport =
+            std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
     participant_qos.transport().user_transports.push_back(udp_transport);
     participant_qos.transport().use_builtin_transports = false;
 

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -313,6 +313,8 @@ set(INIT_MONITOR_TEST_LIST
     init_monitor_several_monitors
     init_monitor_twice
     stop_monitor
+    init_monitor_check_participant_name
+    init_monitor_check_participant_transport
     )
 
 foreach(test_name ${INIT_MONITOR_TEST_LIST})
@@ -482,7 +484,7 @@ endforeach()
 
 if(GTEST_FOUND AND GMOCK_FOUND)
     find_package(Threads REQUIRED)
-        
+
     add_executable(is_active_tests IsActiveTests.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/database/data.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/database/database_queue.cpp

--- a/test/unittest/StatisticsBackend/InitMonitorTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorTests.cpp
@@ -549,7 +549,7 @@ TEST_F(init_monitor_tests, init_monitor_check_participant_transport)
     EXPECT_EQ(participant_qos.transport().user_transports.size(), 1);
     std::shared_ptr<eprosima::fastdds::rtps::UDPv4TransportDescriptor> participant_transport =
             std::dynamic_pointer_cast<eprosima::fastdds::rtps::UDPv4TransportDescriptor>(
-                    participant_qos.transport().user_transports.back());
+        participant_qos.transport().user_transports.back());
     EXPECT_TRUE(nullptr != participant_transport);
 
     /* Stop the monitor to avoid interfering on the next test */


### PR DESCRIPTION
The monitor stops receiving statistics data after a period of time when the SHM transport is used. This is a workaround for using the UDP transport by default in the statistics backend participant.