### PR TITLE
Create locators on data [11959]

### DIFF
--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -129,11 +129,21 @@ void DatabaseDataQueue::process_sample_type(
     sample.count = item.packet_count();
     std::string remote_locator = deserialize_locator(item.dst_locator());
     auto found_remote_locators = database_->get_entities_by_name(EntityKind::LOCATOR, remote_locator);
+    // In case that the reported locator is not known, create it without being linked to an endpoint
     if (found_remote_locators.empty())
     {
-        throw Error("Locator " + remote_locator + " not found");
+        std::shared_ptr<Locator> locator = std::make_shared<Locator>(remote_locator);
+        locator->id = database_->insert(locator);
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                locator->id,
+                EntityKind::LOCATOR,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        sample.remote_locator = locator->id;
     }
-    sample.remote_locator = found_remote_locators.front().second;
+    else
+    {
+        sample.remote_locator = found_remote_locators.front().second;
+    }
 
     std::string guid = deserialize_guid(item.src_guid());
     try
@@ -160,11 +170,21 @@ void DatabaseDataQueue::process_sample_type(
     sample.magnitude_order = item.byte_magnitude_order();
     std::string remote_locator = deserialize_locator(item.dst_locator());
     auto found_remote_locators = database_->get_entities_by_name(EntityKind::LOCATOR, remote_locator);
+    // In case that the reported locator is not known, create it without being linked to an endpoint
     if (found_remote_locators.empty())
     {
-        throw Error("Locator " + remote_locator + " not found");
+        std::shared_ptr<Locator> locator = std::make_shared<Locator>(remote_locator);
+        locator->id = database_->insert(locator);
+        details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
+                locator->id,
+                EntityKind::LOCATOR,
+                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+        sample.remote_locator = locator->id;
     }
-    sample.remote_locator = found_remote_locators.front().second;
+    else
+    {
+        sample.remote_locator = found_remote_locators.front().second;
+    }
 
     std::string guid = deserialize_guid(item.src_guid());
     try

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -135,9 +135,9 @@ void DatabaseDataQueue::process_sample_type(
         std::shared_ptr<Locator> locator = std::make_shared<Locator>(remote_locator);
         locator->id = database_->insert(locator);
         details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                locator->id,
-                EntityKind::LOCATOR,
-                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+            locator->id,
+            EntityKind::LOCATOR,
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
         sample.remote_locator = locator->id;
     }
     else
@@ -176,9 +176,9 @@ void DatabaseDataQueue::process_sample_type(
         std::shared_ptr<Locator> locator = std::make_shared<Locator>(remote_locator);
         locator->id = database_->insert(locator);
         details::StatisticsBackendData::get_instance()->on_physical_entity_discovery(
-                locator->id,
-                EntityKind::LOCATOR,
-                details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
+            locator->id,
+            EntityKind::LOCATOR,
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
         sample.remote_locator = locator->id;
     }
     else

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -527,6 +527,9 @@ protected:
         return std::make_pair(writer_guid, sequence_number);
     }
 
+    EntityId get_or_create_locator(
+        const std::string& locator_name) const;
+
     // Database
     Database* database_;
 

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -528,7 +528,7 @@ protected:
     }
 
     EntityId get_or_create_locator(
-        const std::string& locator_name) const;
+            const std::string& locator_name) const;
 
     // Database
     Database* database_;

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -2134,7 +2134,8 @@ TEST_F(database_queue_tests, push_rtps_sent_no_locator)
 
     // Add to the queue and wait to be processed
     data_queue.push(timestamp, data);
-    data_queue.flush();}
+    data_queue.flush();
+}
 
 TEST_F(database_queue_tests, push_rtps_lost)
 {


### PR DESCRIPTION
When the statistics data refers to a locator that is unknown, instead of rejecting the data sample, create the locator because it may not have been found during discovery.

This is already done for the locator2locator data (network latency) on #113. Now we are extending this for entity2locator data (RTPS sent and RTPS lost)
