### PR TITLE
Added new metatraffic attribute for entities [12534]

### DIFF
--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -228,6 +228,19 @@ public:
     static bool is_active(
             EntityId entity_id);
 
+        /**
+     * @brief Returns whether the entity is related to a metatraffic topic.
+     *
+     * For Topics, it is true when they are used for sharing metatraffic data.
+     * For DDSEndpoints, it is true when their associated to a metatraffic Topic.
+     * For the rest of entities, metatraffic is always false.
+     *
+     * @param entity_id The ID of the entity whose metatraffic attribute is requested.
+     * @return true if metatraffic, false otherwise.
+     */
+    static bool is_metatraffic(
+            EntityId entity_id);
+
     /**
      * @brief Returns the entity kind of a given id.
      *

--- a/include/fastdds_statistics_backend/types/JSONTags.h
+++ b/include/fastdds_statistics_backend/types/JSONTags.h
@@ -95,6 +95,8 @@ constexpr const char* NAME_INFO_TAG                 = "name";
 constexpr const char* ALIAS_INFO_TAG                 = "alias";
 //! Key tag for alive status of an entity
 constexpr const char* ALIVE_INFO_TAG                  = "alive";
+//! Key tag for metatraffic attribute of an entity
+constexpr const char* METATRAFFIC_INFO_TAG          = "metatraffic";
 //! Key tag for process id of a process entity
 constexpr const char* PID_INFO_TAG                  = "pid";
 //! Key tag for type name of a topic entity
@@ -103,8 +105,8 @@ constexpr const char* DATA_TYPE_INFO_TAG            = "data_type";
 constexpr const char* GUID_INFO_TAG                 = "guid";
 //! Key tag for QoS of a participant, datawriter or datareader entity
 constexpr const char* QOS_INFO_TAG                  = "qos";
-//! Key tag for meta traffic flag of an endpoint
-constexpr const char* METATRAFFIC_TAG                = "metatraffic";
+//! Key tag for meta traffic flag of a virtual endpoint
+constexpr const char* VIRTUAL_METATRAFFIC_TAG       = "virtual_metatraffic";
 //! Conversion from EntityKind to string
 constexpr const char* entity_kind_str[] =
 {"invalid", HOST_ENTITY_TAG, USER_ENTITY_TAG, PROCESS_ENTITY_TAG, DOMAIN_ENTITY_TAG, TOPIC_ENTITY_TAG,

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -449,6 +449,12 @@ bool StatisticsBackend::is_active(
     return details::StatisticsBackendData::get_instance()->database_->get_entity(entity_id)->active;
 }
 
+bool StatisticsBackend::is_metatraffic(
+        EntityId entity_id)
+{
+    return details::StatisticsBackendData::get_instance()->database_->get_entity(entity_id)->metatraffic;
+}
+
 EntityKind StatisticsBackend::get_type(
         EntityId entity_id)
 {
@@ -468,6 +474,7 @@ Info StatisticsBackend::get_info(
     info[NAME_INFO_TAG] = entity->name;
     info[ALIAS_INFO_TAG] = entity->alias;
     info[ALIVE_INFO_TAG] = entity->active;
+    info[METATRAFFIC_INFO_TAG] = entity->metatraffic;
 
     switch (entity->kind)
     {

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -2939,7 +2939,7 @@ DatabaseDump Database::dump_entity_(
 
     entity_info[PARTICIPANT_ENTITY_TAG] = id_to_string(entity->participant->id);
     entity_info[TOPIC_ENTITY_TAG] = id_to_string(entity->topic->id);
-    entity_info[METATRAFFIC_TAG] = entity->is_metatraffic;
+    entity_info[VIRTUAL_METATRAFFIC_TAG] = entity->is_virtual_metatraffic;
 
     // Populate subentity array for Locators
     {
@@ -3005,7 +3005,7 @@ DatabaseDump Database::dump_entity_(
 
     entity_info[PARTICIPANT_ENTITY_TAG] = id_to_string(entity->participant->id);
     entity_info[TOPIC_ENTITY_TAG] = id_to_string(entity->topic->id);
-    entity_info[METATRAFFIC_TAG] = entity->is_metatraffic;
+    entity_info[VIRTUAL_METATRAFFIC_TAG] = entity->is_virtual_metatraffic;
 
     // Populate subentity array for Locators
     {
@@ -3605,7 +3605,7 @@ void Database::load_database(
                 participants_[participant_domain_id][participant_id],
                 topics_[topic_domain_id][topic_id]);
             entity->alias = (*it).at(ALIAS_INFO_TAG);
-            entity->is_metatraffic = (*it).at(METATRAFFIC_TAG).get<bool>();
+            entity->is_virtual_metatraffic = (*it).at(VIRTUAL_METATRAFFIC_TAG).get<bool>();
 
             /* Add reference to locator to the endpoint */
             for (auto it_loc = (*it).at(LOCATOR_CONTAINER_TAG).begin();
@@ -3659,7 +3659,7 @@ void Database::load_database(
                 participants_[participant_domain_id][participant_id],
                 topics_[topic_domain_id][topic_id]);
             entity->alias = (*it).at(ALIAS_INFO_TAG);
-            entity->is_metatraffic = (*it).at(METATRAFFIC_TAG).get<bool>();
+            entity->is_virtual_metatraffic = (*it).at(VIRTUAL_METATRAFFIC_TAG).get<bool>();
 
             /* Add reference to locator to the endpoint */
             for (auto it_loc = (*it).at(LOCATOR_CONTAINER_TAG).begin();

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -521,7 +521,7 @@ protected:
 
         /* Add endpoint to participant' collection */
         (*(endpoint->participant)).template ddsendpoints<T>()[endpoint->id] = endpoint;
-        if (endpoint->is_metatraffic)
+        if (endpoint->is_virtual_metatraffic)
         {
             assert(nullptr == endpoint->participant->meta_traffic_endpoint);
             endpoint->participant->meta_traffic_endpoint = endpoint;

--- a/src/cpp/database/entities.cpp
+++ b/src/cpp/database/entities.cpp
@@ -19,6 +19,55 @@ namespace eprosima {
 namespace statistics_backend {
 namespace database {
 
+bool is_metatraffic_topic(
+        std::string topic_name)
+{
+    bool is_metatraffic = false;
+    std::set<std::string> metatraffic_topics = {
+            "___EPROSIMA___METATRAFFIC___DOMAIN_0___TOPIC",
+            "ros_discovery_info",
+            "rosout",
+            "parameter_events",
+            "get_parameters",
+            "set_parameters",
+            "get_parameter_types",
+            "set_parameters_atomically",
+            "describe_parameters",
+            "list_parameters",
+            "_fastdds_statistics_"};
+
+    std::set<std::string>::iterator it = metatraffic_topics.begin();
+    size_t found;
+    while (it != metatraffic_topics.end())
+    {
+        found = topic_name.rfind(*it);
+        if (found != std::string::npos)
+        {
+            is_metatraffic = true;
+            break;
+        }
+        it++;
+    }
+    return is_metatraffic;
+}
+
+DDSEndpoint::DDSEndpoint(
+        EntityKind entity_kind, /* EntityKind::INVALID */
+        std::string endpoint_name, /* "INVALID" */
+        Qos endpoint_qos, /* {} */
+        std::string endpoint_guid, /* "|GUID UNKNOWN|" */
+        std::shared_ptr<DomainParticipant> endpoint_participant, /* nullptr */
+        std::shared_ptr<Topic> endpoint_topic /* nullptr */) noexcept
+        : DDSEntity(entity_kind, endpoint_name, endpoint_qos, endpoint_guid)
+        , participant(endpoint_participant)
+        , topic(endpoint_topic)
+{
+    if (topic != nullptr)
+    {
+        metatraffic = topic->metatraffic;
+    }
+}
+
 void Host::clear()
 {
     users.clear();

--- a/src/cpp/subscriber/StatisticsParticipantListener.cpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.cpp
@@ -452,7 +452,7 @@ void StatisticsParticipantListener::on_participant_discovery(
                     datawriter->alias = metatraffic_alias;
 
                     // Mark it as the meta traffic one
-                    datawriter->is_metatraffic = true;
+                    datawriter->is_virtual_metatraffic = true;
 
                     // Routine to process one locator from the locator list of the particpant
                     auto process_locators = [&](const Locator_t& dds_locator)


### PR DESCRIPTION
A new metatraffic attribute is included in Entities, which is true when related to topics used for sharing metatraffic data. This is useful for filtering by its value, being then able to hide/display entities used for metatraffic purposes in FastDDS-Monitor.