### PR TITLE
Check if a locator already exist by name before add it to database [12711]

### DIFF
--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -38,7 +38,7 @@ namespace database {
 EntityId Database::insert(
         const std::shared_ptr<Entity>& entity)
 {
-    std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+    std::unique_lock<std::recursive_timed_mutex> lock(mutex_);
 
     // Insert in the database with a unique ID
     EntityId entity_id = EntityId::invalid();
@@ -479,7 +479,7 @@ void Database::insert(
         const EntityId& entity_id,
         const StatisticsSample& sample)
 {
-    std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+    std::unique_lock<std::recursive_timed_mutex> lock(mutex_);
 
     insert_nts(domain_id, entity_id, sample);
 }
@@ -1189,7 +1189,7 @@ void Database::link_participant_with_process(
         const EntityId& participant_id,
         const EntityId& process_id)
 {
-    std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+    std::unique_lock<std::recursive_timed_mutex> lock(mutex_);
 
     link_participant_with_process_nts(participant_id, process_id);
 }
@@ -1261,7 +1261,7 @@ void Database::link_participant_with_process_nts(
 const std::shared_ptr<const Entity> Database::get_entity(
         const EntityId& entity_id) const
 {
-    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+    std::unique_lock<std::recursive_timed_mutex> lock(mutex_);
     /* Iterate over all the collections looking for the entity */
     for (const auto& host_it : hosts_)
     {
@@ -1480,7 +1480,7 @@ void Database::erase(
     }
 
     // The mutex should be taken only once. get_entity_kind already locks.
-    std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+    std::unique_lock<std::recursive_timed_mutex> lock(mutex_);
 
     for (auto& reader : datareaders_[domain_id])
     {
@@ -1572,7 +1572,7 @@ std::vector<const StatisticsSample*> Database::select(
     auto source_entity = get_entity(entity_id_source);
     auto target_entity = get_entity(entity_id_target);
 
-    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+    std::unique_lock<std::recursive_timed_mutex> lock(mutex_);
     std::vector<const StatisticsSample*> samples;
     switch (data_type)
     {
@@ -1770,7 +1770,7 @@ std::vector<const StatisticsSample*> Database::select(
 
     auto entity = get_entity(entity_id);
 
-    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+    std::unique_lock<std::recursive_timed_mutex> lock(mutex_);
     std::vector<const StatisticsSample*> samples;
     switch (data_type)
     {
@@ -2583,7 +2583,7 @@ void Database::insert_ddsendpoint_to_locator(
 DatabaseDump Database::dump_database(
         bool clear)
 {
-    std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+    std::unique_lock<std::recursive_timed_mutex> lock(mutex_);
 
     DatabaseDump dump = DatabaseDump::object();
 
@@ -3439,7 +3439,7 @@ void check_entity_contains_all_references(
 void Database::load_database(
         const DatabaseDump& dump)
 {
-    std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+    std::unique_lock<std::recursive_timed_mutex> lock(mutex_);
 
     if (next_id_ != 0)
     {
@@ -4863,7 +4863,7 @@ void Database::change_entity_status(
         entity_kind == EntityKind::PARTICIPANT || entity_kind == EntityKind::DATAWRITER ||
         entity_kind == EntityKind::DATAREADER || entity_kind == EntityKind::DOMAIN);
 
-    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+    std::unique_lock<std::recursive_timed_mutex> lock(mutex_);
     change_entity_status_of_kind(entity_id, active, entity_kind);
 }
 

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -547,8 +547,8 @@ protected:
 
                 // As the locator already exists, take it and use it for this endpoint
                 std::shared_ptr<database::Locator> locator = std::const_pointer_cast<database::Locator>(
-                        std::static_pointer_cast<const database::Locator>(
-                            get_entity(locators_with_same_name.front().second)));
+                    std::static_pointer_cast<const database::Locator>(
+                        get_entity(locators_with_same_name.front().second)));
                 actual_locators_map[locator->id] = locator;
             }
             else

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -548,7 +548,7 @@ protected:
                 // As the locator already exists, take it and use it for this endpoint
                 std::shared_ptr<database::Locator> locator = std::const_pointer_cast<database::Locator>(
                     std::static_pointer_cast<const database::Locator>(
-                        get_entity(locators_with_same_name.front().second)));
+                        get_entity_nts(locators_with_same_name.front().second)));
                 actual_locators_map[locator->id] = locator;
             }
             else
@@ -729,6 +729,16 @@ protected:
             const bool last_reported = false);
 
     /**
+     * Get an entity given its EntityId. This method is not thread safe.
+     *
+     * @param entity_id constant reference to the EntityId of the retrieved entity.
+     * @throws eprosima::statistics_backend::BadParameter if there is no entity with the given ID.
+     * @return A constant shared pointer to the Entity.
+     */
+    const std::shared_ptr<const Entity> get_entity_nts(
+            const EntityId& entity_id) const;
+
+    /**
      * @brief Create the link between a participant and a process. This method is not thread safe.
      *
      * This operation entails:
@@ -846,7 +856,7 @@ protected:
     std::atomic<int64_t> next_id_{0};
 
     //! Read-write synchronization mutex
-    mutable std::recursive_timed_mutex mutex_;
+    mutable std::shared_timed_mutex mutex_;
 };
 
 template<>

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -553,8 +553,22 @@ protected:
             }
             else
             {
-                // It is actually a new locator, so it is added to the new map
-                actual_locators_map[locator_it.first] = locator_it.second;
+                // Check whether this locator is repeated inside this same endpoint
+                bool repeated = false;
+                for (auto new_locators : actual_locators_map)
+                {
+                    if (new_locators.second->name == locator_it.second->name)
+                    {
+                        repeated = true;
+                        break;
+                    }
+                }
+
+                if (!repeated)
+                {
+                    // It is actually a new locator, so it is added to the new map
+                    actual_locators_map[locator_it.first] = locator_it.second;
+                }
             }
         }
 

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -232,6 +232,7 @@ set(DATABASE_TEST_LIST
     insert_ddsendpoint_empty_locators
     insert_ddsendpoint_two_same_domain_same_guid
     insert_ddsendpoint_two_diff_domain_same_guid
+    insert_ddsendpoint_two_equal_locators
     # Insert invalid
     insert_invalid
     insert_locator

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -523,8 +523,8 @@ void insert_ddsendpoint_two_equal_locators()
     auto locators = db.locators();
     auto locators_by_participant = db.locators_by_participant();
     auto participants_by_locator = db.participants_by_locator();
-    ASSERT_EQ(locators_by_participant[participant_id].size(), endpoint->locators.size());
-    ASSERT_EQ(participants_by_locator[locator1->id].size(), endpoint->locators.size());
+    ASSERT_EQ(locators_by_participant[participant_id].size(), 1); // Check there is only one, as it is repeaated
+    ASSERT_EQ(participants_by_locator[locator1->id].size(), 1);
     for (auto locator_it : endpoint->locators)
     {
         // Check that the endpoint's locators are correctly inserted in locators_
@@ -549,6 +549,9 @@ void insert_ddsendpoint_two_equal_locators()
     ASSERT_EQ(endpoint_name, endpoints[domain_id][endpoint_id]->name);
     ASSERT_EQ(db.test_qos, endpoints[domain_id][endpoint_id]->qos);
     ASSERT_EQ(endpoint_guid, endpoints[domain_id][endpoint_id]->guid);
+
+    // Getting locator by name should only give one
+    ASSERT_EQ(db.get_entities_by_name(EntityKind::LOCATOR, "test_locator").size(), 1);
 }
 
 class database_tests : public ::testing::Test

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -476,6 +476,81 @@ void insert_ddsendpoint_two_diff_domain_same_guid()
     ASSERT_THROW(db.insert(endpoint_2), BadParameter);
 }
 
+template<typename T>
+void insert_ddsendpoint_two_equal_locators()
+{
+    /* Insert a host, user, process, domain, topic, and participant */
+    DataBaseTest db;
+    auto host = std::make_shared<Host>("test_host");
+    db.insert(host);
+    auto user = std::make_shared<User>("test_user", host);
+    db.insert(user);
+    auto process = std::make_shared<Process>("test_process", "test_pid", user);
+    db.insert(process);
+    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain_id = db.insert(domain);
+    auto participant = std::make_shared<DomainParticipant>(
+        "test_participant", db.test_qos, "01.02.03.04", process, domain);
+    auto participant_id = db.insert(participant);
+    auto topic = std::make_shared<Topic>("test_topic_name", "test_topic_type", domain);
+    db.insert(topic);
+
+    /* Insert a DDSEndpoint */
+    std::string endpoint_name = "test_endpoint";
+    std::string endpoint_guid = "test_guid";
+    auto endpoint = std::make_shared<T>(
+        endpoint_name, db.test_qos, endpoint_guid, participant, topic);
+
+    // Create two equal locator for the endpoint
+    auto locator1 = std::make_shared<Locator>("test_locator");
+    locator1->id = db.generate_entity_id();
+    auto locator2 = std::make_shared<Locator>("test_locator");
+    locator2->id = db.generate_entity_id();
+
+    endpoint->locators[locator1->id] = locator1;
+    endpoint->locators[locator2->id] = locator2;
+    auto endpoint_id = db.insert(endpoint);
+
+    /* Check that the endpoint is correctly inserted in participant */
+    ASSERT_EQ(participant->ddsendpoints<T>().size(), 1);
+    ASSERT_EQ(participant->ddsendpoints<T>()[endpoint_id].get(), endpoint.get());
+
+    /* Check that the endpoint is correctly inserted in topic */
+    ASSERT_EQ(topic->ddsendpoints<T>().size(), 1);
+    ASSERT_EQ(topic->ddsendpoints<T>()[endpoint_id].get(), endpoint.get());
+
+    /* Check x_by_y_ collections and locators_ */
+    auto locators = db.locators();
+    auto locators_by_participant = db.locators_by_participant();
+    auto participants_by_locator = db.participants_by_locator();
+    ASSERT_EQ(locators_by_participant[participant_id].size(), endpoint->locators.size());
+    ASSERT_EQ(participants_by_locator[locator1->id].size(), endpoint->locators.size());
+    for (auto locator_it : endpoint->locators)
+    {
+        // Check that the endpoint's locators are correctly inserted in locators_
+        ASSERT_NE(
+            locators.find(locator_it.first),
+            locators.end());
+        // Check that the endpoint's locators are correctly inserted in locators_by_participant_
+        ASSERT_NE(
+            locators_by_participant[participant_id].find(locator_it.first),
+            locators_by_participant[participant_id].end());
+        // Check that the endpoint's participant is correctly inserted in participants_by_locator_
+        ASSERT_NE(
+            participants_by_locator[locator_it.first].find(participant_id),
+            participants_by_locator[locator_it.first].end());
+    }
+
+    /* Check that the ddsendpoint is inserted correctly inserted in the endpoints_<T> collection */
+    auto endpoints = db.get_dds_endpoints<T>();
+    ASSERT_EQ(endpoints.size(), 1);
+    ASSERT_EQ(endpoints[domain_id].size(), 1);
+    ASSERT_NE(endpoints[domain_id].find(endpoint_id), endpoints[domain_id].end());
+    ASSERT_EQ(endpoint_name, endpoints[domain_id][endpoint_id]->name);
+    ASSERT_EQ(db.test_qos, endpoints[domain_id][endpoint_id]->qos);
+    ASSERT_EQ(endpoint_guid, endpoints[domain_id][endpoint_id]->guid);
+}
+
 class database_tests : public ::testing::Test
 {
 public:
@@ -1545,6 +1620,15 @@ TEST_F(database_tests, insert_ddsendpoint_two_diff_domain_same_guid)
 {
     insert_ddsendpoint_two_diff_domain_same_guid<DataReader>();
     insert_ddsendpoint_two_diff_domain_same_guid<DataWriter>();
+}
+
+/*
+ * Check that creating an Endpoint with repeated locators does not break
+ */
+TEST_F(database_tests, insert_ddsendpoint_two_equal_locators)
+{
+    insert_ddsendpoint_two_equal_locators<DataReader>();
+    insert_ddsendpoint_two_equal_locators<DataWriter>();
 }
 
 TEST_F(database_tests, insert_locator)


### PR DESCRIPTION
Monitor fails with assert: `StatisticsParticipantListener.cpp:146 : Assertion locator_ids.empty() || locator_ids.size() == 1' failed.` when it monitors ROS 2 galactic cycloneDDS nodes.

It occurs because the Locatos are created within the Endpoint, and it is possible that they repeat an already existed name in the database.

Signed-off-by: jparisu <javierparis@eprosima.com>