### PR TITLE
Avoid fast-failing and false positives on Windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
   windows-build-test:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         cmake-config:
           - 'Release'
@@ -27,7 +28,6 @@ jobs:
           path: Fast-DDS-statistics-backend
 
       - name: install OpenSSL
-        continue-on-error: true
         shell: pwsh
         run: >
           choco install openssl -yr --no-progress;
@@ -35,7 +35,6 @@ jobs:
           | rm -ErrorAction SilentlyContinue
 
       - name: install GoogleTest
-        continue-on-error: true
         shell: pwsh
         run: >
           cmake --find-package -DNAME=GTest -DCOMPILER_ID=GNU -DLANGUAGE=CXX -DMODE=EXIST | Tee-Object -Variable res;
@@ -48,7 +47,6 @@ jobs:
           }
 
       - name: install foonatham memory
-        continue-on-error: true
         shell: pwsh
         run: >
           git clone --recurse-submodules --branch v0.6-2 https://github.com/foonathan/memory.git;
@@ -57,7 +55,6 @@ jobs:
           cmake --build build\memory --config ${{ matrix.cmake-config }} --target install;
 
       - name: install Fast-CDR
-        continue-on-error: true
         shell: pwsh
         run: >
           git clone https://github.com/eProsima/Fast-CDR.git;
@@ -65,7 +62,6 @@ jobs:
           cmake --build build\fastcdr --config ${{ matrix.cmake-config }} --target install;
 
       - name: install Fast-DDS
-        continue-on-error: true
         shell: pwsh
         run: >
           git clone https://github.com/eProsima/Fast-DDS.git;
@@ -74,7 +70,6 @@ jobs:
           cmake --build build\fastdds --config ${{ matrix.cmake-config }} --target install;
 
       - name: install Fast-DDS-statistics-backend
-        continue-on-error: true
         shell: pwsh
         run: >
           cmake -DCMAKE_PREFIX_PATH='C:\Program Files\gtest' -DBUILD_LIBRARY_TESTS=ON `
@@ -82,7 +77,6 @@ jobs:
           cmake --build build\backend --config ${{ matrix.cmake-config }} --target install;
 
       - name: Run tests on ${{ matrix.cmake-config }}
-        continue-on-error: true
         shell: pwsh
         run: ctest -C ${{ matrix.cmake-config }} --test-dir build\backend -V --timeout 60
 


### PR DESCRIPTION
#144 Introduces false possitives on Windows CI. This PR avoids fast-failing of the Windows job while at the same time allowing individual spawned jobs from the matrix to fail.

Signed-off-by: Eduardo Ponz <eduardoponz@eprosima.com>