### PR TITLE
[14427] Adds XML profile loading before default qos check

### DIFF
--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -392,6 +392,8 @@ EntityId StatisticsBackend::init_monitor(
 #endif // ifdef _WIN32
 
     /* Set DomainParticipantQoS */
+    /* Since configuring the default Qos from an XML is a posibility, we need to load the XML profiles just in case */
+    DomainParticipantFactory::get_instance()->load_profiles();
     DomainParticipantQos participant_qos = DomainParticipantFactory::get_instance()->get_default_participant_qos();
     participant_qos.name("monitor_discovery_server_" + discovery_server_guid_prefix);
 

--- a/test/mock/dds/DomainParticipantFactory/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/test/mock/dds/DomainParticipantFactory/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -46,6 +46,12 @@ public:
         return &instance;
     }
 
+    MOCK_METHOD0(
+        load_profiles,
+        fastrtps::types::ReturnCode_t
+            ()
+        );
+
     MOCK_METHOD4(
         create_participant,
         DomainParticipant *


### PR DESCRIPTION
When using XML Qos configuration, profiles having the _is_default_profile_ tag are not being properly set up as the default Qos to be retrieved with _get_default_participant_qos()_.

This PR should fix that behaviour.