### PR TITLE
[14468][14469] Use correct format locator in `init_monitor`

### DIFF
--- a/docs/code/StatisticsBackendTests.cpp
+++ b/docs/code/StatisticsBackendTests.cpp
@@ -54,7 +54,7 @@ void init_monitor_examples()
         // "44.53.01.5f.45.50.52.4f.53.49.4d.41".
         // The monitor has no listener associated.
         EntityId disc_server_prefix_monitor_id =
-                StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "UDPv4:[127.0.0.1]:11811");
+                StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "UDPv4:[localhost]:11811");
         //!--
         static_cast<void>(domain_monitor_id);
         static_cast<void>(disc_server_monitor_id);
@@ -106,7 +106,7 @@ void init_monitor_examples()
         // eprosima::fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX.
         // The monitor uses a custom listener, a CallbackMask, and a DataKindMask.
         EntityId disc_server_monitor_id =
-                StatisticsBackend::init_monitor("UDPv4:[127.0.0.1]:11811", &domain_listener, callback_mask, datakind_mask);
+                StatisticsBackend::init_monitor("UDPv4:[localhost]:11811", &domain_listener, callback_mask, datakind_mask);
 
         // Init a monitor for a Fast DDS Discovery Server network which server is located in IPv4
         // address 127.0.0.1 and port 11811 using UDP transport layer, and that uses the GUID prefix

--- a/docs/code/StatisticsBackendTests.cpp
+++ b/docs/code/StatisticsBackendTests.cpp
@@ -106,7 +106,8 @@ void init_monitor_examples()
         // eprosima::fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX.
         // The monitor uses a custom listener, a CallbackMask, and a DataKindMask.
         EntityId disc_server_monitor_id =
-                StatisticsBackend::init_monitor("UDPv4:[localhost]:11811", &domain_listener, callback_mask, datakind_mask);
+                StatisticsBackend::init_monitor("UDPv4:[localhost]:11811", &domain_listener, callback_mask,
+                        datakind_mask);
 
         // Init a monitor for a Fast DDS Discovery Server network which server is located in IPv4
         // address 127.0.0.1 and port 11811 using UDP transport layer, and that uses the GUID prefix

--- a/docs/code/StatisticsBackendTests.cpp
+++ b/docs/code/StatisticsBackendTests.cpp
@@ -43,18 +43,18 @@ void init_monitor_examples()
                 StatisticsBackend::init_monitor(0);
 
         // Init a monitor for a Fast DDS Discovery Server network which server is located in IPv4
-        // address 127.0.0.1 and port 11811, and that uses the default GUID prefix
+        // address 127.0.0.1 and port 11811 using UDP as transport layer, and that uses the default GUID prefix
         // eprosima::fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX.
         // The monitor has no listener associated.
         EntityId disc_server_monitor_id =
-                StatisticsBackend::init_monitor("127.0.0.1:11811");
+                StatisticsBackend::init_monitor("UDPv4:[127.0.0.1]:11811");
 
-        // Init a monitor for a Fast DDS Discovery Server network which serveris located in IPv4
-        // address 127.0.0.1 and port 11811, and that uses the GUID prefix
+        // Init a monitor for a Fast DDS Discovery Server network which server is located in IPv4
+        // address 127.0.0.1 and port 11811 using UDP as transport layer, and that uses the GUID prefix
         // "44.53.01.5f.45.50.52.4f.53.49.4d.41".
         // The monitor has no listener associated.
         EntityId disc_server_prefix_monitor_id =
-                StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "127.0.0.1:11811");
+                StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "UDPv4:[127.0.0.1]:11811");
         //!--
         static_cast<void>(domain_monitor_id);
         static_cast<void>(disc_server_monitor_id);
@@ -69,18 +69,18 @@ void init_monitor_examples()
                 StatisticsBackend::init_monitor(0, &domain_listener);
 
         // Init a monitor for a Fast DDS Discovery Server network which server is located in IPv4
-        // address 127.0.0.1 and port 11811, and that uses the default GUID prefix
+        // address 127.0.0.1 and port 11811 using UDP as transport layer, and that uses the default GUID prefix
         // eprosima::fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX.
         // The monitor uses a custom listener.
         EntityId disc_server_monitor_id =
-                StatisticsBackend::init_monitor("127.0.0.1:11811", &domain_listener);
+                StatisticsBackend::init_monitor("UDPv4:[127.0.0.1]:11811", &domain_listener);
 
-        // Init a monitor for a Fast DDS Discovery Server network which serveris located in IPv4
-        // address 127.0.0.1 and port 11811, and that uses the GUID prefix
+        // Init a monitor for a Fast DDS Discovery Server network which server is located in IPv4
+        // address 127.0.0.1 and port 11811 using UDP transport layer, and that uses the GUID prefix
         // "44.53.01.5f.45.50.52.4f.53.49.4d.41".
         // The monitor uses a custom listener.
         EntityId disc_server_prefix_monitor_id =
-                StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "127.0.0.1:11811",
+                StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "UDPv4:[127.0.0.1]:11811",
                         &domain_listener);
         //!--
         static_cast<void>(domain_monitor_id);
@@ -102,18 +102,18 @@ void init_monitor_examples()
                 StatisticsBackend::init_monitor(0, &domain_listener, callback_mask, datakind_mask);
 
         // Init a monitor for a Fast DDS Discovery Server network which server is located in IPv4
-        // address 127.0.0.1 and port 11811, and that uses the default GUID prefix
+        // address 127.0.0.1 and port 11811 using UDP transport layer, and that uses the default GUID prefix
         // eprosima::fastdds::rtps::DEFAULT_ROS2_SERVER_GUIDPREFIX.
         // The monitor uses a custom listener, a CallbackMask, and a DataKindMask.
         EntityId disc_server_monitor_id =
-                StatisticsBackend::init_monitor("127.0.0.1:11811", &domain_listener, callback_mask, datakind_mask);
+                StatisticsBackend::init_monitor("UDPv4:[127.0.0.1]:11811", &domain_listener, callback_mask, datakind_mask);
 
-        // Init a monitor for a Fast DDS Discovery Server network which serveris located in IPv4
-        // address 127.0.0.1 and port 11811, and that uses the GUID prefix
+        // Init a monitor for a Fast DDS Discovery Server network which server is located in IPv4
+        // address 127.0.0.1 and port 11811 using UDP transport layer, and that uses the GUID prefix
         // "44.53.01.5f.45.50.52.4f.53.49.4d.41".
         // The monitor uses a custom listener, a CallbackMask, and a DataKindMask.
         EntityId disc_server_prefix_monitor_id =
-                StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "127.0.0.1:11811",
+                StatisticsBackend::init_monitor("44.53.01.5f.45.50.52.4f.53.49.4d.41", "UDPv4:[127.0.0.1]:11811",
                         &domain_listener, callback_mask, datakind_mask);
         //!--
         static_cast<void>(domain_monitor_id);

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -386,6 +386,9 @@ set(INIT_MONITOR_TEST_LIST
     init_monitor_port_out_of_range
     init_monitor_unsupported_shm
     init_monitor_extra_characters
+    init_monitor_no_locator_kind_old_serialization
+    init_monitor_no_locator_kind_new_serialization
+    init_monitor_invalid_locator_kind
     )
 
 foreach(test_name ${INIT_MONITOR_TEST_LIST})

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -382,12 +382,17 @@ set(INIT_MONITOR_TEST_LIST
     init_monitor_topic_exists_with_another_type
     init_monitor_invalid_ipv4
     init_monitor_invalid_ipv6
+    init_monitor_no_ip_address
+    init_monitor_no_ip_brackets
     init_monitor_invalid_port
     init_monitor_port_out_of_range
+    init_monitor_empty_port
+    init_monitor_no_port
     init_monitor_unsupported_shm
     init_monitor_extra_characters
     init_monitor_no_locator_kind_old_serialization
     init_monitor_no_locator_kind_new_serialization
+    init_monitor_empty_locator_kind
     init_monitor_invalid_locator_kind
     )
 

--- a/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
@@ -374,16 +374,47 @@ TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_ipv6)
     check_init_monitor_discovery_server_failure(server_locators);
 }
 
-TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_port)
+TEST_F(init_monitor_factory_fails_tests, init_monitor_no_ip_address)
 {
-    std::string server_locators = "UDPv4:[192.356.0.1]:-11811";
+    std::string server_locators = "UDPv4:[]:11811";
 
     check_init_monitor_discovery_server_failure(server_locators);
 }
 
+TEST_F(init_monitor_factory_fails_tests, init_monitor_no_ip_brackets)
+{
+    std::string server_locators = "UDPv4:localhost:11811";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+}
+
+// TODO: currently Fast DDS reads the port as an unsigned integer so this specific test is not failing as expected
+TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_port)
+{
+/*
+    std::string server_locators = "UDPv4:[192.0.0.1]:-11811";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+*/
+}
+
 TEST_F(init_monitor_factory_fails_tests, init_monitor_port_out_of_range)
 {
-    std::string server_locators = "UDPv4:[192.356.0.1]:4294967296";
+    std::string server_locators = "UDPv4:[192.0.0.1]:4294967296";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+}
+
+TEST_F(init_monitor_factory_fails_tests, init_monitor_empty_port)
+{
+    std::string server_locators = "UDPv4:[192.0.0.1]:";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+}
+
+TEST_F(init_monitor_factory_fails_tests, init_monitor_no_port)
+{
+    std::string server_locators = "UDPv4:[192.0.0.1]";
 
     check_init_monitor_discovery_server_failure(server_locators);
 }
@@ -397,7 +428,7 @@ TEST_F(init_monitor_factory_fails_tests, init_monitor_unsupported_shm)
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_extra_characters)
 {
-    std::string server_locators = "UDPv4:[192.356.0.1]:1181:ABC";
+    std::string server_locators = "UDPv4:[192.0.0.1]:1181:ABC";
 
     check_init_monitor_discovery_server_failure(server_locators);
 }
@@ -416,9 +447,16 @@ TEST_F(init_monitor_factory_fails_tests, init_monitor_no_locator_kind_new_serial
     check_init_monitor_discovery_server_failure(server_locators);
 }
 
-TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_locator_kind)
+TEST_F(init_monitor_factory_fails_tests, init_monitor_empty_locator_kind)
 {
     std::string server_locators = ":[192.168.0.1]:11812";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+}
+
+TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_locator_kind)
+{
+    std::string server_locators = "ABC:[192.168.0.1]:11812";
 
     check_init_monitor_discovery_server_failure(server_locators);
 }

--- a/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
@@ -402,6 +402,27 @@ TEST_F(init_monitor_factory_fails_tests, init_monitor_extra_characters)
     check_init_monitor_discovery_server_failure(server_locators);
 }
 
+TEST_F(init_monitor_factory_fails_tests, init_monitor_no_locator_kind_old_serialization)
+{
+    std::string server_locators = "192.168.0.1:11812";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+}
+
+TEST_F(init_monitor_factory_fails_tests, init_monitor_no_locator_kind_new_serialization)
+{
+    std::string server_locators = "[192.168.0.1]:11812";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+}
+
+TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_locator_kind)
+{
+    std::string server_locators = ":[192.168.0.1]:11812";
+
+    check_init_monitor_discovery_server_failure(server_locators);
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorFactoryFailsTests.cpp
@@ -391,11 +391,11 @@ TEST_F(init_monitor_factory_fails_tests, init_monitor_no_ip_brackets)
 // TODO: currently Fast DDS reads the port as an unsigned integer so this specific test is not failing as expected
 TEST_F(init_monitor_factory_fails_tests, init_monitor_invalid_port)
 {
-/*
-    std::string server_locators = "UDPv4:[192.0.0.1]:-11811";
+    /*
+        std::string server_locators = "UDPv4:[192.0.0.1]:-11811";
 
-    check_init_monitor_discovery_server_failure(server_locators);
-*/
+        check_init_monitor_discovery_server_failure(server_locators);
+     */
 }
 
 TEST_F(init_monitor_factory_fails_tests, init_monitor_port_out_of_range)

--- a/test/unittest/StatisticsBackend/InitMonitorTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorTests.cpp
@@ -310,7 +310,7 @@ TEST_F(init_monitor_tests, init_monitor_domain_id_no_callback_all_data)
     DomainId domain_id = 0;
     DomainListener domain_listener;
     std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
-    std::string server_locators = "UDPv4:[127.0.0.1]:11811";
+    std::string server_locators = "UDPv4:[localhost]:11811";
 
     auto domain_monitors = init_monitors(domain_id, &domain_listener, server_guid_prefix, server_locators,
                     CallbackMask::none(), all_datakind_mask_);
@@ -395,7 +395,7 @@ TEST_F(init_monitor_tests, init_monitor_domain_id_null_listener_all_data)
 {
     DomainId domain_id = 0;
     std::string server_guid_prefix = "44.53.01.5f.45.50.52.4f.53.49.4d.41";
-    std::string server_locators = "UDPv4:[127.0.0.1]:11811";
+    std::string server_locators = "UDPv4:[localhost]:11811";
 
     auto domain_monitors = init_monitors(domain_id, nullptr, server_guid_prefix, server_locators,
                     all_callback_mask_, all_datakind_mask_);
@@ -555,7 +555,7 @@ TEST_F(init_monitor_tests, init_server_monitor_several_locators)
 {
     std::string server_locators =
             // unicast addresses
-            "UDPv4:[127.0.0.1]:11811;TCPv4:[127.0.0.1]:11812;UDPv6:[::1]:11813;TCPv6:[::1]:11814;"
+            "UDPv4:[localhost]:11811;TCPv4:[localhost]:11812;UDPv6:[::1]:11813;TCPv6:[::1]:11814;"
             // multicast addresses
             "UDPv4:[239.255.0.1]:11821;UDPv6:[ff1e::ffff:efff:1]:11823";
     EntityId monitor_id =  StatisticsBackend::init_monitor(server_locators);


### PR DESCRIPTION
This PR fixes the documentation because the locators need to have a different format for `init_monitor` to succeed (this method uses Locator operator `>>` from [Fast DDS public utils API](https://github.com/eProsima/Fast-DDS/blob/master/include/fastdds/rtps/common/Locator.h#L295)).

It also includes some more tests checking that when the locator does not have the expected format, `init_monitor` throws. One test have been disabled because it was not testing what was intended. Fixing the test has shown a bug that should be fixed in Fast DDS (deserializing locator port, there is no check to ensure that it is not a negative number).