### PR TITLE
Smart Pointer refactor (Monitor) [15811]

### DIFF
--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -87,15 +87,12 @@ static const char* topics[] =
 };
 
 void find_or_create_topic_and_type(
-        details::Monitor* monitor,
+        details::Monitor& monitor,
         const std::string& topic_name,
         const TypeSupport& type)
 {
-    // Argument safe check
-    assert(monitor != nullptr);
-
     // Find if the topic has been already created and if the associated type is correct
-    TopicDescription* topic_desc = monitor->participant->lookup_topicdescription(topic_name);
+    TopicDescription* topic_desc = monitor.participant->lookup_topicdescription(topic_name);
     if (nullptr != topic_desc)
     {
         if (topic_desc->get_type_name() != type->getName())
@@ -106,7 +103,7 @@ void find_or_create_topic_and_type(
 
         try
         {
-            monitor->topics[topic_name] = dynamic_cast<Topic*>(topic_desc);
+            monitor.topics[topic_name] = dynamic_cast<Topic*>(topic_desc);
         }
         catch (const std::bad_cast& e)
         {
@@ -117,23 +114,20 @@ void find_or_create_topic_and_type(
     }
     else
     {
-        if (ReturnCode_t::RETCODE_PRECONDITION_NOT_MET == monitor->participant->register_type(type, type->getName()))
+        if (ReturnCode_t::RETCODE_PRECONDITION_NOT_MET == monitor.participant->register_type(type, type->getName()))
         {
             // Name already in use
             throw Error(std::string("Type name ") + type->getName() + " is already in use");
         }
-        monitor->topics[topic_name] =
-                monitor->participant->create_topic(topic_name, type->getName(), TOPIC_QOS_DEFAULT);
+        monitor.topics[topic_name] =
+                monitor.participant->create_topic(topic_name, type->getName(), TOPIC_QOS_DEFAULT);
     }
 }
 
 void register_statistics_type_and_topic(
-        details::Monitor* monitor,
+        details::Monitor& monitor,
         const std::string& topic_name)
 {
-    // Argument safe check
-    assert(monitor != nullptr);
-
     if (HISTORY_LATENCY_TOPIC == topic_name)
     {
         TypeSupport history_latency_type(new WriterReaderDataPubSubType);
@@ -280,7 +274,7 @@ EntityId create_and_register_monitor(
         /* Register the type and topic*/
         try
         {
-            register_statistics_type_and_topic(monitor.get(), topic);
+            register_statistics_type_and_topic(*monitor, topic);
         }
         catch (const std::exception& e)
         {

--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -116,7 +116,7 @@ void StatisticsBackendData::on_data_available(
     auto monitor = monitors_by_entity_.find(domain_id);
     assert(monitor != monitors_by_entity_.end());
 
-    if (should_call_domain_listener(monitor->second.get(), CallbackKind::ON_DATA_AVAILABLE, data_kind))
+    if (should_call_domain_listener(*monitor->second, CallbackKind::ON_DATA_AVAILABLE, data_kind))
     {
         monitor->second->domain_listener->on_data_available(domain_id, entity_id, data_kind);
     }
@@ -127,19 +127,17 @@ void StatisticsBackendData::on_data_available(
 }
 
 bool StatisticsBackendData::should_call_domain_listener(
-        const Monitor* monitor,
+        const Monitor& monitor,
         CallbackKind callback_kind,
         DataKind data_kind)
 {
-    assert(monitor != nullptr);
-
-    if (nullptr == monitor->domain_listener)
+    if (nullptr == monitor.domain_listener)
     {
         // No user listener
         return false;
     }
 
-    if (!monitor->domain_callback_mask.is_set(callback_kind))
+    if (!monitor.domain_callback_mask.is_set(callback_kind))
     {
         // mask deactivated
         return false;
@@ -147,7 +145,7 @@ bool StatisticsBackendData::should_call_domain_listener(
 
     // If data_kind is INVALID, we do not care about the data kind mask
     // We assume an entity was discovered
-    if (data_kind != DataKind::INVALID && !monitor->data_mask.is_set(data_kind))
+    if (data_kind != DataKind::INVALID && !monitor.data_mask.is_set(data_kind))
     {
         // Data mask deactivated
         return false;
@@ -213,7 +211,7 @@ void StatisticsBackendData::on_domain_entity_discovery(
             // The status must be recorded regardless of the callback
             prepare_entity_discovery_status(discovery_status, monitor->second->participant_status_);
 
-            if (should_call_domain_listener(monitor->second.get(), CallbackKind::ON_PARTICIPANT_DISCOVERY))
+            if (should_call_domain_listener(*monitor->second, CallbackKind::ON_PARTICIPANT_DISCOVERY))
             {
                 monitor->second->domain_listener->on_participant_discovery(domain_id, entity_id,
                         monitor->second->participant_status_);
@@ -232,7 +230,7 @@ void StatisticsBackendData::on_domain_entity_discovery(
             // The status must be recorded regardless of the callback
             prepare_entity_discovery_status(discovery_status, monitor->second->topic_status_);
 
-            if (should_call_domain_listener(monitor->second.get(), CallbackKind::ON_TOPIC_DISCOVERY))
+            if (should_call_domain_listener(*monitor->second, CallbackKind::ON_TOPIC_DISCOVERY))
             {
                 monitor->second->domain_listener->on_topic_discovery(domain_id, entity_id,
                         monitor->second->topic_status_);
@@ -250,7 +248,7 @@ void StatisticsBackendData::on_domain_entity_discovery(
             // The status must be recorded regardless of the callback
             prepare_entity_discovery_status(discovery_status, monitor->second->datawriter_status_);
 
-            if (should_call_domain_listener(monitor->second.get(), CallbackKind::ON_DATAWRITER_DISCOVERY))
+            if (should_call_domain_listener(*monitor->second, CallbackKind::ON_DATAWRITER_DISCOVERY))
             {
                 monitor->second->domain_listener->on_datawriter_discovery(domain_id, entity_id,
                         monitor->second->datawriter_status_);
@@ -268,7 +266,7 @@ void StatisticsBackendData::on_domain_entity_discovery(
             // The status must be recorded regardless of the callback
             prepare_entity_discovery_status(discovery_status, monitor->second->datareader_status_);
 
-            if (should_call_domain_listener(monitor->second.get(), CallbackKind::ON_DATAREADER_DISCOVERY))
+            if (should_call_domain_listener(*monitor->second, CallbackKind::ON_DATAREADER_DISCOVERY))
             {
                 monitor->second->domain_listener->on_datareader_discovery(domain_id, entity_id,
                         monitor->second->datareader_status_);

--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -361,7 +361,6 @@ void StatisticsBackendData::stop_monitor(
     auto it = monitors_by_entity_.find(monitor_id);
     if (it == monitors_by_entity_.end())
     {
-        unlock();
         throw BadParameter("No monitor with such ID");
     }
     auto& monitor = it->second;

--- a/src/cpp/StatisticsBackendData.hpp
+++ b/src/cpp/StatisticsBackendData.hpp
@@ -251,7 +251,7 @@ protected:
      * @return true if the listener should be called. False otherwise.
      */
     bool should_call_domain_listener(
-            const Monitor* monitor,
+            const Monitor& monitor,
             CallbackKind callback_kind,
             DataKind data_kind = DataKind::INVALID);
 

--- a/src/cpp/StatisticsBackendData.hpp
+++ b/src/cpp/StatisticsBackendData.hpp
@@ -87,8 +87,12 @@ public:
     //! Reference to the Database data queue
     database::DatabaseDataQueue* data_queue_;
 
-    //! Collection of active monitors
-    std::map<EntityId, std::shared_ptr<Monitor>> monitors_by_entity_;
+    /**
+     * @brief Collection of active monitors
+     *
+     * @note This is a collection of unique_ptr as Monitors belong to this class and their ownership is managed by this.
+     */
+    std::map<EntityId, std::unique_ptr<Monitor>> monitors_by_entity_;
 
     //! Physical  listener
     PhysicalListener* physical_listener_;
@@ -241,13 +245,13 @@ protected:
      * When the method is called on the discovery of an entity, \c data_kind = INVALID
      * should be used, signalling that the value of the data mask set by the user is irrelevant in this case.
      *
-     * @param monitor The monitor whose domain listener we are testing
+     * @param monitor Reference to the monitor whose domain listener we are testing
      * @param callback_kind The callback kind to check against the callback kind mask
      * @param data_kind The data kind to check against the data kind mask
      * @return true if the listener should be called. False otherwise.
      */
     bool should_call_domain_listener(
-            std::shared_ptr<Monitor>& monitor,
+            const Monitor* monitor,
             CallbackKind callback_kind,
             DataKind data_kind = DataKind::INVALID);
 

--- a/test/unittest/Database/DatabaseStatusTests.cpp
+++ b/test/unittest/Database/DatabaseStatusTests.cpp
@@ -42,9 +42,9 @@ public:
 
         // Simulate that the backend is motorizing the domain
         // NOTE: This is dangerous, please do not do it again
-        std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
+        std::unique_ptr<details::Monitor> monitor = std::make_unique<details::Monitor>();
         monitor->id = domain->id;
-        details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
+        details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = std::move(monitor);
 
         // Simulate the discover of the entitiy
         db.change_entity_status_test(host->id, true, domain->id);

--- a/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
+++ b/test/unittest/StatisticsBackend/CallingUserListenersTests.cpp
@@ -1476,7 +1476,7 @@ public:
             DataKindMask::all());
 
         // Get the participant listener of the created monitor
-        monitor_ = details::StatisticsBackendData::get_instance()->monitors_by_entity_[monitor_id_];
+        monitor_ = details::StatisticsBackendData::get_instance()->monitors_by_entity_[monitor_id_].get();
         participant_listener_ = monitor_->participant_listener;
         reader_listener_ = monitor_->reader_listener;
         participant_ = monitor_->participant;
@@ -1501,7 +1501,7 @@ public:
     MockedPhysicalListener physical_listener_;
     MockedDomainListener domain_listener_;
     EntityId monitor_id_;
-    std::shared_ptr<details::Monitor> monitor_;
+    details::Monitor* monitor_;
 
     eprosima::fastdds::dds::DomainParticipantListener* participant_listener_;
     eprosima::fastdds::dds::DataReaderListener* reader_listener_;

--- a/test/unittest/StatisticsBackend/InitMonitorTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorTests.cpp
@@ -48,8 +48,7 @@ using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::statistics;
 using namespace eprosima::fastrtps::rtps;
 
-namespace test
-{
+namespace test {
 
 /**
  * @brief Get the monitors from database object
@@ -194,7 +193,7 @@ public:
         EXPECT_TRUE(monitor_id_2.is_valid());
 
         std::map<EntityId, eprosima::statistics_backend::details::Monitor*> domain_monitors =
-            test::get_monitors_from_database();
+                test::get_monitors_from_database();
 
         /* Check that three monitors are created */
         EXPECT_EQ(domain_monitors.size(), 3u);

--- a/test/unittest/StatisticsBackend/InitMonitorTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorTests.cpp
@@ -48,6 +48,26 @@ using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::statistics;
 using namespace eprosima::fastrtps::rtps;
 
+namespace test
+{
+
+/**
+ * @brief Get the monitors from database object
+ *
+ * @return Monitors initialized in raw ptrs
+ */
+std::map<EntityId, eprosima::statistics_backend::details::Monitor*> get_monitors_from_database()
+{
+    std::map<EntityId, eprosima::statistics_backend::details::Monitor*> domain_monitors;
+    for (const auto& it: details::StatisticsBackendData::get_instance()->monitors_by_entity_)
+    {
+        domain_monitors.emplace(it.first, it.second.get());
+    }
+    return domain_monitors;
+}
+
+} // namespace test
+
 
 class init_monitor_tests : public ::testing::Test
 {
@@ -144,7 +164,7 @@ public:
         details::StatisticsBackendData::reset_instance();
     }
 
-    std::map<EntityId, std::shared_ptr<eprosima::statistics_backend::details::Monitor>> init_monitors(
+    std::map<EntityId, eprosima::statistics_backend::details::Monitor*> init_monitors(
             DomainId domain_id,
             DomainListener* domain_listener,
             const std::string& server_guid_prefix,
@@ -173,7 +193,8 @@ public:
         EXPECT_TRUE(monitor_id_1.is_valid());
         EXPECT_TRUE(monitor_id_2.is_valid());
 
-        auto domain_monitors = details::StatisticsBackendData::get_instance()->monitors_by_entity_;
+        std::map<EntityId, eprosima::statistics_backend::details::Monitor*> domain_monitors =
+            test::get_monitors_from_database();
 
         /* Check that three monitors are created */
         EXPECT_EQ(domain_monitors.size(), 3u);
@@ -235,7 +256,7 @@ public:
     }
 
     void check_dds_entities(
-            const std::shared_ptr<eprosima::statistics_backend::details::Monitor> monitor,
+            eprosima::statistics_backend::details::Monitor* monitor,
             const std::string& server_guid_prefix = "")
     {
         EXPECT_NE(nullptr, monitor->participant);
@@ -454,7 +475,7 @@ TEST_F(init_monitor_tests, init_monitor_several_monitors)
 
     EXPECT_TRUE(monitor_id2.is_valid());
 
-    auto domain_monitors = details::StatisticsBackendData::get_instance()->monitors_by_entity_;
+    auto domain_monitors = test::get_monitors_from_database();
 
     /* Check that two monitors are created */
     EXPECT_EQ(domain_monitors.size(), 2u);
@@ -513,7 +534,7 @@ TEST_F(init_monitor_tests, init_monitor_twice)
                 CallbackMask::none(),
                 DataKindMask::none()), BadParameter);
 
-    auto domain_monitors = details::StatisticsBackendData::get_instance()->monitors_by_entity_;
+    auto domain_monitors = test::get_monitors_from_database();
 
     /* Check that three monitors are created */
     EXPECT_EQ(domain_monitors.size(), 3u);
@@ -562,7 +583,7 @@ TEST_F(init_monitor_tests, init_server_monitor_several_locators)
 
     EXPECT_TRUE(monitor_id.is_valid());
 
-    auto domain_monitors = details::StatisticsBackendData::get_instance()->monitors_by_entity_;
+    auto domain_monitors = test::get_monitors_from_database();
 
     /* Check that a monitor is created */
     EXPECT_EQ(domain_monitors.size(), 1u);
@@ -647,8 +668,7 @@ TEST_F(init_monitor_tests, init_monitor_check_participant_name)
 
     EXPECT_TRUE(monitor_id.is_valid());
 
-    std::map<EntityId, std::shared_ptr<details::Monitor>> domain_monitors =
-            details::StatisticsBackendData::get_instance()->monitors_by_entity_;
+    auto domain_monitors = test::get_monitors_from_database();
 
     /* Check that only one monitor is created */
     EXPECT_EQ(domain_monitors.size(), 1u);
@@ -677,8 +697,7 @@ TEST_F(init_monitor_tests, init_monitor_check_participant_transport)
 
     EXPECT_TRUE(monitor_id.is_valid());
 
-    std::map<EntityId, std::shared_ptr<details::Monitor>> domain_monitors =
-            details::StatisticsBackendData::get_instance()->monitors_by_entity_;
+    auto domain_monitors = test::get_monitors_from_database();
 
     /* Check that only one monitor is created */
     EXPECT_EQ(domain_monitors.size(), 1u);

--- a/test/unittest/StatisticsBackend/IsActiveTests.cpp
+++ b/test/unittest/StatisticsBackend/IsActiveTests.cpp
@@ -61,9 +61,9 @@ public:
         participant_listener = new StatisticsParticipantListener(domain->id, db, entity_queue, data_queue);
 
         // Simulate that the backend is monitorizing the domain
-        std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
+        std::unique_ptr<details::Monitor> monitor = std::make_unique<details::Monitor>();
         monitor->id = domain->id;
-        details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
+        details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = std::move(monitor);
 
         // Simulate the discover of the entitiy
         host->active = false;

--- a/test/unittest/TestUtils/DatabaseUtils.hpp
+++ b/test/unittest/TestUtils/DatabaseUtils.hpp
@@ -731,12 +731,12 @@ public:
             EntityKind::DOMAIN, EntityId::all());
         for (auto domain : domains)
         {
-            std::shared_ptr<details::Monitor> monitor = std::make_shared<details::Monitor>();
+            std::unique_ptr<details::Monitor> monitor = std::make_unique<details::Monitor>();
             std::stringstream domain_name;
             domain_name << domain->name;
             monitor->id = domain->id;
             monitor->domain_listener = nullptr;
-            details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = monitor;
+            details::StatisticsBackendData::get_instance()->monitors_by_entity_[domain->id] = std::move(monitor);
         }
         has_database_been_set_ = true;
     }


### PR DESCRIPTION
Convert shared_ptrs of Monitors to unique_ptrs as ownership must not be shared.
This implies performance and coherence improvement.

Merge after:
- #175 