### PR TITLE
Bump to v0.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,10 @@ include(${PROJECT_SOURCE_DIR}/cmake/common/asan.cmake)
 ###############################################################################
 # Load external projects.
 ###############################################################################
+set(FASTDDS_MIN_VERSION "2.8.0")
+
 find_package(fastcdr REQUIRED)
-find_package(fastrtps REQUIRED)
+find_package(fastrtps ${FASTDDS_MIN_VERSION} REQUIRED)
 
 ###############################################################################
 # Test system configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
 
 set(PROJECT_NAME_LARGE "Fast DDS Statistics Backend")
 
-project(${PROJECT_NAME} VERSION 0.7.1
+project(${PROJECT_NAME} VERSION 0.8.0
     DESCRIPTION "eProsima ${PROJECT_NAME_LARGE} library provides a simple and easy-to-use API for interacting with data from Fast DDS statistics module")
 
 set(${PROJECT_NAME}_DESCRIPTION_SUMMARY "C++ library for bridging Fast DDS statistics module data")

--- a/docs/code/StatisticsBackendTests.cpp
+++ b/docs/code/StatisticsBackendTests.cpp
@@ -143,6 +143,10 @@ void clear_examples()
         //CONF-CLEAR-EXAMPLE
         // Init a monitor in DDS domain 0 with no listener associated
         EntityId domain_monitor_id = StatisticsBackend::init_monitor(0);
+        // Clear all statistics data
+        StatisticsBackend::clear_statistics_data();
+        // Clear inactive entities
+        StatisticsBackend::clear_inactive_entities();
         // Stop the monitor
         StatisticsBackend::stop_monitor(domain_monitor_id);
         // Clear all data related to the monitor

--- a/docs/rst/exports/alias.include
+++ b/docs/rst/exports/alias.include
@@ -16,6 +16,8 @@
 .. |set_domain_listener-api| replace:: :cpp:func:`set_domain_listener()<eprosima::statistics_backend::StatisticsBackend::set_domain_listener>`
 .. |get_type-api| replace:: :cpp:func:`get_type()<eprosima::statistics_backend::StatisticsBackend::get_type>`
 .. |set_alias-api| replace:: :cpp:func:`set_alias()<eprosima::statistics_backend::StatisticsBackend::set_alias>`
+.. |clear_statistics_data-api| replace:: :cpp:func:`clear_statistics_data()<eprosima::statistics_backend::StatisticsBackend::clear_statistics_data>`
+.. |clear_inactive_entities-api| replace:: :cpp:func:`clear_inactive_entities()<eprosima::statistics_backend::StatisticsBackend::clear_inactive_entities>`
 
 .. |DomainListener-api| replace:: :cpp:class:`DomainListener<eprosima::statistics_backend::DomainListener>`
 .. |DomainListener::on_data_available-api| replace:: :cpp:func:`on_data_available()<eprosima::statistics_backend::DomainListener::on_data_available>`

--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -11,7 +11,7 @@ This release includes the following **improvements**:
 
 1. CI improvements:
 
-    1.  Include address-sanitizer job.
+    1. Include address-sanitizer job.
     2. Flaky tests are run in a specific job.
 
 1. Internal implementation improvements:

--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -1,17 +1,36 @@
 .. _release_notes:
 
-Version 0.7.1
+Version 0.8.0
 =============
 
-This release adds the following **improvements**:
+This release includes the following **features**:
 
-* Update python dependencies for building the documentation
-* Re-generate Fast DDS-Gen generated TypeSupport with Fast DDS-Gen v2.2.0
-* Example to export ROS 2 statistics to Prometheus
+1. New API to clear statistic data and remove inactive entities from database.
+
+This release includes the following **improvements**:
+
+1. CI improvements:
+
+    1.  Include address-sanitizer job.
+    2. Flaky tests are run in a specific job.
+
+1. Internal implementation improvements:
+
+    1. Remove database unused collections.
+    2. Smart pointers refactor using unique instead of shared pointers.
+
+1. Example:
+
+    1. Improve example including new API.
+
+This release includes the following **bugfixes**:
+
+1. Memory leaks fixes reported by address-sanitizer.
 
 Previous versions
 =================
 
+.. include:: previous_versions/v0.7.1.rst
 .. include:: previous_versions/v0.7.0.rst
 .. include:: previous_versions/v0.6.0.rst
 .. include:: previous_versions/v0.5.0.rst

--- a/docs/rst/notes/previous_versions/v0.7.1.rst
+++ b/docs/rst/notes/previous_versions/v0.7.1.rst
@@ -1,0 +1,8 @@
+Version 0.7.1
+-------------
+
+This release adds the following **improvements**:
+
+* Update python dependencies for building the documentation
+* Re-generate Fast DDS-Gen generated TypeSupport with Fast DDS-Gen v2.2.0
+* Example to export ROS 2 statistics to Prometheus

--- a/docs/rst/statistics_backend/clear.rst
+++ b/docs/rst/statistics_backend/clear.rst
@@ -2,16 +2,22 @@
 
 .. _statistics_backend_clear:
 
-Clear all data related to a monitor
------------------------------------
+Clearing data
+-------------
+
+*eProsima Fast DDS Statistics Backend* monitors both the entities discovered in a certain DDS domain or *Fast DDS*
+Discovery Server network, and the statistic data related to these entities.
+|StatisticsBackend-api| provides several methods to clear the data contained in the internal database:
+
+* |clear_statistics_data-api| commands the deletion of all statistics data contained within the database.
+* |clear_inactive_entities-api| deletes from the database those :ref:`entities <types_entity_kind>` that are no longer
+  alive and communicating (see :ref:`statistics_backend_is_active` for more information).
+* |clear_monitor-api| clears all data (entities and statistics) related to a specific monitor.
+  To do so, the corresponding monitor needs to be stopped before the |clear_monitor-api| operation can be performed.
 
 .. warning::
-    This feature is currently not supported.
+    |clear_monitor-api| is currently not supported.
     It will be implemented on a future release of *Fast DDS Statistics Backend*.
-
-In case applications are no longer interested in statistical data of a given DDS domain or *Fast DDS* Discovery Server
-network, it is possible to delete said data completely.
-To do so, the corresponding monitor needs to be stopped before the |clear_monitor-api| operation can be performed.
 
 .. literalinclude:: /code/StatisticsBackendTests.cpp
    :language: c++

--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>fastdds_statistics_backend</name>
   <!-->There must be a release. Update version accordingly<-->
-  <version>0.7.1</version>
+  <version>0.8.0</version>
   <description>
     C++ library to collect data from eProsima Fast DDS Statistics module and generate statistical information.
   </description>

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,14 @@
 Forthcoming
 -----------
 
+Version 0.8.0
+-------------
+
+This release has the following **API extensions**:
+
+* `StatisticsBackend::clear_statistics_data` clears the statistics data from every entity.
+* `StatisticsBackend::clear_inactive_entities` removes every inactive entity from the database.
+
 Version 0.7.0
 -------------
 


### PR DESCRIPTION
This PR bumps version to v0.8.0

It also updates the release notes and completes the public API documentation with the new API extensions introduced in #177.
Changes introduced in #172 requires Fast DDS minimum version to be v.2.8.0.