### PR TITLE
[17786] Add new ignored Info statuses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/common/asan.cmake)
 ###############################################################################
 # Load external projects.
 ###############################################################################
-set(FASTDDS_MIN_VERSION "2.8.0")
+set(FASTDDS_MIN_VERSION "2.10.0")
 
 find_package(fastcdr REQUIRED)
 find_package(fastrtps ${FASTDDS_MIN_VERSION} REQUIRED)

--- a/src/cpp/subscriber/StatisticsParticipantListener.cpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.cpp
@@ -161,6 +161,7 @@ void StatisticsParticipantListener::on_participant_discovery(
         }
         case ParticipantDiscoveryInfo::REMOVED_PARTICIPANT:
         case ParticipantDiscoveryInfo::DROPPED_PARTICIPANT:
+        case ParticipantDiscoveryInfo::IGNORED_PARTICIPANT:
         {
             discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY;
             break;
@@ -253,6 +254,7 @@ void StatisticsParticipantListener::on_subscriber_discovery(
             break;
         }
         case ReaderDiscoveryInfo::REMOVED_READER:
+        case ReaderDiscoveryInfo::IGNORED_READER:
         {
             discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY;
             break;
@@ -303,6 +305,7 @@ void StatisticsParticipantListener::on_publisher_discovery(
             break;
         }
         case WriterDiscoveryInfo::REMOVED_WRITER:
+        case WriterDiscoveryInfo::IGNORED_WRITER:
         {
             discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY;
             break;


### PR DESCRIPTION
This PR depends on #190.

eProsima/Fast-DDS#3354 introduced new API to support DDS ignored standard API. These changes broke the Statistics Backend build that is fixed with this PR.

The coverage is expected to be reduced as the case `IGNORED` cannot be properly tested.