### PR TITLE
[17815] Install fixed gcovr version

### DIFF
--- a/.github/actions/install-python-packages/action.yml
+++ b/.github/actions/install-python-packages/action.yml
@@ -17,6 +17,6 @@ runs:
           vcstool \
           GitPython \
           setuptools \
-          gcovr \
+          gcovr==5.2 \
           tomark
       shell: bash


### PR DESCRIPTION
This PR fixes failing coverage jobs (see [here](https://github.com/eProsima/Fast-DDS-statistics-backend/actions/runs/4369706262/jobs/7643792954#step:10:18))