### PR TITLE
Hotfix: remove obsolete warning since Fast DDS v2.9.0

### DIFF
--- a/docs/rst/formalia/titlepage.rst
+++ b/docs/rst/formalia/titlepage.rst
@@ -23,14 +23,6 @@ generate statistical information to be used by applications.
   Furthermore, several features may not be implemented yet.
 
 .. warning::
-  Be aware that the statistics module is not compiled and used by default by *Fast DDS* but it has to be specifically
-  configured to send statistical data of an specific entity.
-  Therefore, *eProsima Fast DDS* library must be compiled with `FASTDDS_STATISTICS` CMake option enabled and use either
-  the `FASTDDS_STATISTICS` environment variable or the DomainParticipantQos to activate the statistics DataWriters.
-  For more information, please refer to the
-  `Statistics Module documentation <https://fast-dds.docs.eprosima.com/en/latest/fastdds/statistics/statistics.html#statistics-module>`_.
-
-.. warning::
   If Fast DDS has been compiled with statistics and they are explicitly enabled and statistical data are not correctly
   received, only few data arrive or even none, configure the Fast DDS endpoints publishing statistics data with a less
   restrictive memory constraints.


### PR DESCRIPTION
Fast DDS v2.9.0 changed the default behavior by building with `FASTDDS_STATISTICS` enabled by default. Remove obsolete warning in Fast DDS Statistics Backend documentation.