### PR TITLE
[19970] Add <thread> library

### DIFF
--- a/test/dds/communication/Publisher.cpp
+++ b/test/dds/communication/Publisher.cpp
@@ -34,6 +34,7 @@
 #include <condition_variable>
 #include <fstream>
 #include <string>
+#include <thread>
 
 #include <Host.hpp>
 

--- a/test/dds/communication/Subscriber.cpp
+++ b/test/dds/communication/Subscriber.cpp
@@ -35,6 +35,7 @@
 #include <condition_variable>
 #include <fstream>
 #include <string>
+#include <thread>
 
 #include <Host.hpp>
 


### PR DESCRIPTION
Add the <thread> library to files that require it. They are no longer included from FastDDS dependencies.