### PR TITLE
[19974] Update problems' status to be treated as warnings instead of errors

### DIFF
--- a/docs/rst/statistics_backend/get_status_data.rst
+++ b/docs/rst/statistics_backend/get_status_data.rst
@@ -16,7 +16,7 @@ Only |PARTICIPANT-api|, |DATAWRITER-api| and |DATAREADER-api| have associated st
 describes which |StatusKind-api| each of these :ref:`entities<types_entity_kind>` has:
 
 +-------------------------------+-----------------+----------------+----------------+
-||StatusKind-api|               ||PARTICIPANT-api|||DATAWRITER-api|||DATAREADER-api||
+|StatusKind                     ||PARTICIPANT-api|||DATAWRITER-api|||DATAREADER-api||
 +===============================+=================+================+================+
 | |PROXY-api|                   | Yes             | Yes            | Yes            |
 +-------------------------------+-----------------+----------------+----------------+

--- a/docs/rst/types/status_kind.rst
+++ b/docs/rst/types/status_kind.rst
@@ -45,7 +45,7 @@ Only |PARTICIPANT-api|, |DATAWRITER-api| and |DATAREADER-api| have associated st
 describes which |StatusKind-api| each of these :ref:`entities<types_entity_kind>` has:
 
 +-------------------------------+-----------------+----------------+----------------+
-| |StatusKind-api|              ||PARTICIPANT-api|||DATAWRITER-api|||DATAREADER-api||
+| StatusKind                    ||PARTICIPANT-api|||DATAWRITER-api|||DATAREADER-api||
 +===============================+=================+================+================+
 | |PROXY-api|                   | Yes             | Yes            | Yes            |
 +-------------------------------+-----------------+----------------+----------------+
@@ -67,34 +67,27 @@ describes which |StatusKind-api| each of these :ref:`entities<types_entity_kind>
 Each |StatusKind-api| has an associated |StatusLevel-api|. |OK-api| status is obtained when the monitor service message
 reports no problem.
 Entity's associated |StatusLevel-api| is obtained from all status data. The following table describes which
-|StatusLevel-api|'s are associated with each |StatusKind-api|, and which |StatusLevel-api|'s are associated with each
-DDS Entity in relation to the |StatusKind-api|:
+|StatusLevel-api|'s are associated with each |StatusKind-api|:
 
-+-------------------------------+-----------------------+------------------------------+
-| |StatusKind-api|              ||StatusLevel-api|'s    |DDS Entity |StatusLevel-api|'s|
-+===============================+=======================+==============================+
-| |PROXY-api|                   | |OK-api|              | |OK-api|                     |
-+-------------------------------+-----------------------+------------------------------+
-| |CONNECTION_LIST-api|         | |OK-api|              | |OK-api|                     |
-+-------------------------------+-----------------------+------------------------------+
-| |INCOMPATIBLE_QOS-api|        | |OK-api|/|ERROR-api|  | |OK-api|/|ERROR-api|         |
-+-------------------------------+-----------------------+------------------------------+
-| |INCONSISTENT_TOPIC-api|      | \-                    | \-                           |
-+-------------------------------+-----------------------+------------------------------+
-| |LIVELINESS_LOST-api|         | |OK-api|/|WARNING-api|| |OK-api|/|WARNING-api|       |
-+-------------------------------+-----------------------+------------------------------+
-| |LIVELINESS_CHANGED-api|      | |OK-api|              | |OK-api|                     |
-+-------------------------------+-----------------------+------------------------------+
-| |DEADLINE_MISSED-api|         | |OK-api|/|ERROR-api|  | |OK-api|/|WARNING-api|       |
-+-------------------------------+-----------------------+------------------------------+
-| |SAMPLE_LOST-api|             | |OK-api|/|ERROR-api|  | |OK-api|/|WARNING-api|       |
-+-------------------------------+-----------------------+------------------------------+
-
-.. note::
-
-  Deadline missed or a loss of a sample are considered errors, and therefore their corresponding |StatusKind-api|
-  sample may have the |ERROR-api| status. However, this doesn't necessarily mean that the normal operation of the
-  entity is disrupted, and therefore they only take the status of the entity to the |WARNING-api| status level.
++-------------------------------+-----------------------+
+| StatusKind                    |StatusLevel's          |
++===============================+=======================+
+| |PROXY-api|                   | |OK-api|              |
++-------------------------------+-----------------------+
+| |CONNECTION_LIST-api|         | |OK-api|              |
++-------------------------------+-----------------------+
+| |INCOMPATIBLE_QOS-api|        | |OK-api|/|ERROR-api|  |
++-------------------------------+-----------------------+
+| |INCONSISTENT_TOPIC-api|      | \-                    |
++-------------------------------+-----------------------+
+| |LIVELINESS_LOST-api|         | |OK-api|/|WARNING-api||
++-------------------------------+-----------------------+
+| |LIVELINESS_CHANGED-api|      | |OK-api|              |
++-------------------------------+-----------------------+
+| |DEADLINE_MISSED-api|         | |OK-api|/|WARNING-api||
++-------------------------------+-----------------------+
+| |SAMPLE_LOST-api|             | |OK-api|/|WARNING-api||
++-------------------------------+-----------------------+
 
 .. note::
 

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -3680,15 +3680,15 @@ bool Database::update_entity_status_nts(
     {
         entity_error = true;
     }
-    // Check DeadlineMissed Status (error does not mean entity error but warning)
+    // Check DeadlineMissed Status
     if (!entity->monitor_service_data.deadline_missed.empty() &&
-            entity->monitor_service_data.deadline_missed.back().status == StatusLevel::ERROR_STATUS)
+            entity->monitor_service_data.deadline_missed.back().status == StatusLevel::WARNING_STATUS)
     {
         entity_warning = true;
     }
-    // Check SampleLost Status (error does not mean entity error but warning)
+    // Check SampleLost Status
     if (!entity->monitor_service_data.sample_lost.empty() &&
-            entity->monitor_service_data.sample_lost.back().status == StatusLevel::ERROR_STATUS)
+            entity->monitor_service_data.sample_lost.back().status == StatusLevel::WARNING_STATUS)
     {
         entity_warning = true;
     }
@@ -3716,9 +3716,9 @@ bool Database::update_entity_status_nts(
     {
         entity_warning = true;
     }
-    // Check DeadlineMissed Status (error does not mean entity error but warning)
+    // Check DeadlineMissed Status
     if (!entity->monitor_service_data.deadline_missed.empty() &&
-            entity->monitor_service_data.deadline_missed.back().status == StatusLevel::ERROR_STATUS)
+            entity->monitor_service_data.deadline_missed.back().status == StatusLevel::WARNING_STATUS)
     {
         entity_warning = true;
     }

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -930,7 +930,7 @@ void DatabaseDataQueue<eprosima::fastdds::statistics::MonitorServiceStatusData>:
 
     if (item.total_count())
     {
-        sample.status = StatusLevel::ERROR_STATUS;
+        sample.status = StatusLevel::WARNING_STATUS;
     }
     else
     {
@@ -968,7 +968,7 @@ void DatabaseDataQueue<eprosima::fastdds::statistics::MonitorServiceStatusData>:
 
     if (item.total_count())
     {
-        sample.status = StatusLevel::ERROR_STATUS;
+        sample.status = StatusLevel::WARNING_STATUS;
     }
     else
     {

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2428,9 +2428,9 @@ TEST_F(database_tests, insert_monitor_service_sample_proxy)
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     ProxySample sample_2;
     sample_2.kind = StatusKind::PROXY;
@@ -2438,9 +2438,9 @@ TEST_F(database_tests, insert_monitor_service_sample_proxy)
     sample_2.src_ts = std::chrono::system_clock::now();
     sample_2.entity_proxy = {6, 7, 8, 9, 10};
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     ASSERT_EQ(participant->monitor_service_data.proxy.size(), 2u);
     ASSERT_EQ(writer->monitor_service_data.proxy.size(), 1u);
@@ -2458,9 +2458,9 @@ TEST_F(database_tests, insert_monitor_service_sample_proxy_wrong_entity)
     sample.entity_proxy = {1, 2, 3, 4, 5};
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, domain_id, sample), BadParameter);
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_connection_list)
@@ -2488,9 +2488,9 @@ TEST_F(database_tests, insert_monitor_service_sample_connection_list)
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     ConnectionListSample sample_2;
     eprosima::fastdds::statistics::Connection connection_sample_2;
@@ -2514,9 +2514,9 @@ TEST_F(database_tests, insert_monitor_service_sample_connection_list)
     sample_2.src_ts = std::chrono::system_clock::now();
     sample_2.connection_list = {connection_sample_2, connection_sample_2};
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     ASSERT_EQ(participant->monitor_service_data.connection_list.size(), 2u);
     ASSERT_EQ(writer->monitor_service_data.connection_list.size(), 1u);
@@ -2549,9 +2549,9 @@ TEST_F(database_tests, insert_monitor_service_sample_connection_list_wrong_entit
     sample.connection_list = {connection_sample, connection_sample};
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, domain_id, sample), BadParameter);
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_incompatible_qos)
@@ -2570,9 +2570,9 @@ TEST_F(database_tests, insert_monitor_service_sample_incompatible_qos)
     sample.incompatible_qos_status.policies(qos_policy_count_seq);
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     IncompatibleQosSample sample_2;
     sample_2.kind = StatusKind::INCOMPATIBLE_QOS;
@@ -2587,9 +2587,9 @@ TEST_F(database_tests, insert_monitor_service_sample_incompatible_qos)
     qos_policy_count_seq_2 = {qos_policy_count_2};
     sample_2.incompatible_qos_status.policies(qos_policy_count_seq_2);
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::ERROR);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::ERROR_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     ASSERT_EQ(writer->monitor_service_data.incompatible_qos.size(), 2u);
     ASSERT_EQ(reader->monitor_service_data.incompatible_qos.size(), 1u);
@@ -2601,7 +2601,7 @@ TEST_F(database_tests, insert_monitor_service_sample_incompatible_qos_wrong_enti
 {
     IncompatibleQosSample sample;
     sample.kind = StatusKind::INCOMPATIBLE_QOS;
-    sample.status = StatusLevel::OK_STATUS;
+    sample.status = StatusLevel::ERROR_STATUS;
     sample.src_ts = std::chrono::system_clock::now();
     sample.incompatible_qos_status.total_count(5);
     sample.incompatible_qos_status.last_policy_id(2);
@@ -2613,9 +2613,9 @@ TEST_F(database_tests, insert_monitor_service_sample_incompatible_qos_wrong_enti
     sample.incompatible_qos_status.policies(qos_policy_count_seq);
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, participant_id, sample), BadParameter);
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_inconsistent_topic)
@@ -2627,9 +2627,9 @@ TEST_F(database_tests, insert_monitor_service_sample_inconsistent_topic)
     sample.inconsistent_topic_status.total_count(0);
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     InconsistentTopicSample sample_2;
     sample_2.kind = StatusKind::INCONSISTENT_TOPIC;
@@ -2637,9 +2637,9 @@ TEST_F(database_tests, insert_monitor_service_sample_inconsistent_topic)
     sample_2.src_ts = std::chrono::system_clock::now();
     sample_2.inconsistent_topic_status.total_count(2);
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     ASSERT_EQ(writer->monitor_service_data.inconsistent_topic.size(), 2u);
     ASSERT_EQ(reader->monitor_service_data.inconsistent_topic.size(), 1u);
@@ -2656,9 +2656,9 @@ TEST_F(database_tests, insert_monitor_service_sample_inconsistent_topic_wrong_en
     sample.inconsistent_topic_status.total_count(0);
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, participant_id, sample), BadParameter);
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_liveliness_lost)
@@ -2669,9 +2669,9 @@ TEST_F(database_tests, insert_monitor_service_sample_liveliness_lost)
     sample.src_ts = std::chrono::system_clock::now();
     sample.liveliness_lost_status.total_count(0);
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     LivelinessLostSample sample_2;
     sample_2.kind = StatusKind::LIVELINESS_LOST;
@@ -2679,9 +2679,9 @@ TEST_F(database_tests, insert_monitor_service_sample_liveliness_lost)
     sample_2.src_ts = std::chrono::system_clock::now();
     sample_2.liveliness_lost_status.total_count(5);
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::WARNING);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::WARNING_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     ASSERT_EQ(writer->monitor_service_data.liveliness_lost.size(), 2u);
     ASSERT_EQ(writer->monitor_service_data.liveliness_lost[0], static_cast<LivelinessLostSample>(sample));
@@ -2697,9 +2697,9 @@ TEST_F(database_tests, insert_monitor_service_sample_liveliness_lost_wrong_entit
     sample.liveliness_lost_status.total_count(0);
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, reader_id, sample), BadParameter);
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_liveliness_changed)
@@ -2712,9 +2712,9 @@ TEST_F(database_tests, insert_monitor_service_sample_liveliness_changed)
     sample.liveliness_changed_status.not_alive_count(0);
     sample.liveliness_changed_status.last_publication_handle({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     LivelinessChangedSample sample_2;
     sample_2.kind = StatusKind::LIVELINESS_CHANGED;
@@ -2724,9 +2724,9 @@ TEST_F(database_tests, insert_monitor_service_sample_liveliness_changed)
     sample_2.liveliness_changed_status.not_alive_count(4);
     sample_2.liveliness_changed_status.last_publication_handle({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_2));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     ASSERT_EQ(reader->monitor_service_data.liveliness_changed.size(), 2u);
     ASSERT_EQ(reader->monitor_service_data.liveliness_changed[0], static_cast<LivelinessChangedSample>(sample));
@@ -2744,9 +2744,9 @@ TEST_F(database_tests, insert_monitor_service_sample_liveliness_changed_wrong_en
     sample.liveliness_changed_status.last_publication_handle({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, writer_id, sample), BadParameter);
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_deadline_missed)
@@ -2759,9 +2759,9 @@ TEST_F(database_tests, insert_monitor_service_sample_deadline_missed)
     sample.deadline_missed_status.last_instance_handle({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     DeadlineMissedSample sample_2;
     sample_2.kind = StatusKind::DEADLINE_MISSED;
@@ -2770,9 +2770,9 @@ TEST_F(database_tests, insert_monitor_service_sample_deadline_missed)
     sample_2.deadline_missed_status.total_count(2);
     sample_2.deadline_missed_status.last_instance_handle({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::WARNING);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::WARNING_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     ASSERT_EQ(writer->monitor_service_data.deadline_missed.size(), 2u);
     ASSERT_EQ(reader->monitor_service_data.deadline_missed.size(), 1u);
@@ -2790,9 +2790,9 @@ TEST_F(database_tests, insert_monitor_service_sample_deadline_missed_wrong_entit
     sample.deadline_missed_status.last_instance_handle({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, participant_id, sample), BadParameter);
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_sample_lost)
@@ -2803,9 +2803,9 @@ TEST_F(database_tests, insert_monitor_service_sample_sample_lost)
     sample.src_ts = std::chrono::system_clock::now();
     sample.sample_lost_status.total_count(0);
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 
     SampleLostSample sample_2;
     sample_2.kind = StatusKind::SAMPLE_LOST;
@@ -2813,9 +2813,9 @@ TEST_F(database_tests, insert_monitor_service_sample_sample_lost)
     sample_2.src_ts = std::chrono::system_clock::now();
     sample_2.sample_lost_status.total_count(2);
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_2));
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::WARNING);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::WARNING_STATUS);
 
     ASSERT_EQ(reader->monitor_service_data.sample_lost.size(), 2u);
     ASSERT_EQ(reader->monitor_service_data.sample_lost[0], static_cast<SampleLostSample>(sample));
@@ -2831,9 +2831,9 @@ TEST_F(database_tests, insert_monitor_service_sample_sample_lost_wrong_entity)
     sample.sample_lost_status.total_count(2);
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, writer_id, sample), BadParameter);
-    ASSERT_EQ(participant->status, StatusLevel::OK);
-    ASSERT_EQ(writer->status, StatusLevel::OK);
-    ASSERT_EQ(reader->status, StatusLevel::OK);
+    ASSERT_EQ(participant->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(writer->status, StatusLevel::OK_STATUS);
+    ASSERT_EQ(reader->status, StatusLevel::OK_STATUS);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_invalid)

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -2428,6 +2428,9 @@ TEST_F(database_tests, insert_monitor_service_sample_proxy)
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     ProxySample sample_2;
     sample_2.kind = StatusKind::PROXY;
@@ -2435,6 +2438,9 @@ TEST_F(database_tests, insert_monitor_service_sample_proxy)
     sample_2.src_ts = std::chrono::system_clock::now();
     sample_2.entity_proxy = {6, 7, 8, 9, 10};
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     ASSERT_EQ(participant->monitor_service_data.proxy.size(), 2u);
     ASSERT_EQ(writer->monitor_service_data.proxy.size(), 1u);
@@ -2452,6 +2458,9 @@ TEST_F(database_tests, insert_monitor_service_sample_proxy_wrong_entity)
     sample.entity_proxy = {1, 2, 3, 4, 5};
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, domain_id, sample), BadParameter);
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_connection_list)
@@ -2479,6 +2488,9 @@ TEST_F(database_tests, insert_monitor_service_sample_connection_list)
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     ConnectionListSample sample_2;
     eprosima::fastdds::statistics::Connection connection_sample_2;
@@ -2502,6 +2514,9 @@ TEST_F(database_tests, insert_monitor_service_sample_connection_list)
     sample_2.src_ts = std::chrono::system_clock::now();
     sample_2.connection_list = {connection_sample_2, connection_sample_2};
     ASSERT_NO_THROW(db.insert(domain_id, participant_id, sample_2));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     ASSERT_EQ(participant->monitor_service_data.connection_list.size(), 2u);
     ASSERT_EQ(writer->monitor_service_data.connection_list.size(), 1u);
@@ -2534,6 +2549,9 @@ TEST_F(database_tests, insert_monitor_service_sample_connection_list_wrong_entit
     sample.connection_list = {connection_sample, connection_sample};
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, domain_id, sample), BadParameter);
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_incompatible_qos)
@@ -2552,6 +2570,9 @@ TEST_F(database_tests, insert_monitor_service_sample_incompatible_qos)
     sample.incompatible_qos_status.policies(qos_policy_count_seq);
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     IncompatibleQosSample sample_2;
     sample_2.kind = StatusKind::INCOMPATIBLE_QOS;
@@ -2566,6 +2587,9 @@ TEST_F(database_tests, insert_monitor_service_sample_incompatible_qos)
     qos_policy_count_seq_2 = {qos_policy_count_2};
     sample_2.incompatible_qos_status.policies(qos_policy_count_seq_2);
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::ERROR);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     ASSERT_EQ(writer->monitor_service_data.incompatible_qos.size(), 2u);
     ASSERT_EQ(reader->monitor_service_data.incompatible_qos.size(), 1u);
@@ -2589,6 +2613,9 @@ TEST_F(database_tests, insert_monitor_service_sample_incompatible_qos_wrong_enti
     sample.incompatible_qos_status.policies(qos_policy_count_seq);
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, participant_id, sample), BadParameter);
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_inconsistent_topic)
@@ -2600,6 +2627,9 @@ TEST_F(database_tests, insert_monitor_service_sample_inconsistent_topic)
     sample.inconsistent_topic_status.total_count(0);
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     InconsistentTopicSample sample_2;
     sample_2.kind = StatusKind::INCONSISTENT_TOPIC;
@@ -2607,6 +2637,9 @@ TEST_F(database_tests, insert_monitor_service_sample_inconsistent_topic)
     sample_2.src_ts = std::chrono::system_clock::now();
     sample_2.inconsistent_topic_status.total_count(2);
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     ASSERT_EQ(writer->monitor_service_data.inconsistent_topic.size(), 2u);
     ASSERT_EQ(reader->monitor_service_data.inconsistent_topic.size(), 1u);
@@ -2623,6 +2656,9 @@ TEST_F(database_tests, insert_monitor_service_sample_inconsistent_topic_wrong_en
     sample.inconsistent_topic_status.total_count(0);
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, participant_id, sample), BadParameter);
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_liveliness_lost)
@@ -2633,6 +2669,9 @@ TEST_F(database_tests, insert_monitor_service_sample_liveliness_lost)
     sample.src_ts = std::chrono::system_clock::now();
     sample.liveliness_lost_status.total_count(0);
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     LivelinessLostSample sample_2;
     sample_2.kind = StatusKind::LIVELINESS_LOST;
@@ -2640,6 +2679,9 @@ TEST_F(database_tests, insert_monitor_service_sample_liveliness_lost)
     sample_2.src_ts = std::chrono::system_clock::now();
     sample_2.liveliness_lost_status.total_count(5);
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::WARNING);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     ASSERT_EQ(writer->monitor_service_data.liveliness_lost.size(), 2u);
     ASSERT_EQ(writer->monitor_service_data.liveliness_lost[0], static_cast<LivelinessLostSample>(sample));
@@ -2655,6 +2697,9 @@ TEST_F(database_tests, insert_monitor_service_sample_liveliness_lost_wrong_entit
     sample.liveliness_lost_status.total_count(0);
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, reader_id, sample), BadParameter);
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_liveliness_changed)
@@ -2667,6 +2712,9 @@ TEST_F(database_tests, insert_monitor_service_sample_liveliness_changed)
     sample.liveliness_changed_status.not_alive_count(0);
     sample.liveliness_changed_status.last_publication_handle({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     LivelinessChangedSample sample_2;
     sample_2.kind = StatusKind::LIVELINESS_CHANGED;
@@ -2676,6 +2724,9 @@ TEST_F(database_tests, insert_monitor_service_sample_liveliness_changed)
     sample_2.liveliness_changed_status.not_alive_count(4);
     sample_2.liveliness_changed_status.last_publication_handle({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_2));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     ASSERT_EQ(reader->monitor_service_data.liveliness_changed.size(), 2u);
     ASSERT_EQ(reader->monitor_service_data.liveliness_changed[0], static_cast<LivelinessChangedSample>(sample));
@@ -2693,6 +2744,9 @@ TEST_F(database_tests, insert_monitor_service_sample_liveliness_changed_wrong_en
     sample.liveliness_changed_status.last_publication_handle({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, writer_id, sample), BadParameter);
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_deadline_missed)
@@ -2705,14 +2759,20 @@ TEST_F(database_tests, insert_monitor_service_sample_deadline_missed)
     sample.deadline_missed_status.last_instance_handle({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample));
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     DeadlineMissedSample sample_2;
     sample_2.kind = StatusKind::DEADLINE_MISSED;
-    sample_2.status = StatusLevel::ERROR_STATUS;
+    sample_2.status = StatusLevel::WARNING_STATUS;
     sample_2.src_ts = std::chrono::system_clock::now();
     sample_2.deadline_missed_status.total_count(2);
     sample_2.deadline_missed_status.last_instance_handle({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
     ASSERT_NO_THROW(db.insert(domain_id, writer_id, sample_2));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::WARNING);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     ASSERT_EQ(writer->monitor_service_data.deadline_missed.size(), 2u);
     ASSERT_EQ(reader->monitor_service_data.deadline_missed.size(), 1u);
@@ -2724,12 +2784,15 @@ TEST_F(database_tests, insert_monitor_service_sample_deadline_missed_wrong_entit
 {
     DeadlineMissedSample sample;
     sample.kind = StatusKind::DEADLINE_MISSED;
-    sample.status = StatusLevel::ERROR_STATUS;
+    sample.status = StatusLevel::WARNING_STATUS;
     sample.src_ts = std::chrono::system_clock::now();
-    sample.deadline_missed_status.total_count(0);
+    sample.deadline_missed_status.total_count(2);
     sample.deadline_missed_status.last_instance_handle({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, participant_id, sample), BadParameter);
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_sample_lost)
@@ -2740,13 +2803,19 @@ TEST_F(database_tests, insert_monitor_service_sample_sample_lost)
     sample.src_ts = std::chrono::system_clock::now();
     sample.sample_lost_status.total_count(0);
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 
     SampleLostSample sample_2;
     sample_2.kind = StatusKind::SAMPLE_LOST;
-    sample_2.status = StatusLevel::ERROR_STATUS;
+    sample_2.status = StatusLevel::WARNING_STATUS;
     sample_2.src_ts = std::chrono::system_clock::now();
     sample_2.sample_lost_status.total_count(2);
     ASSERT_NO_THROW(db.insert(domain_id, reader_id, sample_2));
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::WARNING);
 
     ASSERT_EQ(reader->monitor_service_data.sample_lost.size(), 2u);
     ASSERT_EQ(reader->monitor_service_data.sample_lost[0], static_cast<SampleLostSample>(sample));
@@ -2757,11 +2826,14 @@ TEST_F(database_tests, insert_monitor_service_sample_sample_lost_wrong_entity)
 {
     SampleLostSample sample;
     sample.kind = StatusKind::SAMPLE_LOST;
-    sample.status = StatusLevel::OK_STATUS;
+    sample.status = StatusLevel::WARNING_STATUS;
     sample.src_ts = std::chrono::system_clock::now();
-    sample.sample_lost_status.total_count(0);
+    sample.sample_lost_status.total_count(2);
     ASSERT_THROW(db.insert(domain_id, db.generate_entity_id(), sample), BadParameter);
     ASSERT_THROW(db.insert(domain_id, writer_id, sample), BadParameter);
+    ASSERT_EQ(participant->status, StatusLevel::OK);
+    ASSERT_EQ(writer->status, StatusLevel::OK);
+    ASSERT_EQ(reader->status, StatusLevel::OK);
 }
 
 TEST_F(database_tests, insert_monitor_service_sample_invalid)


### PR DESCRIPTION
Update problems' status to be treated as warnings instead of errors

- [x] Logic
- [x] Tests
- [x] Doc

Merge after:
- #207 