### PR TITLE
#undef ERROR macro

### DIFF
--- a/include/fastdds_statistics_backend/types/types.hpp
+++ b/include/fastdds_statistics_backend/types/types.hpp
@@ -26,6 +26,8 @@
 
 #include <chrono>
 
+#undef ERROR
+
 namespace eprosima {
 namespace statistics_backend {
 


### PR DESCRIPTION
ERROR is #defined in one of the windows API headers. We need to remove the current definition of the identifier. 