### PR TITLE
Improve export DLL by moving them to the class  methods & impl.

### DIFF
--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -34,7 +34,7 @@
 namespace eprosima {
 namespace statistics_backend {
 
-class FASTDDS_STATISTICS_BACKEND_DllAPI StatisticsBackend
+class StatisticsBackend
 {
 
 public:
@@ -55,6 +55,7 @@ public:
      * @param callback_mask Mask of the callbacks. Only the events that have the mask bit set will be informed.
      * @param data_mask Mask of the data types that will be monitored.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static void set_physical_listener(
             PhysicalListener* listener,
             CallbackMask callback_mask = CallbackMask::all(),
@@ -76,6 +77,7 @@ public:
      * @throws eprosima::statistics_backend::BadParameter if a monitor is already created for the given domain.
      * @throws eprosima::statistics_backend::Error if the creation of the monitor fails.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static EntityId init_monitor(
             DomainId domain,
             DomainListener* domain_listener = nullptr,
@@ -108,6 +110,7 @@ public:
      * @param app_metadata Metadata of the monitor participant.
      * @return The ID of the created statistics Domain.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static EntityId init_monitor(
             std::string discovery_server_locators,
             DomainListener* domain_listener = nullptr,
@@ -139,6 +142,7 @@ public:
      * @param app_metadata Metadata of the monitor participant.
      * @return The ID of the created statistics Domain.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static EntityId init_monitor(
             std::string discovery_server_guid_prefix,
             std::string discovery_server_locators,
@@ -156,6 +160,7 @@ public:
      *
      * @param monitor_id The entity ID of the monitor to restart.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static void restart_monitor(
             EntityId monitor_id);
 
@@ -168,6 +173,7 @@ public:
      * @param monitor_id The entity ID of the monitor to stop.
      * @throws eprosima::statistics_backend::BadParameter if the given monitor ID is not yet registered.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static void stop_monitor(
             EntityId monitor_id);
 
@@ -181,6 +187,7 @@ public:
      *
      * @param monitor_id The entity ID of the monitor to stop.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static void clear_monitor(
             EntityId monitor_id);
 
@@ -197,6 +204,7 @@ public:
      * @param data_mask Mask of the data types that will be monitored.
      * @throws eprosima::statistics_backend::BadParameter if the given monitor ID is not yet registered.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static void set_domain_listener(
             EntityId monitor_id,
             DomainListener* listener = nullptr,
@@ -225,6 +233,7 @@ public:
      *     * if the EntityKind of the Entity with \c entity_id is \c INVALID.
      * @return All entities of type \c entity_type that are related to \c entity_id.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static std::vector<EntityId> get_entities(
             EntityKind entity_type,
             EntityId entity_id = EntityId::all());
@@ -239,6 +248,7 @@ public:
      * @param entity_id The ID of the entity whose activeness is requested.
      * @return true if active, false otherwise.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static bool is_active(
             EntityId entity_id);
 
@@ -252,6 +262,7 @@ public:
      * @param entity_id The ID of the entity whose metatraffic attribute is requested.
      * @return true if metatraffic, false otherwise.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static bool is_metatraffic(
             EntityId entity_id);
 
@@ -262,6 +273,7 @@ public:
      * @throws eprosima::statistics_backend::BadParameter if there is no entity with the given ID.
      * @return EntityKind of \c entity_id.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static EntityKind get_type(
             EntityId entity_id);
 
@@ -272,6 +284,7 @@ public:
      * @throws eprosima::statistics_backend::BadParameter if there is no entity with the given ID.
      * @return StatusLevel of \c entity_id.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static StatusLevel get_status(
             EntityId entity_id);
 
@@ -281,6 +294,7 @@ public:
      * @param entity_id The entity for which the meta information is retrieved.
      * @return Info object describing the entity's meta information.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static Info get_info(
             EntityId entity_id);
 
@@ -322,6 +336,7 @@ public:
      * @throws eprosima::statistics_backend::BadParameter if the above preconditions are not met.
      * @return a vector of \c bin elements with the values of the requested statistic.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static std::vector<StatisticsData> get_data(
             DataKind data_type,
             const std::vector<EntityId>& entity_ids_source,
@@ -367,6 +382,7 @@ public:
      * @throws eprosima::statistics_backend::BadParameter if the above preconditions are not met.
      * @return a vector of \c bin elements with the values of the requested statistic.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static std::vector<StatisticsData> get_data(
             DataKind data_type,
             const std::vector<EntityId>& entity_ids,
@@ -391,6 +407,7 @@ public:
      * @throws eprosima::statistics_backend::BadParameter if the above preconditions are not met.
      * @return a vector of \c bin elements with the values of the requested statistic.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static std::vector<StatisticsData> get_data(
             DataKind data_type,
             const std::vector<EntityId>& entity_ids_source,
@@ -412,6 +429,7 @@ public:
      * @throws eprosima::statistics_backend::BadParameter if the above preconditions are not met.
      * @return a vector of \c bin elements with the values of the requested statistic.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static std::vector<StatisticsData> get_data(
             DataKind data_type,
             const std::vector<EntityId>& entity_ids,
@@ -442,6 +460,7 @@ public:
      * @throws eprosima::statistics_backend::BadParameter if there is no graph for the specified domain id.
      * @return Graph object describing per domain topology of the entities.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static Graph get_domain_view_graph(
             const EntityId& domain_id);
 
@@ -452,6 +471,7 @@ public:
      *
      * @return True if the graph has been regenerated
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static bool regenerate_domain_graph(
             const EntityId& domain_id);
 
@@ -462,6 +482,7 @@ public:
      *
      * @return DatabaseDump object representing the backend database.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static DatabaseDump dump_database(
             bool clear);
 
@@ -471,6 +492,7 @@ public:
      * @param filename The name of the file where the database is dumped.
      * @param clear If true, clear all the statistics data of all entities.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static void dump_database(
             const std::string& filename,
             bool clear);
@@ -484,6 +506,7 @@ public:
      * @param filename The name of the file from which where the database is loaded.
      * @throws eprosima::statistics_backend::BadParameter if the file does not exist.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static void load_database(
             const std::string& filename);
 
@@ -492,10 +515,12 @@ public:
      *
      * @param t_to Timestamp regarding the maximum time to stop removing data.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static void clear_statistics_data(
             const Timestamp& t_to = the_end_of_time());
 
     //! Remove all inactive entities from database.
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static void clear_inactive_entities();
 
     /**
@@ -511,6 +536,7 @@ public:
      *
      * @pre There are no active monitors. There can be inactive monitors.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static void reset();
 
     /**
@@ -566,6 +592,7 @@ public:
      * @sa DataKind
      * @sa get_data
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static std::vector<std::pair<EntityKind, EntityKind>> get_data_supported_entity_kinds(
             DataKind data_kind);
 
@@ -576,6 +603,7 @@ public:
      * @param alias New alias that will replace the old one.
      * @throws eprosima::statistics_backend::BadParameter if there is no entity with the given ID.
      */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     static void set_alias(
             EntityId entity_id,
             const std::string& alias);

--- a/include/fastdds_statistics_backend/types/types.hpp
+++ b/include/fastdds_statistics_backend/types/types.hpp
@@ -375,7 +375,8 @@ struct MonitorServiceSample
 
     virtual ~MonitorServiceSample() = default;
 
-    virtual void clear();
+    virtual FASTDDS_STATISTICS_BACKEND_DllAPI
+    void clear();
 
     inline bool operator ==(
             const MonitorServiceSample& other) const noexcept
@@ -407,6 +408,7 @@ struct ProxySample : MonitorServiceSample
 
     virtual ~ProxySample() = default;
 
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     void clear() final;
 
     inline bool operator ==(
@@ -436,6 +438,7 @@ struct ConnectionListSample : MonitorServiceSample
 
     virtual ~ConnectionListSample() = default;
 
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     void clear() final;
 
     inline bool operator ==(
@@ -467,6 +470,7 @@ struct IncompatibleQosSample : MonitorServiceSample
 
     virtual ~IncompatibleQosSample() = default;
 
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     void clear() final;
 
     inline bool operator ==(
@@ -496,6 +500,7 @@ struct InconsistentTopicSample : MonitorServiceSample
 
     virtual ~InconsistentTopicSample() = default;
 
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     void clear() final;
 
     inline bool operator ==(
@@ -526,6 +531,7 @@ struct LivelinessLostSample : MonitorServiceSample
 
     virtual ~LivelinessLostSample() = default;
 
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     void clear() final;
 
     inline bool operator ==(
@@ -555,6 +561,7 @@ struct LivelinessChangedSample : MonitorServiceSample
 
     virtual ~LivelinessChangedSample() = default;
 
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     void clear() final;
 
     inline bool operator ==(
@@ -585,6 +592,7 @@ struct DeadlineMissedSample : MonitorServiceSample
 
     virtual ~DeadlineMissedSample() = default;
 
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     void clear() final;
 
     inline bool operator ==(
@@ -614,6 +622,7 @@ struct SampleLostSample : MonitorServiceSample
 
     virtual ~SampleLostSample() = default;
 
+    FASTDDS_STATISTICS_BACKEND_DllAPI
     void clear() final;
 
     inline bool operator ==(

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -733,6 +733,7 @@ void StatisticsBackend::get_status_data(
 }
 
 template <>
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void StatisticsBackend::get_status_data(
         const EntityId& entity_id,
         ProxySample& status_data)
@@ -741,6 +742,7 @@ void StatisticsBackend::get_status_data(
 }
 
 template <>
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void StatisticsBackend::get_status_data(
         const EntityId& entity_id,
         ConnectionListSample& status_data)
@@ -749,6 +751,7 @@ void StatisticsBackend::get_status_data(
 }
 
 template <>
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void StatisticsBackend::get_status_data(
         const EntityId& entity_id,
         IncompatibleQosSample& status_data)
@@ -757,6 +760,7 @@ void StatisticsBackend::get_status_data(
 }
 
 template <>
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void StatisticsBackend::get_status_data(
         const EntityId& entity_id,
         InconsistentTopicSample& status_data)
@@ -765,6 +769,7 @@ void StatisticsBackend::get_status_data(
 }
 
 template <>
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void StatisticsBackend::get_status_data(
         const EntityId& entity_id,
         LivelinessLostSample& status_data)
@@ -773,6 +778,7 @@ void StatisticsBackend::get_status_data(
 }
 
 template <>
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void StatisticsBackend::get_status_data(
         const EntityId& entity_id,
         LivelinessChangedSample& status_data)
@@ -781,6 +787,7 @@ void StatisticsBackend::get_status_data(
 }
 
 template <>
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void StatisticsBackend::get_status_data(
         const EntityId& entity_id,
         DeadlineMissedSample& status_data)
@@ -789,6 +796,7 @@ void StatisticsBackend::get_status_data(
 }
 
 template <>
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void StatisticsBackend::get_status_data(
         const EntityId& entity_id,
         SampleLostSample& status_data)

--- a/src/cpp/types/types.cpp
+++ b/src/cpp/types/types.cpp
@@ -14,9 +14,12 @@
 
 #include <fastdds_statistics_backend/types/types.hpp>
 
+#include <fastdds_statistics_backend/fastdds_statistics_backend_dll.h>
+
 namespace eprosima {
 namespace statistics_backend {
 
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void MonitorServiceSample::clear()
 {
     kind = StatusKind::INVALID;
@@ -24,18 +27,21 @@ void MonitorServiceSample::clear()
     src_ts = {};
 }
 
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void ProxySample::clear()
 {
     MonitorServiceSample::clear();
     entity_proxy.clear();
 }
 
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void ConnectionListSample::clear()
 {
     MonitorServiceSample::clear();
     connection_list.clear();
 }
 
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void IncompatibleQosSample::clear()
 {
     MonitorServiceSample::clear();
@@ -44,18 +50,21 @@ void IncompatibleQosSample::clear()
     incompatible_qos_status.policies(std::vector<eprosima::fastdds::statistics::QosPolicyCount_s>());
 }
 
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void InconsistentTopicSample::clear()
 {
     MonitorServiceSample::clear();
     inconsistent_topic_status.total_count(0);
 }
 
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void LivelinessLostSample::clear()
 {
     MonitorServiceSample::clear();
     liveliness_lost_status.total_count(0);
 }
 
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void LivelinessChangedSample::clear()
 {
     MonitorServiceSample::clear();
@@ -64,6 +73,7 @@ void LivelinessChangedSample::clear()
     liveliness_changed_status.last_publication_handle(std::array<uint8_t, 16UL>());
 }
 
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void DeadlineMissedSample::clear()
 {
     MonitorServiceSample::clear();
@@ -71,6 +81,7 @@ void DeadlineMissedSample::clear()
     deadline_missed_status.last_instance_handle(std::array<uint8_t, 16UL>());
 }
 
+FASTDDS_STATISTICS_BACKEND_DllAPI
 void SampleLostSample::clear()
 {
     MonitorServiceSample::clear();


### PR DESCRIPTION
This was causing issues linking Fast DDS Monitor in windows build