### PR TITLE
[20176] Regenerate Fast DDS docs example types due to Gen release v3.2.1

### DIFF
--- a/examples/cpp/HelloWorldExample/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/HelloWorldExample/HelloWorldPubSubTypes.cxx
@@ -36,7 +36,7 @@ HelloWorldPubSubType::HelloWorldPubSubType()
     setName("HelloWorld");
     uint32_t type_size =
 #if FASTCDR_VERSION_MAJOR == 1
-        HelloWorld::getMaxCdrSerializedSize();
+        static_cast<uint32_t>(HelloWorld::getMaxCdrSerializedSize());
 #else
         HelloWorld_max_cdr_typesize;
 #endif
@@ -139,23 +139,24 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
     return [data, data_representation]() -> uint32_t
            {
 #if FASTCDR_VERSION_MAJOR == 1
-                return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<HelloWorld*>(data))) +
+               static_cast<void>(data_representation);
+               return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<HelloWorld*>(data))) +
                       4u /*encapsulation*/;
 #else
-                try
-                {
-                    eprosima::fastcdr::CdrSizeCalculator calculator(
-                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
-                    size_t current_alignment {0};
-                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                *static_cast<HelloWorld*>(data), current_alignment)) +
-                            4u /*encapsulation*/;
-                }
-                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
-                {
-                    return 0;
-                }
+               try
+               {
+                   eprosima::fastcdr::CdrSizeCalculator calculator(
+                       data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                       eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                   size_t current_alignment {0};
+                   return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                           4u /*encapsulation*/;
+               }
+               catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+               {
+                   return 0;
+               }
 #endif // FASTCDR_VERSION_MAJOR == 1
            };
 }

--- a/include/fastdds_statistics_backend/topic_types/monitorservice_typesCdrAux.ipp
+++ b/include/fastdds_statistics_backend/topic_types/monitorservice_typesCdrAux.ipp
@@ -660,47 +660,47 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     switch (data._d())
     {
         case eprosima::fastdds::statistics::PROXY:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
                                 data.entity_proxy(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::CONNECTION_LIST:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
                                 data.connection_list(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::INCOMPATIBLE_QOS:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
                                 data.incompatible_qos_status(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::INCONSISTENT_TOPIC:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
                                 data.inconsistent_topic_status(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::LIVELINESS_LOST:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
                                 data.liveliness_lost_status(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::LIVELINESS_CHANGED:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
                                 data.liveliness_changed_status(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::DEADLINE_MISSED:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
                                 data.deadline_missed_status(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::SAMPLE_LOST:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
                                 data.sample_lost_status(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::STATUSES_SIZE:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
                                 data.statuses_size(), current_alignment);
                     break;
 
@@ -732,39 +732,39 @@ eProsima_user_DllExport void serialize(
     switch (data._d())
     {
                 case eprosima::fastdds::statistics::PROXY:
-                    scdr << eprosima::fastcdr::MemberId(0) << data.entity_proxy();
+                    scdr << eprosima::fastcdr::MemberId(1) << data.entity_proxy();
                     break;
 
                 case eprosima::fastdds::statistics::CONNECTION_LIST:
-                    scdr << eprosima::fastcdr::MemberId(1) << data.connection_list();
+                    scdr << eprosima::fastcdr::MemberId(2) << data.connection_list();
                     break;
 
                 case eprosima::fastdds::statistics::INCOMPATIBLE_QOS:
-                    scdr << eprosima::fastcdr::MemberId(2) << data.incompatible_qos_status();
+                    scdr << eprosima::fastcdr::MemberId(3) << data.incompatible_qos_status();
                     break;
 
                 case eprosima::fastdds::statistics::INCONSISTENT_TOPIC:
-                    scdr << eprosima::fastcdr::MemberId(3) << data.inconsistent_topic_status();
+                    scdr << eprosima::fastcdr::MemberId(4) << data.inconsistent_topic_status();
                     break;
 
                 case eprosima::fastdds::statistics::LIVELINESS_LOST:
-                    scdr << eprosima::fastcdr::MemberId(4) << data.liveliness_lost_status();
+                    scdr << eprosima::fastcdr::MemberId(5) << data.liveliness_lost_status();
                     break;
 
                 case eprosima::fastdds::statistics::LIVELINESS_CHANGED:
-                    scdr << eprosima::fastcdr::MemberId(5) << data.liveliness_changed_status();
+                    scdr << eprosima::fastcdr::MemberId(6) << data.liveliness_changed_status();
                     break;
 
                 case eprosima::fastdds::statistics::DEADLINE_MISSED:
-                    scdr << eprosima::fastcdr::MemberId(6) << data.deadline_missed_status();
+                    scdr << eprosima::fastcdr::MemberId(7) << data.deadline_missed_status();
                     break;
 
                 case eprosima::fastdds::statistics::SAMPLE_LOST:
-                    scdr << eprosima::fastcdr::MemberId(7) << data.sample_lost_status();
+                    scdr << eprosima::fastcdr::MemberId(8) << data.sample_lost_status();
                     break;
 
                 case eprosima::fastdds::statistics::STATUSES_SIZE:
-                    scdr << eprosima::fastcdr::MemberId(8) << data.statuses_size();
+                    scdr << eprosima::fastcdr::MemberId(9) << data.statuses_size();
                     break;
 
         default:

--- a/include/fastdds_statistics_backend/topic_types/typesCdrAux.ipp
+++ b/include/fastdds_statistics_backend/topic_types/typesCdrAux.ipp
@@ -1496,24 +1496,24 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     switch (data._d())
     {
         case eprosima::fastdds::statistics::HISTORY2HISTORY_LATENCY:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
                                 data.writer_reader_data(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::NETWORK_LATENCY:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
                                 data.locator2locator_data(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT:
         case eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
                                 data.entity_data(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::RTPS_SENT:
         case eprosima::fastdds::statistics::RTPS_LOST:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
                                 data.entity2locator_traffic(), current_alignment);
                     break;
 
@@ -1525,22 +1525,22 @@ eProsima_user_DllExport size_t calculate_serialized_size(
         case eprosima::fastdds::statistics::DATA_COUNT:
         case eprosima::fastdds::statistics::PDP_PACKETS:
         case eprosima::fastdds::statistics::EDP_PACKETS:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
                                 data.entity_count(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::DISCOVERED_ENTITY:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
                                 data.discovery_time(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::SAMPLE_DATAS:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
                                 data.sample_identity_count(), current_alignment);
                     break;
 
         case eprosima::fastdds::statistics::PHYSICAL_DATA:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
                                 data.physical_data(), current_alignment);
                     break;
 
@@ -1572,21 +1572,21 @@ eProsima_user_DllExport void serialize(
     switch (data._d())
     {
                 case eprosima::fastdds::statistics::HISTORY2HISTORY_LATENCY:
-                    scdr << eprosima::fastcdr::MemberId(0) << data.writer_reader_data();
+                    scdr << eprosima::fastcdr::MemberId(1) << data.writer_reader_data();
                     break;
 
                 case eprosima::fastdds::statistics::NETWORK_LATENCY:
-                    scdr << eprosima::fastcdr::MemberId(1) << data.locator2locator_data();
+                    scdr << eprosima::fastcdr::MemberId(2) << data.locator2locator_data();
                     break;
 
                 case eprosima::fastdds::statistics::PUBLICATION_THROUGHPUT:
                 case eprosima::fastdds::statistics::SUBSCRIPTION_THROUGHPUT:
-                    scdr << eprosima::fastcdr::MemberId(2) << data.entity_data();
+                    scdr << eprosima::fastcdr::MemberId(3) << data.entity_data();
                     break;
 
                 case eprosima::fastdds::statistics::RTPS_SENT:
                 case eprosima::fastdds::statistics::RTPS_LOST:
-                    scdr << eprosima::fastcdr::MemberId(3) << data.entity2locator_traffic();
+                    scdr << eprosima::fastcdr::MemberId(4) << data.entity2locator_traffic();
                     break;
 
                 case eprosima::fastdds::statistics::RESENT_DATAS:
@@ -1597,19 +1597,19 @@ eProsima_user_DllExport void serialize(
                 case eprosima::fastdds::statistics::DATA_COUNT:
                 case eprosima::fastdds::statistics::PDP_PACKETS:
                 case eprosima::fastdds::statistics::EDP_PACKETS:
-                    scdr << eprosima::fastcdr::MemberId(4) << data.entity_count();
+                    scdr << eprosima::fastcdr::MemberId(5) << data.entity_count();
                     break;
 
                 case eprosima::fastdds::statistics::DISCOVERED_ENTITY:
-                    scdr << eprosima::fastcdr::MemberId(5) << data.discovery_time();
+                    scdr << eprosima::fastcdr::MemberId(6) << data.discovery_time();
                     break;
 
                 case eprosima::fastdds::statistics::SAMPLE_DATAS:
-                    scdr << eprosima::fastcdr::MemberId(6) << data.sample_identity_count();
+                    scdr << eprosima::fastcdr::MemberId(7) << data.sample_identity_count();
                     break;
 
                 case eprosima::fastdds::statistics::PHYSICAL_DATA:
-                    scdr << eprosima::fastcdr::MemberId(7) << data.physical_data();
+                    scdr << eprosima::fastcdr::MemberId(8) << data.physical_data();
                     break;
 
         default:

--- a/include/fastdds_statistics_backend/topic_types/typesPubSubTypes.cxx
+++ b/include/fastdds_statistics_backend/topic_types/typesPubSubTypes.cxx
@@ -2709,3 +2709,4 @@ namespace eprosima {
 
 
 } //End of namespace eprosima
+


### PR DESCRIPTION
This PR regenerate the example types and the statistics & monitor service types.
This is needed to introduce the Fast DDS Gen release v3.2.1 changes.