### PR TITLE
[20933] Remove datasharing directory info from monitor GUI

### DIFF
--- a/src/cpp/subscriber/QosSerializer.cpp
+++ b/src/cpp/subscriber/QosSerializer.cpp
@@ -393,7 +393,6 @@ void serialize<fastdds::dds::DataSharingQosPolicy> (
             break;
     }
     datasharing[max_domains_tag] = qos.max_domains();
-    datasharing[shm_directory_tag] = qos.shm_directory();
     datasharing[domain_ids_tag] = database::Qos::array();
     for (const auto& id : qos.domain_ids())
     {

--- a/test/unittest/QosSerializer/QosSerializerTests.cpp
+++ b/test/unittest/QosSerializer/QosSerializerTests.cpp
@@ -510,7 +510,6 @@ TEST(qos_serializer_tests, data_sharing_qos_policy)
 
     expected[field.c_str()][kind_tag] = data_sharing_off_tag;
     expected[field.c_str()][max_domains_tag] = 0;
-    expected[field.c_str()][shm_directory_tag] = "";
     expected[field.c_str()][domain_ids_tag] = Qos::array();
     EXPECT_EQ(expected, serialized);
 
@@ -520,7 +519,6 @@ TEST(qos_serializer_tests, data_sharing_qos_policy)
 
     expected[field.c_str()][kind_tag] = data_sharing_auto_tag;
     expected[field.c_str()][max_domains_tag] = 0;
-    expected[field.c_str()][shm_directory_tag] = "datasharing_directory";
     expected[field.c_str()][domain_ids_tag].push_back(25);
     EXPECT_EQ(expected, serialized);
 
@@ -532,7 +530,6 @@ TEST(qos_serializer_tests, data_sharing_qos_policy)
 
     expected[field.c_str()][kind_tag] = data_sharing_on_tag;
     expected[field.c_str()][max_domains_tag] = 2;
-    expected[field.c_str()][shm_directory_tag] = "datasharing_directory";
     expected[field.c_str()][domain_ids_tag] = Qos::array();
     expected[field.c_str()][domain_ids_tag].push_back(25);
     expected[field.c_str()][domain_ids_tag].push_back(30);


### PR DESCRIPTION
During the discovery of an Entity the information about DataSharing directory  is not propagate to the statistics backend participant, consequently it has been removed from FastDDS monitor GUI.