### PR TITLE
[21302] Fix nightly job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,14 +11,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        - custom_version_build: 'v2'
-          ref: '1.x'
-        - custom_version_build: 'v3'
-          ref: 'main'
+        version:
+        - fastdds_ref: 'v2'
+          backend_ref: '1.x'
+        - fastdds_ref: 'v3'
+          backend_ref: 'main'
     name: reusable_tests
     uses: ./.github/workflows/reusable-workflow.yml
     with:
-      custom_version_build: ${{ matrix.custom_version_build }}
+      custom_version_build: ${{ matrix.version.fastdds_ref }}
       dependencies_artifact_postfix: '_nightly'
-      ref: ${{ matrix.ref }}
+      ref: ${{ matrix.version.backend_ref }}
     secrets: inherit

--- a/.github/workflows/reusable-workflow.yml
+++ b/.github/workflows/reusable-workflow.yml
@@ -282,6 +282,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
 
+      - name: Sync repository
+        uses: eProsima/eProsima-CI/external/checkout@v0
+        with:
+          path: src
+          ref: ${{ inputs.ref }}
+
       - name: Install libtinyxml in ubuntu
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
@@ -308,6 +314,12 @@ jobs:
   uncrustify:
     runs-on: ubuntu-22.04
     steps:
+
+      - name: Sync repository
+        uses: eProsima/eProsima-CI/external/checkout@v0
+        with:
+          path: src
+          ref: ${{ inputs.ref }}
 
       - name: Uncrustify
         uses: eProsima/eProsima-CI/ubuntu/uncrustify@v0


### PR DESCRIPTION
During the migration to Fast DDS v3, nightly job was updated but with wrong yaml nomenclature.
This PR fixes the job by adding a `version` layer between the `matrix` and the versioning.

[Manual Run here](https://github.com/eProsima/Fast-DDS-statistics-backend/actions/runs/10665491851)