### PR TITLE
[21817] Add EntityId getters and delete Endpoint kind prefixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -348,7 +348,9 @@ pygments_style = 'sphinx'
 
 suppress_warnings = [
     'cpp.duplicate_declaration',
-    'cpp.parse_function_declaration'
+    'cpp.parse_function_declaration',
+    'config.cache'
+
 ]
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.

--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -274,6 +274,28 @@ public:
             EntityId entity_id);
 
     /**
+     * @brief Returns the id of the topic associated to an endpoint.
+     *
+     * @param endpoint_id The ID of a given endpoint.
+     *
+     * @return EntityId of the topic on which the endpoint publishes/receives messages.
+     */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
+    static EntityId get_endpoint_topic_id(
+            EntityId endpoint_id);
+
+    /**
+     * @brief Returns the id of the domain to which a given entity (Domain, DomainParticipant, Topic, endpoints) belongs.
+     *
+     * @param entity_id The ID of a given entity.
+     *
+     * @return EntityId of the domain.
+     */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
+    static EntityId get_domain_id(
+            EntityId entity_id);
+
+    /**
      * @brief Provides access to the data measured during the monitoring.
      *
      * Use this function for data types that relate to two entities,

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -549,6 +549,18 @@ std::string StatisticsBackend::get_type_idl(
     return StatisticsBackendData::get_instance()->database_->get_type_idl(topic_info[DATA_TYPE_TAG]);
 }
 
+EntityId StatisticsBackend::get_endpoint_topic_id(
+        EntityId endpoint_id)
+{
+    return StatisticsBackendData::get_instance()->database_->get_endpoint_topic_id(endpoint_id);
+}
+
+EntityId StatisticsBackend::get_domain_id(
+        EntityId entity_id)
+{
+    return StatisticsBackendData::get_instance()->database_->get_domain_id(entity_id);
+}
+
 std::vector<StatisticsData> StatisticsBackend::get_data(
         DataKind data_type,
         const std::vector<EntityId>& entity_ids_source,

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -5347,7 +5347,7 @@ EntityId Database::get_endpoint_topic_id(
         const EntityId& endpoint_id)
 {
     std::shared_lock<std::shared_timed_mutex> lock(mutex_);
-    std::shared_ptr<const Entity> endpoint = get_entity_nts(endpoint_id); 
+    std::shared_ptr<const Entity> endpoint = get_entity_nts(endpoint_id);
 
     // Check if the entity is a valid endpoint
     if (endpoint->kind != EntityKind::DATAWRITER && endpoint->kind != EntityKind::DATAREADER)
@@ -5364,7 +5364,7 @@ EntityId Database::get_domain_id(
     std::shared_lock<std::shared_timed_mutex> lock(mutex_);
     std::shared_ptr<const Entity> entity = get_entity_nts(entity_id);
 
-    switch(entity->kind)
+    switch (entity->kind)
     {
         case EntityKind::DOMAIN:
         {
@@ -5390,6 +5390,7 @@ EntityId Database::get_domain_id(
     }
 
 }
+
 void Database::check_entity_kinds(
         EntityKind kind,
         const std::vector<EntityId>& entity_ids,

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -5343,6 +5343,53 @@ Info Database::get_info(
     return info;
 }
 
+EntityId Database::get_endpoint_topic_id(
+        const EntityId& endpoint_id)
+{
+    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+    std::shared_ptr<const Entity> endpoint = get_entity_nts(endpoint_id); 
+
+    // Check if the entity is a valid endpoint
+    if (endpoint->kind != EntityKind::DATAWRITER && endpoint->kind != EntityKind::DATAREADER)
+    {
+        throw BadParameter("Error: Entity is not a valid endpoint");
+    }
+
+    return std::dynamic_pointer_cast<const DDSEndpoint>(endpoint)->topic->id;
+}
+
+EntityId Database::get_domain_id(
+        const EntityId& entity_id)
+{
+    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+    std::shared_ptr<const Entity> entity = get_entity_nts(entity_id);
+
+    switch(entity->kind)
+    {
+        case EntityKind::DOMAIN:
+        {
+            return entity_id;
+        }
+        case EntityKind::PARTICIPANT:
+        {
+            return std::dynamic_pointer_cast<const DomainParticipant>(entity)->domain->id;
+        }
+        case EntityKind::TOPIC:
+        {
+            return std::dynamic_pointer_cast<const Topic>(entity)->domain->id;
+        }
+        case EntityKind::DATAWRITER:
+        case EntityKind::DATAREADER:
+        {
+            return std::dynamic_pointer_cast<const DDSEndpoint>(entity)->participant->domain->id;
+        }
+        default:
+        {
+            return EntityId::invalid();
+        }
+    }
+
+}
 void Database::check_entity_kinds(
         EntityKind kind,
         const std::vector<EntityId>& entity_ids,

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -713,7 +713,7 @@ public:
      */
     EntityId get_domain_id(
             const EntityId& entity_id);
-    
+
     /**
      * @brief Check if the entities passed correspond to the specified entity kind.
      *

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -695,6 +695,26 @@ public:
             const EntityId& entity_id);
 
     /**
+     * @brief Returns the id of the topic associated to an endpoint.
+     *
+     * @param endpoint_id The ID of a given endpoint.
+     *
+     * @return EntityId of the topic on which the endpoint publishes/receives messages.
+     */
+    EntityId get_endpoint_topic_id(
+            const EntityId& endpoint_id);
+
+    /**
+     * @brief Returns the id of the domain associated to a given entity (Domain, Participant, topic and endpoint).
+     *
+     * @param entity_id The ID of an entity.
+     *
+     * @return EntityId of the domain which the entity belongs.
+     */
+    EntityId get_domain_id(
+            const EntityId& entity_id);
+    
+    /**
      * @brief Check if the entities passed correspond to the specified entity kind.
      *
      * @param kind The expected EntityKind of the entities provided.

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -190,7 +190,7 @@ EntityId DatabaseEntityQueue::process_datareader(
             if (participant_id.first != info.domain_id)
             {
                 throw BadParameter("Participant " + to_string(participant_guid)
-                          +  " found in the database but it is not in the current domain");
+                              +  " found in the database but it is not in the current domain");
             }
         }
         catch (const Exception&)
@@ -265,7 +265,7 @@ EntityId DatabaseEntityQueue::process_datawriter(
             if (participant_id.first != info.domain_id)
             {
                 throw BadParameter("Participant " + to_string(participant_guid)
-                          +  " found in the database but it is not in the current domain");
+                              +  " found in the database but it is not in the current domain");
             }
         }
         catch (const Exception&)
@@ -328,7 +328,7 @@ EntityId DatabaseEntityQueue::process_endpoint_discovery(
         if (participant_id.first != info.domain_id)
         {
             throw BadParameter("Participant " + to_string(participant_guid)
-                        +  " found in the database but it is not in the current domain");
+                          +  " found in the database but it is not in the current domain");
         }
     }
     catch (const Exception&)
@@ -377,15 +377,7 @@ EntityId DatabaseEntityQueue::process_endpoint_discovery(
     // Create the endpoint
     EntityId endpoint_id;
     std::stringstream name;
-
-    if (info.kind() == EntityKind::DATAREADER)
-    {
-        name << info.topic_name << "_" << info.guid.entityId;
-    }
-    else
-    {
-        name << info.topic_name << "_" << info.guid.entityId;
-    }
+    name << info.topic_name << "_" << info.guid.entityId;
 
     // Endpoint AppId and metadata
     // TODO: get app data from info (parameters), not from participant

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -380,11 +380,11 @@ EntityId DatabaseEntityQueue::process_endpoint_discovery(
 
     if (info.kind() == EntityKind::DATAREADER)
     {
-        name << "DataReader_" << info.topic_name << "_" << info.guid.entityId;
+        name << info.topic_name << "_" << info.guid.entityId;
     }
     else
     {
-        name << "DataWriter_" << info.topic_name << "_" << info.guid.entityId;
+        name << info.topic_name << "_" << info.guid.entityId;
     }
 
     // Endpoint AppId and metadata

--- a/test/dds/communication/Communication.hpp
+++ b/test/dds/communication/Communication.hpp
@@ -80,9 +80,9 @@ public:
     eProsima_user_DllExport Communication(
             const Communication& x)
     {
-                    m_index = x.m_index;
+        m_index = x.m_index;
 
-                    m_message = x.m_message;
+        m_message = x.m_message;
 
     }
 
@@ -105,9 +105,9 @@ public:
             const Communication& x)
     {
 
-                    m_index = x.m_index;
+        m_index = x.m_index;
 
-                    m_message = x.m_message;
+        m_message = x.m_message;
 
         return *this;
     }
@@ -133,7 +133,7 @@ public:
             const Communication& x) const
     {
         return (m_index == x.m_index &&
-           m_message == x.m_message);
+               m_message == x.m_message);
     }
 
     /*!
@@ -174,7 +174,6 @@ public:
         return m_index;
     }
 
-
     /*!
      * @brief This function copies the value in member message
      * @param _message New value to be copied in member message
@@ -212,8 +211,6 @@ public:
     {
         return m_message;
     }
-
-
 
 private:
 

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -1356,7 +1356,7 @@ TEST_F(database_queue_tests, push_datawriter)
     std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     // Create the writer info
-    std::string datawriter_name = "DataWriter_topic_name_0.0.0.1";  //< Name constructed from the topic and entity_id
+    std::string datawriter_name = "topic_name_0.0.0.1";  //< Name constructed from the topic and entity_id
     Qos datawriter_qos;
     std::string datawriter_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.1";
     std::string topic_name = "topic_name";
@@ -1594,7 +1594,7 @@ TEST_F(database_queue_tests, push_datawriter_topic_does_not_exist)
     std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     // Create the writer info
-    std::string datawriter_name = "DataWriter_topic_name_0.0.0.1";  //< Name constructed from the topic and entity_id
+    std::string datawriter_name = "topic_name_0.0.0.1";  //< Name constructed from the topic and entity_id
     Qos datawriter_qos;
     std::string datawriter_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.1";
     std::string topic_name = "topic_name";
@@ -1720,7 +1720,7 @@ TEST_F(database_queue_tests, push_datareader)
     std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     // Create the reader info
-    std::string datareader_name = "DataReader_topic_name_0.0.0.2";  //< Name constructed from the topic and entity_id
+    std::string datareader_name = "topic_name_0.0.0.2";  //< Name constructed from the topic and entity_id
     Qos datareader_qos;
     std::string datareader_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.2";
     std::string topic_name = "topic_name";
@@ -1958,7 +1958,7 @@ TEST_F(database_queue_tests, push_datareader_topic_does_not_exist)
     std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
     // Create the reader info
-    std::string datareader_name = "DataReader_topic_name_0.0.0.2";  //< Name constructed from the topic and entity_id
+    std::string datareader_name = "topic_name_0.0.0.2";  //< Name constructed from the topic and entity_id
     Qos datareader_qos;
     std::string datareader_guid_str = "01.02.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.2";
     std::string topic_name = "topic_name";

--- a/test/unittest/StatisticsParticipantListener/StatisticsParticipantListenerTests.cpp
+++ b/test/unittest/StatisticsParticipantListener/StatisticsParticipantListenerTests.cpp
@@ -417,7 +417,7 @@ public:
         metatraffic_topic_ = std::make_shared<Topic>(metatraffic_topic_name_, metatraffic_type_name_, domain_);
 
         // Metatraffic Endpoint entity
-        metatraffic_endpoint_name_ = "DataWriter_" + metatraffic_prefix + "TOPIC_0.0.1.c1";
+        metatraffic_endpoint_name_ = metatraffic_prefix + "TOPIC_0.0.1.c1";
         metatraffic_qos_ = {{"description", "This is a virtual placeholder endpoint with no real counterpart"}};
         metatraffic_endpoint_ = std::make_shared<DataWriter>(metatraffic_endpoint_name_, metatraffic_qos_,
                         participant_guid_str_, participant_, metatraffic_topic_);
@@ -552,7 +552,7 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered)
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, participant_guid_str_);
-                EXPECT_EQ(name, "DataWriter_" + metatraffic_prefix + "TOPIC_0.0.1.c1");
+                EXPECT_EQ(name, metatraffic_prefix + "TOPIC_0.0.1.c1");
                 EXPECT_EQ(alias, "_metatraffic_");
                 EXPECT_EQ(qos, metatraffic_qos_);
                 EXPECT_EQ(is_virtual_metatraffic, true);
@@ -749,7 +749,7 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_not_fir
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, participant_2_guid_str);
-                EXPECT_EQ(name, "DataWriter_" + metatraffic_prefix + "TOPIC_0.0.1.c1");
+                EXPECT_EQ(name, metatraffic_prefix + "TOPIC_0.0.1.c1");
                 EXPECT_EQ(alias, "_metatraffic_");
                 EXPECT_EQ(qos, metatraffic_qos_);
                 EXPECT_EQ(is_virtual_metatraffic, true);
@@ -963,7 +963,7 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_empty_n
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, participant_guid_str_);
-                EXPECT_EQ(name, "DataWriter_" + metatraffic_prefix + "TOPIC_0.0.1.c1");
+                EXPECT_EQ(name, metatraffic_prefix + "TOPIC_0.0.1.c1");
                 EXPECT_EQ(alias, "_metatraffic_");
                 EXPECT_EQ(qos, metatraffic_qos_);
                 EXPECT_EQ(is_virtual_metatraffic, true);
@@ -1201,7 +1201,7 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_empty_n
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, participant_guid_str_);
-                EXPECT_EQ(name, "DataWriter_" + metatraffic_prefix + "TOPIC_0.0.1.c1");
+                EXPECT_EQ(name, metatraffic_prefix + "TOPIC_0.0.1.c1");
                 EXPECT_EQ(alias, "_metatraffic_");
                 EXPECT_EQ(qos, metatraffic_qos_);
                 EXPECT_EQ(is_virtual_metatraffic, true);
@@ -1427,7 +1427,7 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_empty_n
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, participant_guid_str_);
-                EXPECT_EQ(name, "DataWriter_" + metatraffic_prefix + "TOPIC_0.0.1.c1");
+                EXPECT_EQ(name, metatraffic_prefix + "TOPIC_0.0.1.c1");
                 EXPECT_EQ(alias, "_metatraffic_");
                 EXPECT_EQ(qos, metatraffic_qos_);
                 EXPECT_EQ(is_virtual_metatraffic, true);
@@ -1658,7 +1658,7 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_empty_n
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, participant_guid_str_);
-                EXPECT_EQ(name, "DataWriter_" + metatraffic_prefix + "TOPIC_0.0.1.c1");
+                EXPECT_EQ(name, metatraffic_prefix + "TOPIC_0.0.1.c1");
                 EXPECT_EQ(alias, "_metatraffic_");
                 EXPECT_EQ(qos, metatraffic_qos_);
                 EXPECT_EQ(is_virtual_metatraffic, true);
@@ -1855,7 +1855,7 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_empty_n
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, participant_guid_str_);
-                EXPECT_EQ(name, "DataWriter_" + metatraffic_prefix + "TOPIC_0.0.1.c1");
+                EXPECT_EQ(name, metatraffic_prefix + "TOPIC_0.0.1.c1");
                 EXPECT_EQ(alias, "_metatraffic_");
                 EXPECT_EQ(qos, metatraffic_qos_);
                 EXPECT_EQ(is_virtual_metatraffic, true);
@@ -2085,7 +2085,7 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_empty_n
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, participant_guid_str_);
-                EXPECT_EQ(name, "DataWriter_" + metatraffic_prefix + "TOPIC_0.0.1.c1");
+                EXPECT_EQ(name, metatraffic_prefix + "TOPIC_0.0.1.c1");
                 EXPECT_EQ(alias, "_metatraffic_");
                 EXPECT_EQ(qos, metatraffic_qos_);
                 EXPECT_EQ(is_virtual_metatraffic, true);
@@ -2420,7 +2420,7 @@ TEST_F(statistics_participant_listener_tests, new_reader_discovered)
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, reader_guid_str_);
-                EXPECT_EQ(name, std::string("DataReader_") + topic_->name + "_" + reader_entity_id_str_);
+                EXPECT_EQ(name, topic_->name + "_" + reader_entity_id_str_);
                 EXPECT_EQ(alias, "");
                 EXPECT_EQ(qos, reader_proxy_data_to_backend_qos(data));
                 EXPECT_EQ(is_virtual_metatraffic, false);
@@ -2593,7 +2593,7 @@ TEST_F(statistics_participant_listener_tests, new_reader_no_topic)
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, reader_guid_str_);
-                EXPECT_EQ(name, std::string("DataReader_") + topic_->name + "_" + reader_entity_id_str_);
+                EXPECT_EQ(name, topic_->name + "_" + reader_entity_id_str_);
                 EXPECT_EQ(alias, "");
                 EXPECT_EQ(qos, reader_proxy_data_to_backend_qos(data));
                 EXPECT_EQ(is_virtual_metatraffic, false);
@@ -2728,7 +2728,7 @@ TEST_F(statistics_participant_listener_tests, new_reader_several_topics)
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, reader_guid_str_);
-                EXPECT_EQ(name, std::string("DataReader_") + topic_->name + "_" + reader_entity_id_str_);
+                EXPECT_EQ(name, topic_->name + "_" + reader_entity_id_str_);
                 EXPECT_EQ(alias, "");
                 EXPECT_EQ(qos, reader_proxy_data_to_backend_qos(data));
                 EXPECT_EQ(is_virtual_metatraffic, false);
@@ -2873,7 +2873,7 @@ TEST_F(statistics_participant_listener_tests, new_reader_several_locators)
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, reader_guid_str_);
-                EXPECT_EQ(name, std::string("DataReader_") + topic_->name + "_" + reader_entity_id_str_);
+                EXPECT_EQ(name, topic_->name + "_" + reader_entity_id_str_);
                 EXPECT_EQ(alias, "");
                 EXPECT_EQ(qos, reader_proxy_data_to_backend_qos(data));
                 EXPECT_EQ(is_virtual_metatraffic, false);
@@ -3025,7 +3025,7 @@ TEST_F(statistics_participant_listener_tests, new_reader_several_locators_no_hos
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, reader_guid_str_);
-                EXPECT_EQ(name, std::string("DataReader_") + topic_->name + "_" + reader_entity_id_str_);
+                EXPECT_EQ(name, topic_->name + "_" + reader_entity_id_str_);
                 EXPECT_EQ(alias, "");
                 EXPECT_EQ(qos, reader_proxy_data_to_backend_qos(data));
                 EXPECT_EQ(is_virtual_metatraffic, false);
@@ -3380,7 +3380,7 @@ TEST_F(statistics_participant_listener_tests, new_writer_discovered)
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, writer_guid_str_);
-                EXPECT_EQ(name, std::string("DataWriter_") + topic_->name + "_" + writer_entity_id_str_);
+                EXPECT_EQ(name, topic_->name + "_" + writer_entity_id_str_);
                 EXPECT_EQ(alias, "");
                 EXPECT_EQ(qos, writer_proxy_data_to_backend_qos(data));
                 EXPECT_EQ(is_virtual_metatraffic, false);
@@ -3553,7 +3553,7 @@ TEST_F(statistics_participant_listener_tests, new_writer_no_topic)
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, writer_guid_str_);
-                EXPECT_EQ(name, std::string("DataWriter_") + topic_->name + "_" + writer_entity_id_str_);
+                EXPECT_EQ(name, topic_->name + "_" + writer_entity_id_str_);
                 EXPECT_EQ(alias, "");
                 EXPECT_EQ(qos, writer_proxy_data_to_backend_qos(data));
                 EXPECT_EQ(is_virtual_metatraffic, false);
@@ -3705,7 +3705,7 @@ TEST_F(statistics_participant_listener_tests, new_writer_several_locators)
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, writer_guid_str_);
-                EXPECT_EQ(name, std::string("DataWriter_") + topic_->name + "_" + writer_entity_id_str_);
+                EXPECT_EQ(name, topic_->name + "_" + writer_entity_id_str_);
                 EXPECT_EQ(alias, "");
                 EXPECT_EQ(qos, writer_proxy_data_to_backend_qos(data));
                 EXPECT_EQ(is_virtual_metatraffic, false);
@@ -3851,7 +3851,7 @@ TEST_F(statistics_participant_listener_tests, new_writer_several_locators_no_hos
                 const std::pair<AppId, std::string> app_data)
             {
                 EXPECT_EQ(endpoint_guid, writer_guid_str_);
-                EXPECT_EQ(name, std::string("DataWriter_") + topic_->name + "_" + writer_entity_id_str_);
+                EXPECT_EQ(name, topic_->name + "_" + writer_entity_id_str_);
                 EXPECT_EQ(alias, "");
                 EXPECT_EQ(qos, writer_proxy_data_to_backend_qos(data));
                 EXPECT_EQ(is_virtual_metatraffic, false);


### PR DESCRIPTION
# Main changes

Minor changes to improve endpoints display and topic traceability in Fast DDS Monitor

It depends of:
- https://github.com/eProsima/Fast-DDS-monitor/pull/238