### PR TITLE
[22482]: Update IDL when new type received

### DIFF
--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -295,6 +295,11 @@ void Database::insert_new_type_idl(
     {
         throw BadParameter("Type name cannot be empty");
     }
+
+    if (is_type_in_database(type_name) && type_idl.empty())
+    {
+        return;
+    }
     type_idls_[type_name] = type_idl;
 }
 

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -166,7 +166,7 @@ public:
             const std::string& type_name);
 
     /**
-     * @brief Insert a new type IDL into the database.
+     * @brief Insert a new type IDL into the database or update it.
      * @param topic_type The type of the topic.
      * @param topic_idl The IDL representation of the type
      */

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -368,8 +368,8 @@ EntityId DatabaseEntityQueue::process_endpoint_discovery(
             details::StatisticsBackendData::DiscoveryStatus::DISCOVERY);
     }
 
-    // Store type IDL in the database if available and in case it is not already stored. Ignore metatraffic topics
-    if (!database_->is_type_in_database(info.type_name) && !info.is_virtual_metatraffic)
+    // Store type IDL in the database Ignore metatraffic topics
+    if (!info.is_virtual_metatraffic)
     {
         database_->insert_new_type_idl(info.type_name, info.type_idl);
     }

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -1391,8 +1391,7 @@ TEST_F(database_queue_tests, push_datawriter)
             std::make_pair(EntityId(0), EntityId(2)))));
     EXPECT_CALL(database, is_topic_in_database(_, EntityId(2))).Times(AnyNumber())
             .WillRepeatedly(Return(true));
-    EXPECT_CALL(database, is_type_in_database(type_name)).Times(AnyNumber())
-            .WillRepeatedly(Return(true));
+    EXPECT_CALL(database, insert_new_type_idl(type_name, "")).Times(AnyNumber());
 
     // Datawriter undiscovery: FAILURE
     {
@@ -1687,7 +1686,6 @@ TEST_F(database_queue_tests, push_datawriter_topic_does_not_exist)
                 .WillOnce(Invoke(&insert_datawriter_args, &InsertEndpointArgs::insert));
 
         // Expectation: Add the type to the database
-        EXPECT_CALL(database, is_type_in_database(type_name)).Times(1).WillOnce(Return(false));
         EXPECT_CALL(database, insert_new_type_idl(type_name, "")).Times(1);
 
         // Expectation: Modify graph and notify user
@@ -1755,8 +1753,7 @@ TEST_F(database_queue_tests, push_datareader)
             std::make_pair(EntityId(0), EntityId(2)))));
     EXPECT_CALL(database, is_topic_in_database(_, EntityId(2))).Times(AnyNumber())
             .WillRepeatedly(Return(true));
-    EXPECT_CALL(database, is_type_in_database(type_name)).Times(AnyNumber())
-            .WillRepeatedly(Return(true));
+    EXPECT_CALL(database, insert_new_type_idl(type_name, "")).Times(AnyNumber());
 
     // Datareader undiscovery: FAILURE
     {
@@ -2050,7 +2047,6 @@ TEST_F(database_queue_tests, push_datareader_topic_does_not_exist)
                 .WillOnce(Invoke(&insert_datareader_args, &InsertEndpointArgs::insert));
 
         // Expectation: Add the type to the database
-        EXPECT_CALL(database, is_type_in_database(type_name)).Times(1).WillOnce(Return(false));
         EXPECT_CALL(database, insert_new_type_idl(type_name, "")).Times(1);
 
         // Expectation: Modify graph and notify user

--- a/test/unittest/StatisticsParticipantListener/StatisticsParticipantListenerTests.cpp
+++ b/test/unittest/StatisticsParticipantListener/StatisticsParticipantListenerTests.cpp
@@ -609,7 +609,6 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered)
         eprosima::statistics_backend::details::StatisticsBackendData::DiscoveryStatus::DISCOVERY)).Times(1);
 
     // Expectation: Metatraffic type is ignored
-    EXPECT_CALL(database, is_type_in_database(metatraffic_type_name_)).Times(1).WillOnce(Return(false));
     EXPECT_CALL(database, insert_new_type_idl(metatraffic_type_name_, "")).Times(0);
 
     // Execution: Call the listener
@@ -705,8 +704,6 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_not_fir
             .WillOnce(Invoke(&insert_args, &InsertParticipantArgs::insert));
 
     // Expectation: Metatraffic topic types are ignored
-    EXPECT_CALL(database, is_type_in_database(metatraffic_type_name_)).Times(1)
-            .WillOnce(Return(false));
     EXPECT_CALL(database, insert_new_type_idl(metatraffic_type_name_, "")).Times(0);
 
     // Expectation: The host already exists with ID 13, the user already exists with ID 14 and the process already exists with ID 15
@@ -945,8 +942,6 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_empty_n
             .WillOnce(Invoke(&insert_topic_args, &InsertTopicArgs::insert));
 
     // Expectation: Metatraffic topic types are ignored
-    EXPECT_CALL(database, is_type_in_database(metatraffic_type_name_)).Times(1)
-            .WillOnce(Return(false));
     EXPECT_CALL(database, insert_new_type_idl(metatraffic_prefix + "TYPE", "")).Times(0);
 
     // Expectation: The Metatraffic Endpoint is added to the database. We do not care about the given ID
@@ -1138,8 +1133,6 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_empty_n
             .WillOnce(Invoke(&insert_args, &InsertParticipantArgs::insert));
 
     // Expectation: Metatraffic topic types are ignored
-    EXPECT_CALL(database, is_type_in_database(metatraffic_type_name_)).Times(1)
-            .WillOnce(Return(false));
     EXPECT_CALL(database, insert_new_type_idl(metatraffic_prefix + "TYPE", "")).Times(0);
 
     // Expectation: The host is created and given ID 13, the user is created and given ID 14 and the process is created and given ID 15
@@ -1365,8 +1358,6 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_empty_n
             .WillOnce(Invoke(&insert_args, &InsertParticipantArgs::insert));
 
     // Expectation: Metatraffic topic types are ignored
-    EXPECT_CALL(database, is_type_in_database(metatraffic_type_name_)).Times(1)
-            .WillOnce(Return(false));
     EXPECT_CALL(database, insert_new_type_idl(metatraffic_type_name_, "")).Times(0);
 
     // Expectation: The host is created and given ID 13, the user is created and given ID 14 and the process is created and given ID 15
@@ -1596,8 +1587,6 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_empty_n
             .WillOnce(Invoke(&insert_args, &InsertParticipantArgs::insert));
 
     // Expectation: Metatraffic topic types are ignored
-    EXPECT_CALL(database, is_type_in_database(metatraffic_type_name_)).Times(1)
-            .WillOnce(Return(false));
     EXPECT_CALL(database, insert_new_type_idl(metatraffic_type_name_, "")).Times(0);
 
     // Expectation: The host is created and given ID 13, the user is created and given ID 14 and the process is created and given ID 15
@@ -1793,9 +1782,6 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_empty_n
             .WillOnce(Invoke(&insert_args, &InsertParticipantArgs::insert));
 
     // Expectation: Metatraffic topic types are ignored
-    EXPECT_CALL(database, is_type_in_database(metatraffic_type_name_)).Times(1)
-            .WillOnce(Return(false));
-
     EXPECT_CALL(database, insert_new_type_idl(metatraffic_type_name_, "")).Times(0);
     // Expectation: The host is created and given ID 13, the user is created and given ID 14 and the process is created and given ID 15
     ProcessPhysicalArgs process_physical_args([&](
@@ -2023,8 +2009,6 @@ TEST_F(statistics_participant_listener_tests, new_participant_discovered_empty_n
             .WillOnce(Invoke(&insert_args, &InsertParticipantArgs::insert));
 
     // Expectation: Metatraffic topic types are ignored
-    EXPECT_CALL(database, is_type_in_database(metatraffic_type_name_)).Times(1)
-            .WillOnce(Return(false));
     EXPECT_CALL(database, insert_new_type_idl(metatraffic_type_name_, "")).Times(0);
 
     // Expectation: The host is created and given ID 13, the user is created and given ID 14 and the process is created and given ID 15
@@ -2443,9 +2427,7 @@ TEST_F(statistics_participant_listener_tests, new_reader_discovered)
     // Precondition: The reader change it status
     EXPECT_CALL(database, change_entity_status(EntityId(10), true)).Times(1);
 
-    // Expectation: Type is already added to the database
-    EXPECT_CALL(database, is_type_in_database(type_name_)).Times(1)
-            .WillOnce(Return(true));
+    EXPECT_CALL(database, insert_new_type_idl(type_name_, "")).Times(1);
 
     // Expectation: Modify graph and notify user
     EXPECT_CALL(database,
@@ -2618,8 +2600,6 @@ TEST_F(statistics_participant_listener_tests, new_reader_no_topic)
     EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
 
     // Expectation: Add type to the database
-    EXPECT_CALL(database, is_type_in_database(type_name_)).Times(1)
-            .WillOnce(Return(false));
     EXPECT_CALL(database, insert_new_type_idl(type_name_, "")).Times(1);
 
     // Expectation: Modify graph and notify user (twice, also from participant update)
@@ -2752,9 +2732,7 @@ TEST_F(statistics_participant_listener_tests, new_reader_several_topics)
     // Precondition: The reader change it status
     EXPECT_CALL(database, change_entity_status(EntityId(10), true)).Times(1);
 
-    // Expectation: Type is already added to the database
-    EXPECT_CALL(database, is_type_in_database(type_name_)).Times(1)
-            .WillOnce(Return(true));
+    EXPECT_CALL(database, insert_new_type_idl(type_name_, "")).Times(1);
 
     // Expectation: Modify graph and notify user (twice, also from participant update)
     EXPECT_CALL(database,
@@ -2900,9 +2878,7 @@ TEST_F(statistics_participant_listener_tests, new_reader_several_locators)
     // Precondition: The reader change it status
     EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
 
-    // Expectation: Type already added to the database
-    EXPECT_CALL(database, is_type_in_database(type_name_)).Times(1)
-            .WillOnce(Return(true));
+    EXPECT_CALL(database, insert_new_type_idl(type_name_, "")).Times(1);
 
     // Expectation: Modify graph and notify user (twice, also from participant update)
     EXPECT_CALL(database,
@@ -3052,9 +3028,7 @@ TEST_F(statistics_participant_listener_tests, new_reader_several_locators_no_hos
     // Precondition: The reader change it status
     EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
 
-    // Expectation: Type already added to the database
-    EXPECT_CALL(database, is_type_in_database(type_name_)).Times(1)
-            .WillOnce(Return(true));
+    EXPECT_CALL(database, insert_new_type_idl(type_name_, "")).Times(1);
 
     // Expectation: Modify graph and notify user (twice, also from participant update)
     EXPECT_CALL(database,
@@ -3403,9 +3377,7 @@ TEST_F(statistics_participant_listener_tests, new_writer_discovered)
     // Precondition: The writer change it status
     EXPECT_CALL(database, change_entity_status(EntityId(10), true)).Times(1);
 
-    // Expectation: Type already added to the database
-    EXPECT_CALL(database, is_type_in_database(type_name_)).Times(1)
-            .WillOnce(Return(true));
+    EXPECT_CALL(database, insert_new_type_idl(type_name_, "")).Times(1);
 
     // Expectation: Modify graph and notify user
     EXPECT_CALL(database,
@@ -3577,9 +3549,6 @@ TEST_F(statistics_participant_listener_tests, new_writer_no_topic)
     // Precondition: The writer change it status
     EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
 
-    // Expectation: Add the type to the database
-    EXPECT_CALL(database, is_type_in_database(type_name_)).Times(1)
-            .WillOnce(Return(false));
     EXPECT_CALL(database, insert_new_type_idl(type_name_, "")).Times(1);
 
     // Expectation: Modify graph and notify user (twice, also from participant update)
@@ -3732,9 +3701,7 @@ TEST_F(statistics_participant_listener_tests, new_writer_several_locators)
     // Precondition: The writer change it status
     EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
 
-    // Expectation: Type already added to the database
-    EXPECT_CALL(database, is_type_in_database(type_name_)).Times(1)
-            .WillOnce(Return(true));
+    EXPECT_CALL(database, insert_new_type_idl(type_name_, "")).Times(1);
 
     // Expectation: Modify graph and notify user (twice, also from participant update)
     EXPECT_CALL(database,
@@ -3878,9 +3845,7 @@ TEST_F(statistics_participant_listener_tests, new_writer_several_locators_no_hos
     // Precondition: The writer change it status
     EXPECT_CALL(database, change_entity_status(EntityId(11), true)).Times(1);
 
-    // Expectation: Type already added to the database
-    EXPECT_CALL(database, is_type_in_database(type_name_)).Times(1)
-            .WillOnce(Return(true));
+    EXPECT_CALL(database, insert_new_type_idl(type_name_, "")).Times(1);
 
     // Expectation: Modify graph and notify user (twice, also from participant update)
     EXPECT_CALL(database,


### PR DESCRIPTION
# Main Changes

This PR fix some problems when displaying type IDLs in Fast DDS Monitor. Type IDLs map is not updated after receiving the first endpoint discovery info, so types are not updated in case of running an endpoint without publishing type info before running another endpoint publishing it