### PR TITLE
[22894] Apply demangling to ROS 2 topics in IDL view

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Find more about us at [eProsima’s webpage](https://eprosima.com/).
 
 ## Documentation
 
-You can access the documentation online, which is hosted on [Read the Docs](https://eprosima-dds-router.readthedocs.io).
+You can access the documentation online, which is hosted on [Read the Docs](https://fast-dds-statistics-backend.readthedocs.io).
 
 * [Introduction](https://fast-dds-statistics-backend.readthedocs.io/en/latest/)
 * [Installation Manual](https://fast-dds-statistics-backend.readthedocs.io/en/latest/rst/installation/linux_installation.html)

--- a/docs/rst/spelling_wordlist.txt
+++ b/docs/rst/spelling_wordlist.txt
@@ -10,6 +10,7 @@ Colcon
 datareader
 datasharing
 datawriter
+demangled
 Deserialize
 destructor
 eprosima

--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -283,7 +283,7 @@ public:
     FASTDDS_STATISTICS_BACKEND_DllAPI
     static std::string get_type_idl(
             EntityId entity_id);
-            
+
     /**
      * @brief Get the demangled type name in string format for a given topic entity, if it exists, for display purposes.
      *

--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -275,13 +275,33 @@ public:
             EntityId entity_id);
 
     /**
-     * @brief Get the IDL representation of a data type in string format for a given topic entity
+     * @brief Get the IDL representation of a data type in string format for a given topic entity.
      *
      * @param entity_id The entity for which the data type IDL is retrieved.
      * @return String object describing the entity's data type IDL.
      */
     FASTDDS_STATISTICS_BACKEND_DllAPI
     static std::string get_type_idl(
+            EntityId entity_id);
+            
+    /**
+     * @brief Get the demangled type name in string format for a given topic entity, if it exists, for display purposes.
+     *
+     * @param entity_id The entity for which the data type IDL is retrieved.
+     * @return String object describing the entity's data type IDL.
+     */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
+    static std::string get_ros2_type_name(
+            EntityId entity_id);
+
+    /**
+     * @brief Get the ROS 2 IDL representation of a data type in string format for a given topic entity, if it exists.
+     *
+     * @param entity_id The entity for which the data type IDL is retrieved.
+     * @return String object describing the entity's data type IDL.
+     */
+    FASTDDS_STATISTICS_BACKEND_DllAPI
+    static std::string get_ros2_type_idl(
             EntityId entity_id);
 
     /**

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -559,6 +559,30 @@ std::string StatisticsBackend::get_type_idl(
     return StatisticsBackendData::get_instance()->database_->get_type_idl(topic_info[DATA_TYPE_TAG]);
 }
 
+std::string StatisticsBackend::get_ros2_type_name(
+    EntityId entity_id)
+{
+    // Check if the entity is a topic
+    if (EntityKind::TOPIC != get_type(entity_id))
+    {
+        throw BadParameter("EntityId received does not match with a valid topic entity");
+    }
+    Info topic_info = StatisticsBackend::get_info(entity_id);
+    return StatisticsBackendData::get_instance()->database_->get_ros2_type_name(topic_info[DATA_TYPE_TAG]);
+}
+
+std::string StatisticsBackend::get_ros2_type_idl(
+    EntityId entity_id)
+{
+    // Check if the entity is a topic
+    if (EntityKind::TOPIC != get_type(entity_id))
+    {
+        throw BadParameter("EntityId received does not match with a valid topic entity");
+    }
+    Info topic_info = StatisticsBackend::get_info(entity_id);
+    return StatisticsBackendData::get_instance()->database_->get_ros2_type_idl(topic_info[DATA_TYPE_TAG]);
+}
+
 EntityId StatisticsBackend::get_endpoint_topic_id(
         EntityId endpoint_id)
 {

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -560,7 +560,7 @@ std::string StatisticsBackend::get_type_idl(
 }
 
 std::string StatisticsBackend::get_ros2_type_name(
-    EntityId entity_id)
+        EntityId entity_id)
 {
     // Check if the entity is a topic
     if (EntityKind::TOPIC != get_type(entity_id))
@@ -572,7 +572,7 @@ std::string StatisticsBackend::get_ros2_type_name(
 }
 
 std::string StatisticsBackend::get_ros2_type_idl(
-    EntityId entity_id)
+        EntityId entity_id)
 {
     // Check if the entity is a topic
     if (EntityKind::TOPIC != get_type(entity_id))

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -333,11 +333,11 @@ void Database::insert_new_type_idl(
                 //First: delete the module dds_ identification, and the open brace
                 size_t pos_start = type_idl_demangled.find("module dds_\n");
                 size_t pos_open_brace = type_idl_demangled.find("{", pos_start);
-                type_idl_demangled.erase(pos_start, pos_open_brace - pos_start + 1);
+                type_idl_demangled.erase(pos_start, pos_open_brace - pos_start + 2);
 
                 //Second: find next line, and delete dangling whitespace
                 size_t pos_line = type_idl_demangled.find_first_not_of(" ", pos_start);
-                type_idl_demangled.erase(pos_start, pos_line);
+                type_idl_demangled.erase(pos_start, pos_line - pos_start);
 
                 //Third: unindent all the content
                 pos_start = type_idl_demangled.find("   ", pos_start);
@@ -350,7 +350,7 @@ void Database::insert_new_type_idl(
 
                 //Fourth: delete the closing brace and whitespace
                 size_t pos_end = type_idl_demangled.find("};", pos_start);
-                type_idl_demangled.erase(pos_start, pos_end - pos_start + 2);
+                type_idl_demangled.erase(pos_start - 1, pos_end - pos_start + 3);
             }
 
             //Step 2: delete the ::dds_:: namespace

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -307,7 +307,9 @@ void Database::insert_new_type_idl(
 
     lock.unlock();
 
-    if (type_idl.find("module dds_\n") != std::string::npos || type_idl.find("::dds_::") != std::string::npos)
+    if (type_idl.find("module dds_\n") != std::string::npos
+    || type_idl.find("::dds_::") != std::string::npos
+    || type_name.find("dds_") != std::string::npos)
     {
         //Perform the demangling operations
 
@@ -2580,6 +2582,55 @@ std::string Database::get_type_idl_nts(
         return it->second;
     }
     throw BadParameter("Type " + type_name + " not found in the database");
+}
+
+std::string Database::get_ros2_type_name(
+    const std::string& type_name) const
+{
+std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+return get_ros2_type_name_nts(type_name);
+}
+
+std::string Database::get_ros2_type_name_nts(
+    const std::string& type_name) const
+{
+    auto it = type_ros2_modified_name_.find(type_name);
+    if (it != type_ros2_modified_name_.end())
+    {
+        // The type was demangled
+        return it->second;
+    }
+    else
+    {
+        auto it_non_ros2 = type_idls_.find(type_name);
+        if (it_non_ros2 != type_idls_.end())
+        {
+            return type_name;
+        }
+        throw BadParameter("Type " + type_name + " not found in the database");
+    }
+}
+
+std::string Database::get_ros2_type_idl(
+    const std::string& type_name) const
+{
+std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+return get_ros2_type_idl_nts(type_name);
+}
+
+std::string Database::get_ros2_type_idl_nts(
+    const std::string& type_name) const
+{
+    auto it = type_ros2_unmodified_idl_.find(type_name);
+    if (it != type_ros2_unmodified_idl_.end())
+    {
+        // The type was demangled
+        return it->second;
+    }
+    else
+    {
+        return get_type_idl_nts(type_name);
+    }
 }
 
 void Database::erase(

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -308,8 +308,8 @@ void Database::insert_new_type_idl(
     lock.unlock();
 
     if (type_idl.find("module dds_\n") != std::string::npos
-    || type_idl.find("::dds_::") != std::string::npos
-    || type_name.find("dds_") != std::string::npos)
+            || type_idl.find("::dds_::") != std::string::npos
+            || type_name.find("dds_") != std::string::npos)
     {
         //Perform the demangling operations
 
@@ -2585,14 +2585,14 @@ std::string Database::get_type_idl_nts(
 }
 
 std::string Database::get_ros2_type_name(
-    const std::string& type_name) const
+        const std::string& type_name) const
 {
-std::shared_lock<std::shared_timed_mutex> lock(mutex_);
-return get_ros2_type_name_nts(type_name);
+    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+    return get_ros2_type_name_nts(type_name);
 }
 
 std::string Database::get_ros2_type_name_nts(
-    const std::string& type_name) const
+        const std::string& type_name) const
 {
     auto it = type_ros2_modified_name_.find(type_name);
     if (it != type_ros2_modified_name_.end())
@@ -2612,14 +2612,14 @@ std::string Database::get_ros2_type_name_nts(
 }
 
 std::string Database::get_ros2_type_idl(
-    const std::string& type_name) const
+        const std::string& type_name) const
 {
-std::shared_lock<std::shared_timed_mutex> lock(mutex_);
-return get_ros2_type_idl_nts(type_name);
+    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+    return get_ros2_type_idl_nts(type_name);
 }
 
 std::string Database::get_ros2_type_idl_nts(
-    const std::string& type_name) const
+        const std::string& type_name) const
 {
     auto it = type_ros2_unmodified_idl_.find(type_name);
     if (it != type_ros2_unmodified_idl_.end())

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -335,20 +335,20 @@ void Database::insert_new_type_idl(
             {
                 //First: delete the module dds_ identification, and the open brace
                 size_t pos_start = type_idl_demangled.find("module dds_\n");
-                size_t pos_open_brace = type_idl_demangled.find("{", pos_module);
+                size_t pos_open_brace = type_idl_demangled.find("{", pos_start);
                 type_idl_demangled.erase(pos_start, pos_open_brace - pos_start + 1);
 
                 //Second: find next line, and delete dangling whitespace
-                size_t pos_line = type_idl_demangled.find_first_not_of(' ', pos_start);
+                size_t pos_line = type_idl_demangled.find_first_not_of(" ", pos_start);
                 type_idl_demangled.erase(pos_start, pos_line);
 
                 //Third: unindent all the content
-                pos_start = type_idl_demangled.find('   ', pos_start);
-                while(type_idl_demangled[type_idl_demangled.find_first_not_of('   ', pos_start)] != "}")
+                pos_start = type_idl_demangled.find("   ", pos_start);
+                while(type_idl_demangled[type_idl_demangled.find_first_not_of("   ", pos_start)] != '}')
                 {
                     type_idl_demangled.erase(pos_start, 3);
                     size_t pos_new_line = type_idl_demangled.find_first_not_of(' ', pos_start);
-                    pos_start = type_idl_demangled.find('   ', pos_new_line);
+                    pos_start = type_idl_demangled.find("   ", pos_new_line);
                 }
 
                 //Fourth: delete the closing brace and whitespace

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -343,7 +343,7 @@ void Database::insert_new_type_idl(
                 pos_start = type_idl_demangled.find("   ", pos_start);
                 while (type_idl_demangled[type_idl_demangled.find_first_not_of("   ", pos_start)] != '}')
                 {
-                    type_idl_demangled.erase(pos_start, 3);
+                    type_idl_demangled.erase(pos_start, 4);
                     size_t pos_new_line = type_idl_demangled.find_first_not_of(' ', pos_start);
                     pos_start = type_idl_demangled.find("   ", pos_new_line);
                 }

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -311,14 +311,15 @@ void Database::insert_new_type_idl(
 
     //Check that the type name does not have the reserved naming convention
 
-    if(type_name.substr(type_name.size() - backup_naming.size()) == backup_naming)
+    if (type_name.substr(type_name.size() - backup_naming.size()) == backup_naming)
     {
-        EPROSIMA_LOG_ERROR(BACKEND_DATABASE, "Type name cannot contain the reserved end naming convention " + backup_naming);
+        EPROSIMA_LOG_ERROR(BACKEND_DATABASE,
+                "Type name cannot contain the reserved end naming convention " + backup_naming);
         return;
     }
     else
     {
-        if(type_idl.find("module dds_\n")!=std::string::npos || type_idl.find("::dds_::")!=std::string::npos)
+        if (type_idl.find("module dds_\n") != std::string::npos || type_idl.find("::dds_::") != std::string::npos)
         {
             //Register the original type as the backup
             lock.lock();
@@ -331,7 +332,7 @@ void Database::insert_new_type_idl(
 
             //Step 1: delete the module dds_ 
 
-            while(type_idl_demangled.find("module dds_\n")!=std::string::npos)
+            while (type_idl_demangled.find("module dds_\n") != std::string::npos)
             {
                 //First: delete the module dds_ identification, and the open brace
                 size_t pos_start = type_idl_demangled.find("module dds_\n");
@@ -344,7 +345,7 @@ void Database::insert_new_type_idl(
 
                 //Third: unindent all the content
                 pos_start = type_idl_demangled.find("   ", pos_start);
-                while(type_idl_demangled[type_idl_demangled.find_first_not_of("   ", pos_start)] != '}')
+                while (type_idl_demangled[type_idl_demangled.find_first_not_of("   ", pos_start)] != '}')
                 {
                     type_idl_demangled.erase(pos_start, 3);
                     size_t pos_new_line = type_idl_demangled.find_first_not_of(' ', pos_start);
@@ -358,7 +359,7 @@ void Database::insert_new_type_idl(
 
             //Step 2: delete the ::dds_:: namespace 
 
-            while(type_idl_demangled.find("::dds_::")!=std::string::npos)
+            while (type_idl_demangled.find("::dds_::") != std::string::npos)
             {
                 size_t pos = type_idl_demangled.find("::dds_::");
                 type_idl_demangled.erase(pos, 6);
@@ -366,25 +367,25 @@ void Database::insert_new_type_idl(
 
             //Step 3: delete the underscores
 
-            while(type_idl_demangled.find("__")!=std::string::npos)
+            while (type_idl_demangled.find("__") != std::string::npos)
             {
                 size_t pos = type_idl_demangled.find("__");
                 type_idl_demangled.erase(pos, 2);
             }
 
-            while(type_idl_demangled.find("_ ")!=std::string::npos)
+            while (type_idl_demangled.find("_ ") != std::string::npos)
             {
                 size_t pos = type_idl_demangled.find("_ ");
                 type_idl_demangled.erase(pos, 1);
             }
 
-            while(type_idl_demangled.find("_\n")!=std::string::npos)
+            while (type_idl_demangled.find("_\n") != std::string::npos)
             {
                 size_t pos = type_idl_demangled.find("_\n");
                 type_idl_demangled.erase(pos, 1);
             }
 
-            while(type_idl_demangled.find("_>")!=std::string::npos)
+            while (type_idl_demangled.find("_>") != std::string::npos)
             {
                 size_t pos = type_idl_demangled.find("_>");
                 type_idl_demangled.erase(pos, 1);

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -330,7 +330,7 @@ void Database::insert_new_type_idl(
 
             std::string type_idl_demangled = type_idl;
 
-            //Step 1: delete the module dds_ 
+            //Step 1: delete the module dds_
 
             while (type_idl_demangled.find("module dds_\n") != std::string::npos)
             {
@@ -357,7 +357,7 @@ void Database::insert_new_type_idl(
                 type_idl_demangled.erase(pos_start, pos_end - pos_start + 2);
             }
 
-            //Step 2: delete the ::dds_:: namespace 
+            //Step 2: delete the ::dds_:: namespace
 
             while (type_idl_demangled.find("::dds_::") != std::string::npos)
             {

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -1517,7 +1517,14 @@ protected:
      * Collection of type names relating the original name and the ROS 2 demangled name.
      * Only those types that have been modified are stored.
      */
-    std::map<std::string, std::string> type_ros2_modified_;
+    std::map<std::string, std::string> type_ros2_modified_name_;
+    
+    /**
+     * Collection of type idls relating the original idl and the original name.
+     * Note that demangling is done by default, so the demangled IDL is stored in the main map. 
+     * Only those types that have been modified are stored.
+     */
+    std::map<std::string, std::string> type_ros2_unmodified_idl_;
 
     //! Graph map describing per domain complete topology of the entities.
     std::map<EntityId, Graph> domain_view_graph;

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -1518,10 +1518,10 @@ protected:
      * Only those types that have been modified are stored.
      */
     std::map<std::string, std::string> type_ros2_modified_name_;
-    
+
     /**
      * Collection of type idls relating the original idl and the original name.
-     * Note that demangling is done by default, so the demangled IDL is stored in the main map. 
+     * Note that demangling is done by default, so the demangled IDL is stored in the main map.
      * Only those types that have been modified are stored.
      */
     std::map<std::string, std::string> type_ros2_unmodified_idl_;

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -167,7 +167,7 @@ public:
 
     /**
      * @brief Insert a new type IDL into the database or update it, and perform ROS 2 demangling if needed.
-     * If demangled, insert the demangled type IDL and separately, the original one as *topic_name*_backup_.
+     * If demangled, insert the demangled type IDL and separately, the original one in a different map.
      * @param topic_type The type of the topic.
      * @param topic_idl The IDL representation of the type.
      */

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -1513,6 +1513,12 @@ protected:
      */
     std::map<std::string, std::string> type_idls_;
 
+    /**
+     * Collection of type names relating the original name and the ROS 2 demangled name.
+     * Only those types that have been modified are stored.
+     */
+    std::map<std::string, std::string> type_ros2_modified_;
+
     //! Graph map describing per domain complete topology of the entities.
     std::map<EntityId, Graph> domain_view_graph;
 

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -474,6 +474,26 @@ public:
             const std::string& type_name) const;
 
     /**
+     * @brief Get the demangled type name of a given type, if it exists, for display purposes.
+     *
+     * @param type_name The name of the data type for which to search.
+     * @throws eprosima::statistics_backend::BadParameter if \c type_name does not exist in the database.
+     * @return The name type in std::string format.
+     */
+    std::string get_ros2_type_name(
+        const std::string& type_name) const;
+
+    /**
+     * @brief Get the original ROS 2 type IDL of a given type name, if it exists.
+     *
+     * @param type_name The name of the data type for which to search.
+     * @throws eprosima::statistics_backend::BadParameter if \c type_name does not exist in the database.
+     * @return The original ROS 2 IDL representation of the type in std::string format.
+     */
+    std::string get_ros2_type_idl(
+        const std::string& type_name) const;
+
+    /**
      * @brief Get the entity of a given EntityKind that matches with the requested GUID.
      *
      * @param entity_kind The EntityKind of the fetched entities.
@@ -1225,6 +1245,26 @@ protected:
      */
     std::string get_type_idl_nts(
             const std::string& type_name) const;
+
+    /**
+     * @brief Get the demangled type name of a given type, if it exists, for display purposes. This method is not thread safe.
+     *
+     * @param type_name The name of the data type for which to search.
+     * @throws eprosima::statistics_backend::BadParameter if \c type_name does not exist in the database.
+     * @return The name type in std::string format.
+     */
+    std::string get_ros2_type_name_nts(
+        const std::string& type_name) const;
+
+    /**
+     * @brief Get the original ROS 2 type IDL of a given type name, if it exists.  This method is not thread safe.
+     *
+     * @param type_name The name of the data type for which to search.
+     * @throws eprosima::statistics_backend::BadParameter if \c type_name does not exist in the database.
+     * @return The original ROS 2 IDL representation of the type in std::string format.
+     */
+    std::string get_ros2_type_idl_nts(
+        const std::string& type_name) const;
 
     /**
      * @brief Get the entity of a given EntityKind that matches with the requested GUID. This method is not thread safe.

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -481,7 +481,7 @@ public:
      * @return The name type in std::string format.
      */
     std::string get_ros2_type_name(
-        const std::string& type_name) const;
+            const std::string& type_name) const;
 
     /**
      * @brief Get the original ROS 2 type IDL of a given type name, if it exists.
@@ -491,7 +491,7 @@ public:
      * @return The original ROS 2 IDL representation of the type in std::string format.
      */
     std::string get_ros2_type_idl(
-        const std::string& type_name) const;
+            const std::string& type_name) const;
 
     /**
      * @brief Get the entity of a given EntityKind that matches with the requested GUID.
@@ -1254,7 +1254,7 @@ protected:
      * @return The name type in std::string format.
      */
     std::string get_ros2_type_name_nts(
-        const std::string& type_name) const;
+            const std::string& type_name) const;
 
     /**
      * @brief Get the original ROS 2 type IDL of a given type name, if it exists.  This method is not thread safe.
@@ -1264,7 +1264,7 @@ protected:
      * @return The original ROS 2 IDL representation of the type in std::string format.
      */
     std::string get_ros2_type_idl_nts(
-        const std::string& type_name) const;
+            const std::string& type_name) const;
 
     /**
      * @brief Get the entity of a given EntityKind that matches with the requested GUID. This method is not thread safe.

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -166,9 +166,10 @@ public:
             const std::string& type_name);
 
     /**
-     * @brief Insert a new type IDL into the database or update it.
+     * @brief Insert a new type IDL into the database or update it, and perform ROS 2 demangling if needed.
+     * If demangled, insert the demangled type IDL and separately, the original one as *topic_name*_backup_.
      * @param topic_type The type of the topic.
-     * @param topic_idl The IDL representation of the type
+     * @param topic_idl The IDL representation of the type.
      */
     void insert_new_type_idl(
             const std::string& topic_type,

--- a/test/unittest/Database/CMakeLists.txt
+++ b/test/unittest/Database/CMakeLists.txt
@@ -389,6 +389,8 @@ set(DATABASE_TEST_LIST
     get_entity_by_guid_locator
     get_entity_by_guid_invalid
     get_entity_by_guid_other_kind
+    # ros2_demangling
+    check_ros2_demangler
     )
 
 foreach(test_name ${DATABASE_TEST_LIST})

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -5080,9 +5080,9 @@ TEST_F(database_tests, get_entity_by_guid_other_kind)
 {
     EXPECT_THROW(db.get_entity_by_guid(static_cast<EntityKind>(127), "any_guid"), BadParameter);
 }
-    
+
 std::string readFileToString(
-        const std::string& filename) 
+        const std::string& filename)
 {
     std::ifstream file(filename);
     std::ostringstream ss;

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -5080,27 +5080,29 @@ TEST_F(database_tests, get_entity_by_guid_other_kind)
 {
     EXPECT_THROW(db.get_entity_by_guid(static_cast<EntityKind>(127), "any_guid"), BadParameter);
 }
+    
+std::string readFileToString(
+        const std::string& filename) 
+{
+    std::ifstream file(filename);
+    std::ostringstream ss;
+    ss << file.rdbuf();
+    return ss.str();
+}
 
 TEST_F(database_tests, check_ros2_demangler)
 {
-    std::string readFileToString(const std::string& filename) {
-        std::ifstream file(filename);
-        std::ostringstream ss;
-        ss << file.rdbuf();
-        return ss.str();
-    }
+    std::string ros2_mangled_name = "module1::module2::dds_::String_";
+    std::string ros2_demangled_name_goal = "module1::module2::String";
 
-    string ros2_mangled_name = "module1::module2::dds_::String_";
-    string ros2_demangled_name_goal = "module1::module2::String";
+    std::string ros2_mangled_idl = readFileToString("../Resources/ros2_trial_idl_mangled.idl");
+    std::string ros2_demangled_idl_goal = readFileToString("../Resources/ros2_trial_idl_demangled.idl");
 
-    string ros2_mangled_idl = readFileToString("../Resources/ros2_trial_idl_mangled.idl");
-    string ros2_demangled_idl_goal = readFileToString("../Resources/ros2_trial_idl_demangled.idl");
-    
     db.insert_new_type_idl(ros2_mangled_name, ros2_mangled_idl);
 
-    string ros2_demangled_name = db.get_ros2_type_name(ros2_mangled_name);
+    std::string ros2_demangled_name = db.get_ros2_type_name(ros2_mangled_name);
 
-    string ros2_demangled_idl = db.get_ros2_type_idl(ros2_mangled_name);
+    std::string ros2_demangled_idl = db.get_ros2_type_idl(ros2_mangled_name);
 
     // Check the results
 

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -5081,6 +5081,33 @@ TEST_F(database_tests, get_entity_by_guid_other_kind)
     EXPECT_THROW(db.get_entity_by_guid(static_cast<EntityKind>(127), "any_guid"), BadParameter);
 }
 
+TEST_F(database_tests, check_ros2_demangler)
+{
+    std::string readFileToString(const std::string& filename) {
+        std::ifstream file(filename);
+        std::ostringstream ss;
+        ss << file.rdbuf();
+        return ss.str();
+    }
+
+    string ros2_mangled_name = "module1::module2::dds_::String_";
+    string ros2_demangled_name_goal = "module1::module2::String";
+
+    string ros2_mangled_idl = readFileToString("../Resources/ros2_trial_idl_mangled.idl");
+    string ros2_demangled_idl_goal = readFileToString("../Resources/ros2_trial_idl_demangled.idl");
+    
+    db.insert_new_type_idl(ros2_mangled_name, ros2_mangled_idl);
+
+    string ros2_demangled_name = db.get_ros2_type_name(ros2_mangled_name);
+
+    string ros2_demangled_idl = db.get_ros2_type_idl(ros2_mangled_name);
+
+    // Check the results
+
+    EXPECT_EQ(ros2_demangled_name, ros2_demangled_name_goal);
+    EXPECT_EQ(ros2_demangled_idl, ros2_demangled_idl_goal);
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/unittest/Resources/ros2_trial_idl_demangled.idl
+++ b/test/unittest/Resources/ros2_trial_idl_demangled.idl
@@ -1,0 +1,25 @@
+module module3
+{
+    module module4
+    {
+        @extensibility(FINAL)
+        struct my_data
+        {
+            string my_datas;
+        };
+    };
+};
+
+module module1
+{
+    module module2
+    {
+        @extensibility(FINAL)
+        struct String
+        {
+            string data;
+            sequence<module3::module4::my_data> my_data_seq;
+            module3::module4::my_data my_data_noseq;
+        };
+    };
+};

--- a/test/unittest/Resources/ros2_trial_idl_mangled.idl
+++ b/test/unittest/Resources/ros2_trial_idl_mangled.idl
@@ -1,0 +1,31 @@
+module module3
+{
+    module module4
+    {
+        module dds_
+        {
+            @extensibility(FINAL)
+            struct my_data__
+            {
+                string my_datas;
+            };
+        };
+    };
+};
+
+module module1
+{
+    module module2
+    {
+        module dds_
+        {
+            @extensibility(FINAL)
+            struct String_
+            {
+                string data;
+                sequence<module3::module4::dds_::my_data__> my_data_seq;
+                module3::module4::dds_::my_data__ my_data_noseq;
+            };
+        };
+    };
+};


### PR DESCRIPTION
This PR adds the code to process the IDL files generated from the TypeObject, eliminating the ROS 2 mangling in case it is necessary, before registering the IDL. If it was demangled, the original one is saved in a second map, so it can still be retrieved. A third map registers the relation between the original name and the demangled one, for the monitor to use. This PR also includes the functions needed for the monitor to be able to access this information.