### PR TITLE
[22871] Support ROS 2 Easy Mode

### DIFF
--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -5,3 +5,7 @@
 ###################
 Forthcoming Version
 ###################
+
+This release adds the following **features**:
+
+* Add support to configure ROS 2 Easy Mode.

--- a/include/fastdds_statistics_backend/StatisticsBackend.hpp
+++ b/include/fastdds_statistics_backend/StatisticsBackend.hpp
@@ -73,6 +73,7 @@ public:
      * @param data_mask Mask of the data types that will be monitored.
      * @param app_id App id of the monitor participant.
      * @param app_metadata Metadata of the monitor participant.
+     * @param easy_mode_ip IP address of the remote discovery server used in ROS2 Easy Mode.
      * @return The ID of the created statistics Domain.
      * @throws eprosima::statistics_backend::BadParameter if a monitor is already created for the given domain.
      * @throws eprosima::statistics_backend::Error if the creation of the monitor fails.
@@ -84,7 +85,8 @@ public:
             CallbackMask callback_mask = CallbackMask::all(),
             DataKindMask data_mask = DataKindMask::none(),
             std::string app_id = app_id_str[(int)AppId::UNKNOWN],
-            std::string app_metadata = "");
+            std::string app_metadata = "",
+            std::string easy_mode_ip = "");
 
     /**
      * @brief Starts monitoring the network corresponding to a server.

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -368,7 +368,8 @@ EntityId StatisticsBackend::init_monitor(
         CallbackMask callback_mask,
         DataKindMask data_mask,
         std::string app_id,
-        std::string app_metadata)
+        std::string app_metadata,
+        std::string easy_mode_ip /* = "" */)
 {
     /* Deactivate statistics in case they were set */
 #ifdef _WIN32
@@ -397,6 +398,12 @@ EntityId StatisticsBackend::init_monitor(
         "fastdds.application.metadata",
         app_metadata,
         "true");
+
+    ReturnCode_t retcode = participant_qos.wire_protocol().easy_mode(easy_mode_ip);
+    if (RETCODE_OK != retcode)
+    {
+        throw Error("Error setting easy mode IP: " + std::to_string(retcode));
+    }
 
     return create_and_register_monitor(domain_name.str(), domain_listener, callback_mask, data_mask, participant_qos,
                    domain_id);

--- a/test/unittest/StatisticsBackend/CMakeLists.txt
+++ b/test/unittest/StatisticsBackend/CMakeLists.txt
@@ -326,6 +326,7 @@ set(INIT_MONITOR_TEST_LIST
     stop_monitor
     init_monitor_check_participant_name
     init_monitor_check_participant_transport
+    init_monitor_easy_mode
     )
 
 foreach(test_name ${INIT_MONITOR_TEST_LIST})

--- a/test/unittest/StatisticsBackend/InitMonitorTests.cpp
+++ b/test/unittest/StatisticsBackend/InitMonitorTests.cpp
@@ -739,6 +739,40 @@ TEST_F(init_monitor_tests, init_monitor_check_participant_transport)
     StatisticsBackend::stop_monitor(monitor_id);
 }
 
+TEST_F(init_monitor_tests, init_monitor_easy_mode)
+{
+    DomainId domain_id = 0;
+    DomainListener domain_listener;
+    std::string app_id = app_id_str[(int)AppId::FASTDDS_MONITOR];
+    std::string app_metadata = "metadata";
+    std::string easy_mode_ip = "127.0.0.1";
+
+    EntityId monitor_id = StatisticsBackend::init_monitor(
+        domain_id,
+        &domain_listener,
+        all_callback_mask_,
+        all_datakind_mask_,
+        app_id,
+        app_metadata,
+        easy_mode_ip);
+
+    EXPECT_TRUE(monitor_id.is_valid());
+
+    auto domain_monitors = test::get_monitors_from_database();
+
+    /* Check that a monitor is created */
+    EXPECT_EQ(domain_monitors.size(), 1u);
+
+    eprosima::fastdds::dds::DomainParticipant* participant = domain_monitors[monitor_id]->participant;
+    eprosima::fastdds::dds::DomainParticipantQos participant_qos = participant->get_qos();
+
+    // Check that the easy mode IP is set correctly
+    ASSERT_EQ(easy_mode_ip, participant_qos.wire_protocol().easy_mode());
+
+    /* Stop the monitor to avoid interfering on the next test */
+    StatisticsBackend::stop_monitor(monitor_id);
+}
+
 int main(
         int argc,
         char** argv)


### PR DESCRIPTION
# Main Changes
This PR updates `StatisticsBackend::init_monitor` to support ROS 2 Easy Mode configuration in FastDDS Monitor

Related to:
- https://github.com/eProsima/Fast-DDS-monitor/pull/255