### PR TITLE
[23136] Fix backend graph json dump() exception   

### DIFF
--- a/src/cpp/database/entities.cpp
+++ b/src/cpp/database/entities.cpp
@@ -54,6 +54,20 @@ bool Entity::is_metatraffic_topic(
     return is_metatraffic;
 }
 
+std::string Entity::normalize_entity_name(
+    const std::string& entity_name)
+{
+    std::string normalized_name;
+
+    // Filter out invalid characters
+    // Leave all ascii printable characters
+
+    std::regex regular_expression("[^ -~]");
+    normalized_name = std::regex_replace(entity_name, regular_expression, "");
+
+    return normalized_name;
+}
+
 DdsVendor DDSEntity::dds_vendor_by_guid(
         const std::string& guid)
 {

--- a/src/cpp/database/entities.cpp
+++ b/src/cpp/database/entities.cpp
@@ -55,7 +55,7 @@ bool Entity::is_metatraffic_topic(
 }
 
 std::string Entity::normalize_entity_name(
-    const std::string& entity_name)
+        const std::string& entity_name)
 {
     std::string normalized_name;
 

--- a/src/cpp/database/entities.hpp
+++ b/src/cpp/database/entities.hpp
@@ -20,6 +20,7 @@
 #ifndef FASTDDS_STATISTICS_BACKEND_SRC_CPP_DATABASE__ENTITIES_HPP
 #define FASTDDS_STATISTICS_BACKEND_SRC_CPP_DATABASE__ENTITIES_HPP
 
+#include <regex>
 #include <string>
 
 #include <fastdds_statistics_backend/types/types.hpp>
@@ -57,8 +58,8 @@ struct Entity
             bool entity_active = true,
             StatusLevel entity_status = StatusLevel::OK_STATUS) noexcept
         : kind(entity_kind)
-        , name(entity_name)
-        , alias(entity_name)
+        , name(normalize_entity_name(entity_name))
+        , alias(normalize_entity_name(entity_name))
         , metatraffic(entity_metatraffic)
         , active(entity_active)
         , status(entity_status)
@@ -82,6 +83,15 @@ struct Entity
      */
     static bool is_metatraffic_topic(
             std::string topic_name);
+
+    /**
+     * @brief Normalize the entity name to an ascii-valid name.
+     *
+     * @param entity_name Name of the name to convert.
+     * @return The normalized string name.
+     */
+    static std::string normalize_entity_name(
+        const std::string& entity_name);
 
     //! The unique identification of the entity
     EntityId id;

--- a/src/cpp/database/entities.hpp
+++ b/src/cpp/database/entities.hpp
@@ -91,7 +91,7 @@ struct Entity
      * @return The normalized string name.
      */
     static std::string normalize_entity_name(
-        const std::string& entity_name);
+            const std::string& entity_name);
 
     //! The unique identification of the entity
     EntityId id;

--- a/test/unittest/Database/DatabaseDomainViewGraphTests.cpp
+++ b/test/unittest/Database/DatabaseDomainViewGraphTests.cpp
@@ -594,11 +594,11 @@ TEST_F(database_domain_view_graph_tests, graph_with_strange_user_host_characters
     host_id = database.insert(weird_host);
     user_id = database.insert(weird_user);
 
-    // Insert participant_1 from process_1
+    // Insert participant_1 from weird_process
     auto weird_process = std::make_shared<database::Process>("1234", "1234", weird_user);
-    auto process_id_1 = database.insert(weird_process);
+    auto weird_process_id = database.insert(weird_process);
     participant_id_1 = database.insert(participant_1);
-    database.link_participant_with_process(participant_id_1, process_id_1);
+    database.link_participant_with_process(participant_id_1, weird_process_id);
 
     // Add participant to graph
     database.update_participant_in_graph(domain_id, host_id, user_id, process_id_1, participant_id_1);

--- a/test/unittest/Database/DatabaseDomainViewGraphTests.cpp
+++ b/test/unittest/Database/DatabaseDomainViewGraphTests.cpp
@@ -577,6 +577,39 @@ TEST_F(database_domain_view_graph_tests, regenerate_graph_functionality)
     ASSERT_EQ(json_graph, database.get_domain_view_graph(0));
 }
 
+// Test that the graph can be dumped even if the user and host have non-ascii characters
+TEST_F(database_domain_view_graph_tests, graph_with_strange_user_host_characters_correctly_dumps)
+{
+    Graph json_graph;
+
+    // Override user and host
+    const char raw_bytes [] = {static_cast<char>(0xC0), static_cast<char>(0xC1), static_cast<char>(0x41),
+                               static_cast<char>(0x42), static_cast<char>(0x43), static_cast<char>(0x44),
+                               static_cast<char>(0x45)
+        };
+    auto weird_host = std::make_shared<database::Host>(raw_bytes);
+    auto weird_user = std::make_shared<database::User>(raw_bytes, weird_host);
+
+    // Insert host and user
+    host_id = database.insert(weird_host);
+    user_id = database.insert(weird_user);
+
+    // Insert participant_1 from process_1
+    auto weird_process = std::make_shared<database::Process>("1234", "1234", weird_user);
+    auto process_id_1 = database.insert(weird_process);
+    participant_id_1 = database.insert(participant_1);
+    database.link_participant_with_process(participant_id_1, process_id_1);
+
+    // Add participant to graph
+    database.update_participant_in_graph(domain_id, host_id, user_id, process_id_1, participant_id_1);
+
+    // Retrieve graph
+    json_graph = database.get_domain_view_graph(0);
+
+    // Check dumping the json does not throw nlohmann::type_error exception
+    ASSERT_NO_THROW(json_graph.dump());
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/unittest/Database/DatabaseDomainViewGraphTests.cpp
+++ b/test/unittest/Database/DatabaseDomainViewGraphTests.cpp
@@ -586,7 +586,7 @@ TEST_F(database_domain_view_graph_tests, graph_with_strange_user_host_characters
     const char raw_bytes [] = {static_cast<char>(0xC0), static_cast<char>(0xC1), static_cast<char>(0x41),
                                static_cast<char>(0x42), static_cast<char>(0x43), static_cast<char>(0x44),
                                static_cast<char>(0x45)
-        };
+    };
     auto weird_host = std::make_shared<database::Host>(raw_bytes);
     auto weird_user = std::make_shared<database::User>(raw_bytes, weird_host);
 


### PR DESCRIPTION
This PR fixes a situation in which user name and or host names inserted in the database contains weird (non-ascii/printable) characters. This PR normalizes the names, filtering out non ascii characters.