### PR TITLE
[23269] Fix build with tests

### DIFF
--- a/test/mock/dds/DomainParticipantFactory/fastdds/dds/domain/TypeObjectRegistry.hpp
+++ b/test/mock/dds/DomainParticipantFactory/fastdds/dds/domain/TypeObjectRegistry.hpp
@@ -71,6 +71,13 @@ public:
         return eprosima::fastdds::dds::RETCODE_OK;
     }
 
+    ReturnCode_t get_complete_type_object(
+            const TypeIdentifierPair&,
+            CompleteTypeObject&) override
+    {
+        return eprosima::fastdds::dds::RETCODE_OK;
+    }
+
     ReturnCode_t get_type_objects(
             const std::string&,
             TypeObjectPair&) override


### PR DESCRIPTION
This PR fixes an error during build when BUILD_TESTS=ON due to a pure virtual method which was not being overwritten in the mock file. This issue comes from PR: 

- https://github.com/eProsima/Fast-DDS/pull/5885