### PR TITLE
[23518] Represent domain id and name separately in Domain Graph

### DIFF
--- a/docs/code/StatisticsBackendTests.cpp
+++ b/docs/code/StatisticsBackendTests.cpp
@@ -427,7 +427,7 @@ int get_domain_view_graph_examples(
         Graph domain_view_graph = Graph::parse(file_example);
 
         //CONF-NAVIGATE-GRAPH-EXAMPLE
-        std::cout << "Domain: " << domain_view_graph[DOMAIN_ENTITY_TAG] << std::endl;
+        std::cout << "Domain: " << domain_view_graph[DOMAIN_INFO_TAG][DOMAIN_ID_TAG] << std::endl;
         // Iterate
         for (const auto& host : domain_view_graph[HOST_CONTAINER_TAG])
         {

--- a/docs/code/domain_info_example.json
+++ b/docs/code/domain_info_example.json
@@ -1,7 +1,8 @@
 {
     "id": 0,
     "kind": "domain",
-    "name": "0",
+    "domain_id": 1,
+    "name": "domain_name",
     "alias": "domain_alias",
     "alive": true,
     "metatraffic": false,

--- a/docs/code/dump_example.json
+++ b/docs/code/dump_example.json
@@ -38,6 +38,11 @@
         "4":
         {
             "name": "domain_0",
+            "alias": "domain_0",
+            "domain_id": 0,
+            "metatraffic": false,
+            "alive": true,
+            "status": 0,
             "participants": ["6"],
             "topics": ["5"]
         }

--- a/docs/code/graph_example.json
+++ b/docs/code/graph_example.json
@@ -1,6 +1,10 @@
 {
     "kind": "domain",
-    "domain": "0",
+    "domain_info":
+    {
+        "domain_id": 0,
+        "domain_name": "domain_name"
+    },
     "topics":
     {
         "5":

--- a/include/fastdds_statistics_backend/types/JSONTags.h
+++ b/include/fastdds_statistics_backend/types/JSONTags.h
@@ -127,6 +127,10 @@ constexpr const char* APP_METADATA_TAG                  = "app_metadata";
 constexpr const char* VIRTUAL_METATRAFFIC_TAG       = "virtual_metatraffic";
 //! Key tag for vendor id of a participant entity
 constexpr const char* DDS_VENDOR_TAG                = "dds_vendor";
+//! Key tags for domain info of an entity
+constexpr const char* DOMAIN_INFO_TAG                = "domain_info";
+constexpr const char* DOMAIN_ID_TAG                  = "domain_id";
+constexpr const char* DOMAIN_NAME_TAG                = "domain_name";
 
 //! Conversion from EntityKind to string
 constexpr const char* entity_kind_str[] =

--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -203,11 +203,11 @@ EntityId create_and_register_monitor(
     std::lock_guard<details::StatisticsBackendData> guard(*backend_data);
 
     /* Create monitor instance and register it in the database */
-    std::shared_ptr<database::Domain> domain = std::make_shared<database::Domain>(domain_name);
+    std::shared_ptr<database::Domain> domain = std::make_shared<database::Domain>(domain_name, domain_id);
     domain->id = backend_data->database_->insert(domain);
 
     // Init database graph
-    backend_data->database_->init_domain_view_graph(domain_name, domain->id);
+    backend_data->database_->init_domain_view_graph(domain_name, domain_id, domain->id);
 
     // TODO: in case this function fails afterwards, the domain will be kept in the database without associated
     // Participant. There must exist a way in database to delete a domain, or to make a rollback.

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -5958,6 +5958,13 @@ Info Database::get_info(
             info[LOCATOR_CONTAINER_TAG] = locators;
             break;
         }
+        case EntityKind::DOMAIN:
+        {
+            std::shared_ptr<const Domain> domain =
+                    std::dynamic_pointer_cast<const Domain>(entity);
+            info[DOMAIN_ID_TAG] = domain->domain_id;
+            break;
+        }
         case EntityKind::DATAWRITER:
         case EntityKind::DATAREADER:
         {

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -3950,12 +3950,8 @@ bool Database::regenerate_domain_graph_nts(
     Graph* domain_graph = &domain_view_graph[domain_entity_id];
 
     std::shared_ptr<const Entity> db_entity = get_entity_nts(domain_entity_id);
-    if (db_entity == nullptr || db_entity->kind != EntityKind::DOMAIN)
-    {
-        EPROSIMA_LOG_WARNING(BACKEND_DATABASE,
-                "Error regenerating graph. EntityId does not correspond to a valid Domain");
-        return false;
-    }
+    assert((db_entity != nullptr) && (db_entity->kind == EntityKind::DOMAIN));
+
     std::shared_ptr<const Domain> domain_entity = std::static_pointer_cast<const Domain>(db_entity);
     (*domain_graph)[KIND_TAG] = DOMAIN_ENTITY_TAG;
     (*domain_graph)[DOMAIN_INFO_TAG][DOMAIN_NAME_TAG] = domain_entity->name;

--- a/src/cpp/database/database.hpp
+++ b/src/cpp/database/database.hpp
@@ -582,11 +582,13 @@ public:
     /**
      * @brief Init domain view graph with specified domain.
      *
-     * @param domain_name Domain where monitoring.
+     * @param domain_name The name of the domain where monitoring.
+     * @param domain_id The DomainId of the domain where monitoring.
      * @param domain_entity_id The EntityId of the domain.
      */
     void init_domain_view_graph(
             const std::string& domain_name,
+            const DomainId domain_id,
             const EntityId& domain_entity_id);
 
     /**
@@ -1373,6 +1375,7 @@ protected:
      */
     void init_domain_view_graph_nts(
             const std::string& domain_name,
+            const DomainId domain_id,
             const EntityId& domain_entity_id);
 
     /**

--- a/src/cpp/database/entities.hpp
+++ b/src/cpp/database/entities.hpp
@@ -220,8 +220,10 @@ struct Domain : Entity
 {
     Domain(
             std::string domain_name,
+            DomainId domain_id,
             StatusLevel status = StatusLevel::OK_STATUS) noexcept
         : Entity(EntityKind::DOMAIN, domain_name, false, true, status)
+        , domain_id(domain_id)
     {
     }
 
@@ -241,6 +243,9 @@ struct Domain : Entity
      * The collection is ordered by the EntityId of the DomainParticipant nodes.
      */
     std::map<EntityId, details::fragile_ptr<DomainParticipant>> participants;
+
+    //! The domainId identifier
+    DomainId domain_id;
 };
 
 /*

--- a/test/mock/database/database/database/database.hpp
+++ b/test/mock/database/database/database/database.hpp
@@ -186,8 +186,9 @@ public:
     {
     }
 
-    MOCK_METHOD2(init_domain_view_graph, void(
+    MOCK_METHOD3(init_domain_view_graph, void(
                 const std::string& domain_name,
+                const DomainId domain_id,
                 const EntityId& domain_entity_id));
 
     MOCK_METHOD5(update_participant_in_graph, bool(

--- a/test/unittest/Database/DatabaseClearTests.cpp
+++ b/test/unittest/Database/DatabaseClearTests.cpp
@@ -57,8 +57,8 @@ constexpr const int16_t MAGNITUDE_DEFAULT = 0;
 #define HOST_DEFAULT_NAME(x) "host_" + std::to_string(x)
 #define USER_DEFAULT_NAME(x) "user_" + std::to_string(x)
 #define PROCESS_DEFAULT_NAME(x) "process_" + std::to_string(x)
-#define DOMAIN_DEFAULT_NAME(x) "12" + std::to_string(x)
-#define ALIAS_DEFAULT_NAME(x) "domain_" + std::to_string(x)
+#define DOMAIN_DEFAULT_NAME(x) "domain_name_" + std::to_string(x)
+#define ALIAS_DEFAULT_NAME(x) "domain_alias_" + std::to_string(x)
 #define TOPIC_DEFAULT_NAME(x) "topic_" + std::to_string(x)
 #define PARTICIPANT_DEFAULT_NAME(x) "participant_" + std::to_string(x)
 #define DATAWRITER_DEFAULT_NAME(x) "datawriter_" + std::to_string(x)
@@ -90,7 +90,7 @@ void initialize_empty_entities(
     std::shared_ptr<User> user = std::make_shared<User>(std::string(USER_DEFAULT_NAME(index)), host);
     std::shared_ptr<Process> process = std::make_shared<Process>(std::string(PROCESS_DEFAULT_NAME(
                         index)), PID_DEFAULT, user);
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(index)));
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(index)), 0);
     domain->alias = ALIAS_DEFAULT_NAME(index);
     std::shared_ptr<Topic> topic = std::make_shared<Topic>(std::string(TOPIC_DEFAULT_NAME(
                         index)), DATA_TYPE_DEFAULT, domain);
@@ -159,7 +159,7 @@ TEST(database, clear_inactive_entities_database_simple)
     Database db;
     test::initialize_empty_entities(db, 0, true);
     auto domains = db.get_entities_by_name(EntityKind::DOMAIN, DOMAIN_DEFAULT_NAME(0));
-    db.init_domain_view_graph(DOMAIN_DEFAULT_NAME(0), domains[0].second);
+    db.init_domain_view_graph(DOMAIN_DEFAULT_NAME(0), 0, domains[0].second);
     db.regenerate_domain_graph(domains[0].second);
 
     // DATAWRITER

--- a/test/unittest/Database/DatabaseDomainViewGraphTests.cpp
+++ b/test/unittest/Database/DatabaseDomainViewGraphTests.cpp
@@ -55,10 +55,11 @@ public:
     void SetUp()
     {
         std::string domain_name = "33";
-        domain = std::make_shared<database::Domain>(domain_name);
+        DomainId domain_id = 33;
+        domain = std::make_shared<database::Domain>(domain_name, domain_id);
 
-        domain_id = database.insert(domain);
-        database.init_domain_view_graph(domain_name, domain_id);
+        domain_entity_id = database.insert(domain);
+        database.init_domain_view_graph(domain_name, domain_id, domain_entity_id);
 
         topic = std::make_shared<database::Topic>(
             "HelloWorld",
@@ -121,7 +122,7 @@ public:
 
     }
 
-    EntityId domain_id;
+    EntityId domain_entity_id;
     std::shared_ptr<eprosima::statistics_backend::database::Domain> domain;
 
     Qos entity_qos;
@@ -186,7 +187,7 @@ TEST_F(database_domain_view_graph_tests, complete_with_two_participants)
         database.link_participant_with_process(participant_id_1, process_id_1);
 
         // Add participant to graph
-        database.update_participant_in_graph(domain_id, host_id, user_id, process_id_1, participant_id_1);
+        database.update_participant_in_graph(domain_entity_id, host_id, user_id, process_id_1, participant_id_1);
 
         // Insert topic
         topic_id = database.insert(topic);
@@ -199,13 +200,13 @@ TEST_F(database_domain_view_graph_tests, complete_with_two_participants)
         datawriter_id_1 = database.insert(datawriter_1);
 
         // Add endpoint and topic to graph
-        database.update_endpoint_in_graph(domain_id, participant_id_1, topic_id, datawriter_id_1);
+        database.update_endpoint_in_graph(domain_entity_id, participant_id_1, topic_id, datawriter_id_1);
 
         // Insert participant_2 from process_2
         process_id_2 = database.insert(process_2);
         participant_id_2 = database.insert(participant_2);
         database.link_participant_with_process(participant_id_2, process_id_2);
-        database.update_participant_in_graph(domain_id, host_id, user_id, process_id_2, participant_id_2);
+        database.update_participant_in_graph(domain_entity_id, host_id, user_id, process_id_2, participant_id_2);
 
         // Insert locator
         locator_id_2 = database.insert(locator_2);
@@ -215,7 +216,7 @@ TEST_F(database_domain_view_graph_tests, complete_with_two_participants)
         datareader_id_2 = database.insert(datareader_2);
 
         // Add endpoint and topic to graph
-        database.update_endpoint_in_graph(domain_id, participant_id_2, topic_id, datareader_id_2);
+        database.update_endpoint_in_graph(domain_entity_id, participant_id_2, topic_id, datareader_id_2);
 
         // Load reference graph
         load_file(DOMAIN_VIEW_GRAPH_TWO_PARTICIPANTS_DUMP_FILE, json_graph);
@@ -225,8 +226,8 @@ TEST_F(database_domain_view_graph_tests, complete_with_two_participants)
     }
     // No Update
     {
-        database.update_participant_in_graph(domain_id, host_id, user_id, process_id_1, participant_id_1);
-        database.update_endpoint_in_graph(domain_id, participant_id_1, topic_id, datawriter_id_1);
+        database.update_participant_in_graph(domain_entity_id, host_id, user_id, process_id_1, participant_id_1);
+        database.update_endpoint_in_graph(domain_entity_id, participant_id_1, topic_id, datawriter_id_1);
 
         // Load reference graph
         load_file(DOMAIN_VIEW_GRAPH_TWO_PARTICIPANTS_DUMP_FILE, json_graph);
@@ -241,43 +242,43 @@ TEST_F(database_domain_view_graph_tests, complete_with_two_participants)
         std::shared_ptr<database::Entity> participant_entity_modified = std::const_pointer_cast<database::Entity>(
             participant_const_entity_modified);
         participant_entity_modified->alias = "participant_1_modified";
-        database.update_graph_on_updated_entity(domain_id, participant_id_1);
+        database.update_graph_on_updated_entity(domain_entity_id, participant_id_1);
 
         std::shared_ptr<const database::Entity> host_const_entity_modified = database.get_entity(host_id);
         std::shared_ptr<database::Entity> host_entity_modified = std::const_pointer_cast<database::Entity>(
             host_const_entity_modified);
         host_entity_modified->alias = "eprosima-host_modified";
-        database.update_graph_on_updated_entity(domain_id, host_id);
+        database.update_graph_on_updated_entity(domain_entity_id, host_id);
 
         std::shared_ptr<const database::Entity> user_const_entity_modified = database.get_entity(user_id);
         std::shared_ptr<database::Entity> user_entity_modified = std::const_pointer_cast<database::Entity>(
             user_const_entity_modified);
         user_entity_modified->alias = "eprosima_modified";
-        database.update_graph_on_updated_entity(domain_id, user_id);
+        database.update_graph_on_updated_entity(domain_entity_id, user_id);
 
         std::shared_ptr<const database::Entity> process_const_entity_modified = database.get_entity(process_id_1);
         std::shared_ptr<database::Entity> process_entity_modified = std::const_pointer_cast<database::Entity>(
             process_const_entity_modified);
         process_entity_modified->alias = "1234_modified";
-        database.update_graph_on_updated_entity(domain_id, process_id_1);
+        database.update_graph_on_updated_entity(domain_entity_id, process_id_1);
 
         std::shared_ptr<const database::Entity> topic_const_entity_modified = database.get_entity(topic_id);
         std::shared_ptr<database::Entity> topic_entity_modified = std::const_pointer_cast<database::Entity>(
             topic_const_entity_modified);
         topic_entity_modified->alias = "HelloWorld_modified";
-        database.update_graph_on_updated_entity(domain_id, topic_id);
+        database.update_graph_on_updated_entity(domain_entity_id, topic_id);
 
         std::shared_ptr<const database::Entity> datawriter_const_entity_modified = database.get_entity(datawriter_id_1);
         std::shared_ptr<database::Entity> datawriter_entity_modified = std::const_pointer_cast<database::Entity>(
             datawriter_const_entity_modified);
         datawriter_entity_modified->alias = "publisher_modified";
-        database.update_graph_on_updated_entity(domain_id, datawriter_id_1);
+        database.update_graph_on_updated_entity(domain_entity_id, datawriter_id_1);
 
         std::shared_ptr<const database::Entity> datareader_const_entity_modified = database.get_entity(datareader_id_2);
         std::shared_ptr<database::Entity> datareader_entity_modified = std::const_pointer_cast<database::Entity>(
             datareader_const_entity_modified);
         datareader_entity_modified->alias = "subscriber_modified";
-        database.update_graph_on_updated_entity(domain_id, datareader_id_2);
+        database.update_graph_on_updated_entity(domain_entity_id, datareader_id_2);
 
         // Load reference graph
         load_file(DOMAIN_VIEW_GRAPH_UPDATED_ENTITIES_DUMP_FILE, json_graph);
@@ -293,47 +294,47 @@ TEST_F(database_domain_view_graph_tests, complete_with_two_participants)
         std::shared_ptr<database::Entity> participant_entity_modified = std::const_pointer_cast<database::Entity>(
             participant_const_entity_modified);
         participant_entity_modified->alias = "participant_1";
-        database.update_graph_on_updated_entity(domain_id, participant_id_1);
+        database.update_graph_on_updated_entity(domain_entity_id, participant_id_1);
 
         std::shared_ptr<const database::Entity> host_const_entity_modified = database.get_entity(host_id);
         std::shared_ptr<database::Entity> host_entity_modified = std::const_pointer_cast<database::Entity>(
             host_const_entity_modified);
         host_entity_modified->alias = "eprosima-host";
-        database.update_graph_on_updated_entity(domain_id, host_id);
+        database.update_graph_on_updated_entity(domain_entity_id, host_id);
 
         std::shared_ptr<const database::Entity> user_const_entity_modified = database.get_entity(user_id);
         std::shared_ptr<database::Entity> user_entity_modified = std::const_pointer_cast<database::Entity>(
             user_const_entity_modified);
         user_entity_modified->alias = "eprosima";
-        database.update_graph_on_updated_entity(domain_id, user_id);
+        database.update_graph_on_updated_entity(domain_entity_id, user_id);
 
         std::shared_ptr<const database::Entity> process_const_entity_modified = database.get_entity(process_id_1);
         std::shared_ptr<database::Entity> process_entity_modified = std::const_pointer_cast<database::Entity>(
             process_const_entity_modified);
         process_entity_modified->alias = "1234";
-        database.update_graph_on_updated_entity(domain_id, process_id_1);
+        database.update_graph_on_updated_entity(domain_entity_id, process_id_1);
 
         std::shared_ptr<const database::Entity> topic_const_entity_modified = database.get_entity(topic_id);
         std::shared_ptr<database::Entity> topic_entity_modified = std::const_pointer_cast<database::Entity>(
             topic_const_entity_modified);
         topic_entity_modified->alias = "HelloWorld";
-        database.update_graph_on_updated_entity(domain_id, topic_id);
+        database.update_graph_on_updated_entity(domain_entity_id, topic_id);
 
         std::shared_ptr<const database::Entity> datawriter_const_entity_modified = database.get_entity(datawriter_id_1);
         std::shared_ptr<database::Entity> datawriter_entity_modified = std::const_pointer_cast<database::Entity>(
             datawriter_const_entity_modified);
         datawriter_entity_modified->alias = "publisher";
-        database.update_graph_on_updated_entity(domain_id, datawriter_id_1);
+        database.update_graph_on_updated_entity(domain_entity_id, datawriter_id_1);
 
         std::shared_ptr<const database::Entity> datareader_const_entity_modified = database.get_entity(datareader_id_2);
         std::shared_ptr<database::Entity> datareader_entity_modified = std::const_pointer_cast<database::Entity>(
             datareader_const_entity_modified);
         datareader_entity_modified->alias = "subscriber";
-        database.update_graph_on_updated_entity(domain_id, datareader_id_2);
+        database.update_graph_on_updated_entity(domain_entity_id, datareader_id_2);
 
         // Change status
         database.change_entity_status(datawriter_id_1, false);
-        database.update_endpoint_in_graph(domain_id, participant_id_1, topic_id, datawriter_id_1);
+        database.update_endpoint_in_graph(domain_entity_id, participant_id_1, topic_id, datawriter_id_1);
 
         // Load reference graph
         load_file(DOMAIN_VIEW_GRAPH_UNDISCOVER_ENDPOINT_DUMP_FILE, json_graph);
@@ -354,7 +355,7 @@ TEST_F(database_domain_view_graph_tests, complete_with_two_participants)
     // Undiscovery second participant
     {
         database.change_entity_status(participant_id_2, false);
-        database.update_endpoint_in_graph(domain_id, participant_id_2, topic_id, datareader_id_2);
+        database.update_endpoint_in_graph(domain_entity_id, participant_id_2, topic_id, datareader_id_2);
         database.update_participant_in_graph(domain->id, host_id, user_id, process_id_2, participant_id_2);
 
         // Load reference graph
@@ -382,7 +383,7 @@ TEST_F(database_domain_view_graph_tests, host_insert_failure)
         participant_id_1 = database.insert(participant_1);
 
         // Add participant to graph
-        database.update_participant_in_graph(domain_id, EntityId(), EntityId(), EntityId(), participant_id_1);
+        database.update_participant_in_graph(domain_entity_id, EntityId(), EntityId(), EntityId(), participant_id_1);
 
         // Insert topic
         topic_id = database.insert(topic);
@@ -395,7 +396,7 @@ TEST_F(database_domain_view_graph_tests, host_insert_failure)
         datawriter_id_1 = database.insert(datawriter_1);
 
         // Add endpoint and topic to graph
-        database.update_endpoint_in_graph(domain_id, participant_id_1, topic_id, datawriter_id_1);
+        database.update_endpoint_in_graph(domain_entity_id, participant_id_1, topic_id, datawriter_id_1);
 
         // Load reference graph
         load_file(DOMAIN_VIEW_GRAPH_HOST_INSERT_FAILURE_DUMP_FILE, json_graph);
@@ -406,7 +407,7 @@ TEST_F(database_domain_view_graph_tests, host_insert_failure)
     {
         // Delete topic with no endpoint in the graph
         database.change_entity_status(datawriter_id_1, false);
-        database.update_endpoint_in_graph(domain_id, participant_id_1, topic_id, datawriter_id_1);
+        database.update_endpoint_in_graph(domain_entity_id, participant_id_1, topic_id, datawriter_id_1);
 
         // Load reference graph
         load_file(DOMAIN_VIEW_GRAPH_EMPTY_DOMAIN_DUMP_FILE, json_graph);
@@ -437,7 +438,7 @@ TEST_F(database_domain_view_graph_tests, user_insert_failure)
     participant_id_1 = database.insert(participant_1);
 
     // Add participant to graph
-    database.update_participant_in_graph(domain_id, host_id, EntityId(), EntityId(), participant_id_1);
+    database.update_participant_in_graph(domain_entity_id, host_id, EntityId(), EntityId(), participant_id_1);
 
     // Insert topic
     topic_id = database.insert(topic);
@@ -450,7 +451,7 @@ TEST_F(database_domain_view_graph_tests, user_insert_failure)
     datawriter_id_1 = database.insert(datawriter_1);
 
     // Add endpoint and topic to graph
-    database.update_endpoint_in_graph(domain_id, participant_id_1, topic_id, datawriter_id_1);
+    database.update_endpoint_in_graph(domain_entity_id, participant_id_1, topic_id, datawriter_id_1);
 
     // Load reference graph
     load_file(DOMAIN_VIEW_GRAPH_USER_INSERT_FAILURE_DUMP_FILE, json_graph);
@@ -480,7 +481,7 @@ TEST_F(database_domain_view_graph_tests, process_insert_failure)
     participant_id_1 = database.insert(participant_1);
 
     // Add participant to graph
-    database.update_participant_in_graph(domain_id, host_id, user_id, EntityId(), participant_id_1);
+    database.update_participant_in_graph(domain_entity_id, host_id, user_id, EntityId(), participant_id_1);
 
     // Insert topic
     topic_id = database.insert(topic);
@@ -493,7 +494,7 @@ TEST_F(database_domain_view_graph_tests, process_insert_failure)
     datawriter_id_1 = database.insert(datawriter_1);
 
     // Add endpoint and topic to graph
-    database.update_endpoint_in_graph(domain_id, participant_id_1, topic_id, datawriter_id_1);
+    database.update_endpoint_in_graph(domain_entity_id, participant_id_1, topic_id, datawriter_id_1);
 
     // Load reference graph
     load_file(DOMAIN_VIEW_GRAPH_PROCESS_INSERT_FAILURE_DUMP_FILE, json_graph);
@@ -525,7 +526,7 @@ TEST_F(database_domain_view_graph_tests, regenerate_graph_functionality)
     database.link_participant_with_process(participant_id_1, process_id_1);
 
     // Add participant to graph
-    database.update_participant_in_graph(domain_id, host_id, user_id, process_id_1, participant_id_1);
+    database.update_participant_in_graph(domain_entity_id, host_id, user_id, process_id_1, participant_id_1);
 
     // Insert topic
     topic_id = database.insert(topic);
@@ -538,13 +539,13 @@ TEST_F(database_domain_view_graph_tests, regenerate_graph_functionality)
     datawriter_id_1 = database.insert(datawriter_1);
 
     // Add endpoint and topic to graph
-    database.update_endpoint_in_graph(domain_id, participant_id_1, topic_id, datawriter_id_1);
+    database.update_endpoint_in_graph(domain_entity_id, participant_id_1, topic_id, datawriter_id_1);
 
     // Insert participant_2 from process_2
     process_id_2 = database.insert(process_2);
     participant_id_2 = database.insert(participant_2);
     database.link_participant_with_process(participant_id_2, process_id_2);
-    database.update_participant_in_graph(domain_id, host_id, user_id, process_id_2, participant_id_2);
+    database.update_participant_in_graph(domain_entity_id, host_id, user_id, process_id_2, participant_id_2);
 
     // Insert locator
     locator_id_2 = database.insert(locator_2);
@@ -554,26 +555,26 @@ TEST_F(database_domain_view_graph_tests, regenerate_graph_functionality)
     datareader_id_2 = database.insert(datareader_2);
 
     // Add endpoint and topic to graph
-    database.update_endpoint_in_graph(domain_id, participant_id_2, topic_id, datareader_id_2);
+    database.update_endpoint_in_graph(domain_entity_id, participant_id_2, topic_id, datareader_id_2);
 
     // Undiscovery datawriter publisher
     load_file(DOMAIN_VIEW_GRAPH_UNDISCOVER_ENDPOINT_DUMP_FILE, json_graph);
     database.change_entity_status(datawriter_id_1, false);
-    database.regenerate_domain_graph(domain_id);
+    database.regenerate_domain_graph(domain_entity_id);
 
     ASSERT_EQ(json_graph, database.get_domain_view_graph(0));
 
     // Undiscovery first participant
     load_file(DOMAIN_VIEW_GRAPH_UNDISCOVER_PARTICIPANT_DUMP_FILE, json_graph);
     database.change_entity_status(participant_id_1, false);
-    database.regenerate_domain_graph(domain_id);
+    database.regenerate_domain_graph(domain_entity_id);
 
     ASSERT_EQ(json_graph, database.get_domain_view_graph(0));
 
     // Undiscovery second participant
     load_file(DOMAIN_VIEW_GRAPH_EMPTY_DOMAIN_DUMP_FILE, json_graph);
     database.change_entity_status(participant_id_2, false);
-    database.regenerate_domain_graph(domain_id);
+    database.regenerate_domain_graph(domain_entity_id);
     ASSERT_EQ(json_graph, database.get_domain_view_graph(0));
 }
 
@@ -601,7 +602,7 @@ TEST_F(database_domain_view_graph_tests, graph_with_strange_user_host_characters
     database.link_participant_with_process(participant_id_1, weird_process_id);
 
     // Add participant to graph
-    database.update_participant_in_graph(domain_id, host_id, user_id, process_id_1, participant_id_1);
+    database.update_participant_in_graph(domain_entity_id, host_id, user_id, process_id_1, participant_id_1);
 
     // Retrieve graph
     json_graph = database.get_domain_view_graph(0);

--- a/test/unittest/Database/DatabaseDumpTests.cpp
+++ b/test/unittest/Database/DatabaseDumpTests.cpp
@@ -49,6 +49,7 @@ constexpr const int16_t MAGNITUDE_DEFAULT = 0;
 #define USER_DEFAULT_NAME(x) "user_" + std::to_string(x)
 #define PROCESS_DEFAULT_NAME(x) "process_" + std::to_string(x)
 #define DOMAIN_DEFAULT_NAME(x) "12" + std::to_string(x)
+#define DOMAIN_DEFAULT_DOMAIN_ID(x) static_cast<DomainId>(std::stoul(DOMAIN_DEFAULT_NAME(x)))
 #define ALIAS_DEFAULT_NAME(x) "domain_" + std::to_string(x)
 #define TOPIC_DEFAULT_NAME(x) "topic_" + std::to_string(x)
 #define PARTICIPANT_DEFAULT_NAME(x) "participant_" + std::to_string(x)
@@ -79,7 +80,7 @@ void initialize_empty_entities(
     std::shared_ptr<User> user = std::make_shared<User>(std::string(USER_DEFAULT_NAME(index)), host);
     std::shared_ptr<Process> process = std::make_shared<Process>(std::string(PROCESS_DEFAULT_NAME(
                         index)), PID_DEFAULT, user);
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(index)));
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(index)), DOMAIN_DEFAULT_DOMAIN_ID(index));
     domain->alias = ALIAS_DEFAULT_NAME(index);
     std::shared_ptr<Topic> topic = std::make_shared<Topic>(std::string(TOPIC_DEFAULT_NAME(
                         index)), DATA_TYPE_DEFAULT, domain);
@@ -390,7 +391,7 @@ void initialize_empty_entities_unlinked(
     std::shared_ptr<User> user = std::make_shared<User>(std::string(USER_DEFAULT_NAME(index)), host);
     std::shared_ptr<Process> process = std::make_shared<Process>(std::string(PROCESS_DEFAULT_NAME(
                         index)), PID_DEFAULT, user);
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(index)));
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(index)), DOMAIN_DEFAULT_DOMAIN_ID(index));
     domain->alias = ALIAS_DEFAULT_NAME(index);
     std::shared_ptr<Topic> topic = std::make_shared<Topic>(std::string(TOPIC_DEFAULT_NAME(
                         index)), DATA_TYPE_DEFAULT, domain);

--- a/test/unittest/Database/DatabaseDumpTests.cpp
+++ b/test/unittest/Database/DatabaseDumpTests.cpp
@@ -80,7 +80,8 @@ void initialize_empty_entities(
     std::shared_ptr<User> user = std::make_shared<User>(std::string(USER_DEFAULT_NAME(index)), host);
     std::shared_ptr<Process> process = std::make_shared<Process>(std::string(PROCESS_DEFAULT_NAME(
                         index)), PID_DEFAULT, user);
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(index)), DOMAIN_DEFAULT_DOMAIN_ID(index));
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(
+                        index)), DOMAIN_DEFAULT_DOMAIN_ID(index));
     domain->alias = ALIAS_DEFAULT_NAME(index);
     std::shared_ptr<Topic> topic = std::make_shared<Topic>(std::string(TOPIC_DEFAULT_NAME(
                         index)), DATA_TYPE_DEFAULT, domain);
@@ -391,7 +392,8 @@ void initialize_empty_entities_unlinked(
     std::shared_ptr<User> user = std::make_shared<User>(std::string(USER_DEFAULT_NAME(index)), host);
     std::shared_ptr<Process> process = std::make_shared<Process>(std::string(PROCESS_DEFAULT_NAME(
                         index)), PID_DEFAULT, user);
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(index)), DOMAIN_DEFAULT_DOMAIN_ID(index));
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(
+                        index)), DOMAIN_DEFAULT_DOMAIN_ID(index));
     domain->alias = ALIAS_DEFAULT_NAME(index);
     std::shared_ptr<Topic> topic = std::make_shared<Topic>(std::string(TOPIC_DEFAULT_NAME(
                         index)), DATA_TYPE_DEFAULT, domain);

--- a/test/unittest/Database/DatabaseEraseTests.cpp
+++ b/test/unittest/Database/DatabaseEraseTests.cpp
@@ -85,7 +85,8 @@ void check_erased_database(
 void erase_and_check(
         const std::string& initial_filename,
         const std::string& final_filename,
-        const std::string& domain)
+        const std::string& domain_name,
+        const DomainId domain_id)
 {
     // Read JSON files
     DatabaseDump initial_dump;
@@ -100,17 +101,17 @@ void erase_and_check(
     db.load_database(initial_dump);
 
     // Call erase monitor removing domain_1
-    std::vector<std::pair<EntityId, EntityId>> domains = db.get_entities_by_name(EntityKind::DOMAIN, domain);
-    EntityId domain_id = domains.begin()->first;
-    db.init_domain_view_graph(domain, domain_id);
-    db.regenerate_domain_graph(domain_id);
+    std::vector<std::pair<EntityId, EntityId>> domains = db.get_entities_by_name(EntityKind::DOMAIN, domain_name);
+    EntityId domain_entity_id = domains.begin()->first;
+    db.init_domain_view_graph(domain_name, domain_id, domain_entity_id);
+    db.regenerate_domain_graph(domain_entity_id);
     // Save entities associated to the erased domain to check that the cross maps are correctly erased.
-    std::vector<std::shared_ptr<const Entity>> participants = db.get_entities(EntityKind::PARTICIPANT, domain_id);
-    std::vector<std::shared_ptr<const Entity>> readers = db.get_entities(EntityKind::DATAREADER, domain_id);
-    std::vector<std::shared_ptr<const Entity>> writers = db.get_entities(EntityKind::DATAWRITER, domain_id);
-    db.erase(domain_id);
+    std::vector<std::shared_ptr<const Entity>> participants = db.get_entities(EntityKind::PARTICIPANT, domain_entity_id);
+    std::vector<std::shared_ptr<const Entity>> readers = db.get_entities(EntityKind::DATAREADER, domain_entity_id);
+    std::vector<std::shared_ptr<const Entity>> writers = db.get_entities(EntityKind::DATAWRITER, domain_entity_id);
+    db.erase(domain_entity_id);
 
-    check_erased_database(db, domain_id, participants, readers, writers);
+    check_erased_database(db, domain_entity_id, participants, readers, writers);
 
     // Dump erased database
     DatabaseDump erased_dump = db.dump_database();
@@ -126,7 +127,7 @@ void erase_and_check(
  */
 TEST(database_erase_tests, erase_domain_1)
 {
-    erase_and_check(COMPLEX_DUMP_FILE, COMPLEX_ERASED_DOMAIN_1_DUMP_FILE, "121");
+    erase_and_check(COMPLEX_DUMP_FILE, COMPLEX_ERASED_DOMAIN_1_DUMP_FILE, "121", 121);
 }
 
 /**
@@ -136,14 +137,14 @@ TEST(database_erase_tests, erase_domain_1)
  */
 TEST(database_erase_tests, erase_domain_2)
 {
-    erase_and_check(ALTERNATIVE_COMPLEX_DUMP_FILE, ALTERNATIVE_COMPLEX_ERASED_DOMAIN_2_DUMP_FILE, "122");
+    erase_and_check(ALTERNATIVE_COMPLEX_DUMP_FILE, ALTERNATIVE_COMPLEX_ERASED_DOMAIN_2_DUMP_FILE, "122", 122);
 }
 
 // This test checks that erasing a database where the participant is not yet linked to the process works as expected
 TEST(database_erase_tests, erase_domain_unlinked_participant_process)
 {
     erase_and_check(NO_PROCESS_PARTICIPANT_LINK_DUMP_FILE, NO_PROCESS_PARTICIPANT_LINK_ERASED_DOMAIN_DUMP_FILE,
-            "120");
+            "120", 120);
 }
 
 // This test checks that calling erase with an EntityId that does not correspond with EntityKind::DOMAIN, kills the

--- a/test/unittest/Database/DatabaseEraseTests.cpp
+++ b/test/unittest/Database/DatabaseEraseTests.cpp
@@ -106,7 +106,8 @@ void erase_and_check(
     db.init_domain_view_graph(domain_name, domain_id, domain_entity_id);
     db.regenerate_domain_graph(domain_entity_id);
     // Save entities associated to the erased domain to check that the cross maps are correctly erased.
-    std::vector<std::shared_ptr<const Entity>> participants = db.get_entities(EntityKind::PARTICIPANT, domain_entity_id);
+    std::vector<std::shared_ptr<const Entity>> participants =
+            db.get_entities(EntityKind::PARTICIPANT, domain_entity_id);
     std::vector<std::shared_ptr<const Entity>> readers = db.get_entities(EntityKind::DATAREADER, domain_entity_id);
     std::vector<std::shared_ptr<const Entity>> writers = db.get_entities(EntityKind::DATAWRITER, domain_entity_id);
     db.erase(domain_entity_id);

--- a/test/unittest/Database/DatabaseProcessEntitiesTests.cpp
+++ b/test/unittest/Database/DatabaseProcessEntitiesTests.cpp
@@ -94,7 +94,7 @@ public:
 TEST_F(database_process_entities_tests, insert_new_participant)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Create a DomainParticipant*/
@@ -129,7 +129,7 @@ TEST_F(database_process_entities_tests, insert_new_participant)
 TEST_F(database_process_entities_tests, insert_new_participant_already_exists)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -171,7 +171,7 @@ TEST_F(database_process_entities_tests, insert_new_participant_no_domain)
 TEST_F(database_process_entities_tests, process_physical_entities)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -240,7 +240,7 @@ TEST_F(database_process_entities_tests, process_physical_entities)
 TEST_F(database_process_entities_tests, process_physical_entities_no_link)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -306,7 +306,7 @@ TEST_F(database_process_entities_tests, process_physical_entities_no_link)
 TEST_F(database_process_entities_tests, process_physical_entities_no_process)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -382,7 +382,7 @@ TEST_F(database_process_entities_tests, process_physical_entities_no_process)
 TEST_F(database_process_entities_tests, process_physical_entities_no_process_no_user)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -462,7 +462,7 @@ TEST_F(database_process_entities_tests, process_physical_entities_no_process_no_
 TEST_F(database_process_entities_tests, process_physical_entities_no_process_no_user_no_host)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -543,7 +543,7 @@ TEST_F(database_process_entities_tests, process_physical_entities_no_process_no_
 TEST_F(database_process_entities_tests, process_physical_entities_process_throws)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -608,7 +608,7 @@ TEST_F(database_process_entities_tests, process_physical_entities_process_throws
 TEST_F(database_process_entities_tests, process_physical_entities_user_throws)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -665,7 +665,7 @@ TEST_F(database_process_entities_tests, process_physical_entities_user_throws)
 TEST_F(database_process_entities_tests, process_physical_entities_host_throws)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -718,7 +718,7 @@ TEST_F(database_process_entities_tests, process_physical_entities_host_throws)
 TEST_F(database_process_entities_tests, is_topic_in_database)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     std::shared_ptr<Topic> topic = std::make_shared<Topic>(topic_name, topic_type, domain);
@@ -739,7 +739,7 @@ TEST_F(database_process_entities_tests, is_topic_in_database)
 TEST_F(database_process_entities_tests, insert_new_topic)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Create a Topic*/
@@ -761,7 +761,7 @@ TEST_F(database_process_entities_tests, insert_new_topic)
 TEST_F(database_process_entities_tests, insert_new_topic_already_exists)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -794,7 +794,7 @@ TEST_F(database_process_entities_tests, insert_new_topic_no_domain)
 TEST_F(database_process_entities_tests, insert_new_endpoint_datawriter)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -877,7 +877,7 @@ TEST_F(database_process_entities_tests, insert_new_endpoint_datawriter)
 TEST_F(database_process_entities_tests, insert_new_endpoint_datareader)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -961,7 +961,7 @@ TEST_F(database_process_entities_tests, insert_new_endpoint_datareader)
 TEST_F(database_process_entities_tests, insert_new_endpoint_already_exists)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -1026,7 +1026,7 @@ TEST_F(database_process_entities_tests, insert_new_endpoint_already_exists)
 TEST_F(database_process_entities_tests, insert_new_endpoint_no_topic)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert a DomainParticipant*/
@@ -1075,7 +1075,7 @@ TEST_F(database_process_entities_tests, insert_new_endpoint_no_topic)
 TEST_F(database_process_entities_tests, insert_new_endpoint_no_participant)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert a Topic*/
@@ -1119,7 +1119,7 @@ TEST_F(database_process_entities_tests, insert_new_endpoint_no_participant)
 TEST_F(database_process_entities_tests, insert_new_endpoint_no_locators)
 {
     /* Insert a domain */
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain");
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant*/

--- a/test/unittest/Database/DatabaseStatusTests.cpp
+++ b/test/unittest/Database/DatabaseStatusTests.cpp
@@ -475,7 +475,7 @@ TEST_F(database_status_tests, domain)
     ASSERT_TRUE(locator->active);
 
     // The new entity will be active
-    auto domain1 = std::make_shared<Domain>("domain1");
+    auto domain1 = std::make_shared<Domain>("domain1", 1);
     db.insert(domain1);
     ASSERT_TRUE(domain1->active);
 

--- a/test/unittest/Database/DatabaseTests.cpp
+++ b/test/unittest/Database/DatabaseTests.cpp
@@ -43,7 +43,7 @@ void insert_ddsendpoint_valid()
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     auto domain_id = db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
@@ -113,7 +113,7 @@ void insert_ddsendpoint_two_valid()
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     auto domain_id = db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
@@ -216,7 +216,7 @@ void insert_ddsendpoint_duplicated()
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
@@ -245,7 +245,7 @@ void insert_ddsendpoint_wrong_participant()
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
@@ -275,7 +275,7 @@ void insert_ddsendpoint_wrong_topic()
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
@@ -304,7 +304,7 @@ void insert_ddsendpoint_empty_name()
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
@@ -332,7 +332,7 @@ void insert_ddsendpoint_empty_qos()
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
@@ -360,7 +360,7 @@ void insert_ddsendpoint_empty_guid()
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
@@ -388,7 +388,7 @@ void insert_ddsendpoint_empty_locators()
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
@@ -413,7 +413,7 @@ void insert_ddsendpoint_two_same_domain_same_guid()
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
@@ -447,9 +447,9 @@ void insert_ddsendpoint_two_diff_domain_same_guid()
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
-    auto domain_2 = std::make_shared<Domain>("test_domain_2");
+    auto domain_2 = std::make_shared<Domain>("test_domain_2", 1);
     db.insert(domain_2);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
@@ -488,7 +488,7 @@ void insert_ddsendpoint_two_equal_locators()
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     auto domain_id = db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain);
@@ -567,7 +567,7 @@ public:
         user_id = db.insert(user);
         process.reset(new Process(process_name, "12345", user));
         process_id = db.insert(process);
-        domain.reset(new Domain(domain_name));
+        domain.reset(new Domain(domain_name, 0));
         domain_id = db.insert(domain);
         participant.reset(new DomainParticipant(participant_name, db.test_qos, participant_guid, nullptr, domain));
         participant_id = db.insert(participant);
@@ -1064,7 +1064,7 @@ TEST_F(database_tests, insert_domain_valid)
     /* Insert a domain */
     DataBaseTest db;
     std::string domain_name = "test_domain";
-    auto domain = std::make_shared<Domain>(domain_name);
+    auto domain = std::make_shared<Domain>(domain_name, 0);
     EntityId domain_id = db.insert(domain);
 
     /* Check that the domain is inserted correctly */
@@ -1081,8 +1081,8 @@ TEST_F(database_tests, insert_domain_two_valid)
     DataBaseTest db;
     std::string domain_name = "test_domain";
     std::string domain_name_2 = "test_domain_2";
-    auto domain = std::make_shared<Domain>(domain_name);
-    auto domain_2 = std::make_shared<Domain>(domain_name_2);
+    auto domain = std::make_shared<Domain>(domain_name, 0);
+    auto domain_2 = std::make_shared<Domain>(domain_name_2, 1);
     EntityId domain_id = db.insert(domain);
     EntityId domain_id_2 = db.insert(domain_2);
 
@@ -1101,7 +1101,7 @@ TEST_F(database_tests, insert_domain_duplicated)
 {
     /* Insert a domain twice */
     DataBaseTest db;
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     ASSERT_THROW(db.insert(domain), BadParameter);
 }
@@ -1110,7 +1110,7 @@ TEST_F(database_tests, insert_domain_empty_name)
 {
     /* Insert a domain with empty name */
     DataBaseTest db;
-    auto domain = std::make_shared<Domain>("");
+    auto domain = std::make_shared<Domain>("", 0);
     ASSERT_THROW(db.insert(domain), BadParameter);
 }
 
@@ -1118,8 +1118,8 @@ TEST_F(database_tests, insert_domain_same_name)
 {
     /* Insert two domains with same name */
     DataBaseTest db;
-    auto domain = std::make_shared<Domain>("test_domain");
-    auto domain_2 = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
+    auto domain_2 = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     ASSERT_THROW(db.insert(domain_2), BadParameter);
 }
@@ -1128,7 +1128,7 @@ TEST_F(database_tests, insert_topic_valid)
 {
     /* Insert a domain */
     DataBaseTest db;
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert a topic */
@@ -1155,7 +1155,7 @@ TEST_F(database_tests, insert_topic_two_valid)
 {
     /* Insert a domain */
     DataBaseTest db;
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert two topics */
@@ -1192,7 +1192,7 @@ TEST_F(database_tests, insert_topic_duplicated)
 {
     /* Insert a domain */
     DataBaseTest db;
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert a topic twice */
@@ -1205,11 +1205,11 @@ TEST_F(database_tests, insert_topic_wrong_domain)
 {
     /* Insert a domain */
     DataBaseTest db;
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert a topic with a non-inserted domain */
-    auto domain_2 = std::make_shared<Domain>("test_domain_2");
+    auto domain_2 = std::make_shared<Domain>("test_domain_2", 1);
     auto topic = std::make_shared<Topic>("test_topic_name", "test_topic_type", domain_2);
     ASSERT_THROW(db.insert(topic), BadParameter);
 }
@@ -1218,7 +1218,7 @@ TEST_F(database_tests, insert_topic_empty_name)
 {
     /* Insert a domain */
     DataBaseTest db;
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert a topic with empty name */
@@ -1230,7 +1230,7 @@ TEST_F(database_tests, insert_topic_empty_datatype)
 {
     /* Insert a domain */
     DataBaseTest db;
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert a topic with empty data_type */
@@ -1242,7 +1242,7 @@ TEST_F(database_tests, insert_topic_two_same_domain_same_name)
 {
     /* Insert a domain */
     DataBaseTest db;
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert two topics with different types */
@@ -1279,7 +1279,7 @@ TEST_F(database_tests, insert_topic_two_same_domain_same_name_same_type)
 {
     /* Insert a domain */
     DataBaseTest db;
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert two topics with same name and type */
@@ -1296,7 +1296,7 @@ TEST_F(database_tests, insert_topic_two_same_domain_diff_name_same_type)
 {
     /* Insert a domain */
     DataBaseTest db;
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     EntityId domain_id = db.insert(domain);
 
     /* Insert two topics */
@@ -1340,7 +1340,7 @@ TEST_F(database_tests, insert_participant_valid)
     db.insert(process);
 
     /* Insert a domain */
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     auto domain_id = db.insert(domain);
 
     /* Insert a DomainParticipant */
@@ -1377,7 +1377,7 @@ TEST_F(database_tests, insert_participant_two_valid)
     db.insert(process);
 
     /* Insert a domain */
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     auto domain_id = db.insert(domain);
 
     /* Insert two DomainParticipants */
@@ -1423,7 +1423,7 @@ TEST_F(database_tests, insert_participant_duplicated)
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert a DomainParticipant */
@@ -1443,11 +1443,11 @@ TEST_F(database_tests, insert_participant_wrong_domain)
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert a DomainParticipant in a non-inserted domain */
-    auto domain_2 = std::make_shared<Domain>("test_domain_2");
+    auto domain_2 = std::make_shared<Domain>("test_domain_2", 1);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", process, domain_2);
     ASSERT_THROW(db.insert(participant), BadParameter);
@@ -1463,7 +1463,7 @@ TEST_F(database_tests, insert_participant_empty_name)
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert a DomainParticipant with an empty name */
@@ -1482,7 +1482,7 @@ TEST_F(database_tests, insert_participant_empty_qos)
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert a DomainParticipant with an empty name */
@@ -1501,7 +1501,7 @@ TEST_F(database_tests, insert_participant_empty_guid)
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert a DomainParticipant with an empty name */
@@ -1520,7 +1520,7 @@ TEST_F(database_tests, insert_participant_two_same_domain_same_guid)
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
 
     /* Insert two DomainParticipants with same domain and guid */
@@ -1543,9 +1543,9 @@ TEST_F(database_tests, insert_participant_two_diff_domain_same_guid)
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
-    auto domain_2 = std::make_shared<Domain>("test_domain_2");
+    auto domain_2 = std::make_shared<Domain>("test_domain_2", 1);
     db.insert(domain_2);
 
     /* Insert two DomainParticipants with different domain and same guid */
@@ -1720,7 +1720,7 @@ TEST_F(database_tests, link_participant_with_process_unlinked)
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     auto process_id = db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     auto domain_id = db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", nullptr, domain);
@@ -1756,7 +1756,7 @@ TEST_F(database_tests, link_participant_with_process_wrong_participant)
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     auto process_id = db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", nullptr, domain);
@@ -1776,7 +1776,7 @@ TEST_F(database_tests, link_participant_with_process_wrong_process)
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", nullptr, domain);
@@ -1796,7 +1796,7 @@ TEST_F(database_tests, link_participant_with_process_linked_participant)
     db.insert(user);
     auto process = std::make_shared<Process>("test_process", "test_pid", user);
     auto process_id = db.insert(process);
-    auto domain = std::make_shared<Domain>("test_domain");
+    auto domain = std::make_shared<Domain>("test_domain", 0);
     db.insert(domain);
     auto participant = std::make_shared<DomainParticipant>(
         "test_participant", db.test_qos, "01.02.03.04", nullptr, domain);
@@ -3427,7 +3427,7 @@ TEST_F(database_tests, get_entities_by_name_topic)
     EXPECT_EQ(topics[0].second, topic_id);
 
     /* Insert another one with the same name and check that both of them are retrieved correctly */
-    auto domain_2 = std::make_shared<Domain>("domain_2");
+    auto domain_2 = std::make_shared<Domain>("domain_2", 1);
     db.insert(domain_2);
     auto topic_2 = std::make_shared<Topic>(topic_name, topic_type, domain_2);
     auto topic_id_2 = db.insert(topic_2);

--- a/test/unittest/Resources/alternative_complex_dump.json
+++ b/test/unittest/Resources/alternative_complex_dump.json
@@ -606,6 +606,7 @@
         "13":{
             "name":"121",
             "alias":"domain_1",
+            "domain_id": 121,
             "metatraffic":false,
             "alive":true,
             "status": 0,
@@ -619,6 +620,7 @@
         "22":{
             "name":"122",
             "alias":"domain_2",
+            "domain_id": 122,
             "metatraffic":false,
             "alive":true,
             "status": 0,
@@ -632,6 +634,7 @@
         "4":{
             "name":"120",
             "alias":"domain_0",
+            "domain_id": 120,
             "metatraffic":false,
             "alive":true,
             "status": 0,

--- a/test/unittest/Resources/alternative_complex_dump_erased_domain_2.json
+++ b/test/unittest/Resources/alternative_complex_dump_erased_domain_2.json
@@ -407,6 +407,7 @@
         "13":{
             "name":"121",
             "alias":"domain_1",
+            "domain_id": 121,
             "metatraffic":false,
             "alive":true,
             "status": 0,
@@ -420,6 +421,7 @@
         "22": {
             "name": "122",
             "alias": "domain_2",
+            "domain_id": 122,
             "metatraffic": false,
             "alive": true,
             "status": 0,
@@ -429,6 +431,7 @@
         "4":{
             "name":"120",
             "alias":"domain_0",
+            "domain_id": 120,
             "metatraffic":false,
             "alive":true,
             "status": 0,

--- a/test/unittest/Resources/complex_dump.json
+++ b/test/unittest/Resources/complex_dump.json
@@ -602,6 +602,7 @@
     "13": {
       "name": "121",
       "alias": "domain_1",
+      "domain_id": 121,
       "metatraffic": false,
       "alive": true,
       "status": 0,
@@ -615,6 +616,7 @@
     "22": {
       "name": "122",
       "alias": "domain_2",
+      "domain_id": 122,
       "metatraffic": false,
       "alive": true,
       "status": 0,
@@ -628,6 +630,7 @@
     "4": {
       "name": "120",
       "alias": "domain_0",
+      "domain_id": 120,
       "metatraffic": false,
       "alive": true,
       "status": 0,

--- a/test/unittest/Resources/complex_dump_erased_domain_1.json
+++ b/test/unittest/Resources/complex_dump_erased_domain_1.json
@@ -404,6 +404,7 @@
     "22": {
       "name": "122",
       "alias": "domain_2",
+      "domain_id": 122,
       "metatraffic": false,
       "alive": true,
       "status": 0,
@@ -417,6 +418,7 @@
     "4": {
       "name": "120",
       "alias": "domain_0",
+      "domain_id": 120,
       "metatraffic": false,
       "alive": true,
       "status": 0,
@@ -430,6 +432,7 @@
     "13":{
       "name":"121",
       "alias":"domain_1",
+      "domain_id": 121,
       "metatraffic":false,
       "alive":true,
       "status": 0,

--- a/test/unittest/Resources/database_dump.json
+++ b/test/unittest/Resources/database_dump.json
@@ -1295,6 +1295,7 @@
         "13":{
             "name":"domain_1",
             "alias":"domain_1",
+            "domain_id": 1,
             "metatraffic":false,
             "alive":true,
             "status": 0,
@@ -1308,6 +1309,7 @@
         "22":{
             "name":"domain_2",
             "alias":"domain_2",
+            "domain_id": 2,
             "metatraffic":false,
             "alive":true,
             "status": 0,

--- a/test/unittest/Resources/domain_view_graph_backend_get_domain_view_graph.json
+++ b/test/unittest/Resources/domain_view_graph_backend_get_domain_view_graph.json
@@ -1,5 +1,9 @@
 {
-    "domain": "domain2",
+    "domain_info":
+    {
+        "domain_id": 2,
+        "domain_name": "domain2"
+    },
     "hosts": {
         "1": {
             "alias": "host2",

--- a/test/unittest/Resources/domain_view_graph_empty_domain.json
+++ b/test/unittest/Resources/domain_view_graph_empty_domain.json
@@ -1,6 +1,10 @@
 {
     "kind": "domain",
-    "domain": "33",
+    "domain_info":
+    {
+        "domain_id": 33,
+        "domain_name": "33"
+    },
     "topics":
     {},
     "hosts":

--- a/test/unittest/Resources/domain_view_graph_host_insert_failure.json
+++ b/test/unittest/Resources/domain_view_graph_host_insert_failure.json
@@ -1,6 +1,10 @@
 {
     "kind": "domain",
-    "domain": "33",
+    "domain_info":
+    {
+        "domain_id": 33,
+        "domain_name": "33"
+    },
     "topics":
     {
         "2":

--- a/test/unittest/Resources/domain_view_graph_process_insert_failure.json
+++ b/test/unittest/Resources/domain_view_graph_process_insert_failure.json
@@ -1,6 +1,10 @@
 {
     "kind": "domain",
-    "domain": "33",
+    "domain_info":
+    {
+        "domain_id": 33,
+        "domain_name": "33"
+    },
     "topics":
     {
         "4":

--- a/test/unittest/Resources/domain_view_graph_two_participants.json
+++ b/test/unittest/Resources/domain_view_graph_two_participants.json
@@ -1,6 +1,10 @@
 {
     "kind": "domain",
-    "domain": "33",
+    "domain_info":
+    {
+        "domain_id": 33,
+        "domain_name": "33"
+    },
     "topics":
     {
         "5":

--- a/test/unittest/Resources/domain_view_graph_undiscover_endpoint.json
+++ b/test/unittest/Resources/domain_view_graph_undiscover_endpoint.json
@@ -1,6 +1,10 @@
 {
     "kind": "domain",
-    "domain": "33",
+    "domain_info":
+    {
+        "domain_id": 33,
+        "domain_name": "33"
+    },
     "topics":
     {
         "5":

--- a/test/unittest/Resources/domain_view_graph_undiscover_participant.json
+++ b/test/unittest/Resources/domain_view_graph_undiscover_participant.json
@@ -1,6 +1,10 @@
 {
     "kind": "domain",
-    "domain": "33",
+    "domain_info":
+    {
+        "domain_id": 33,
+        "domain_name": "33"
+    },
     "topics":
     {
         "5":

--- a/test/unittest/Resources/domain_view_graph_updated_entites.json
+++ b/test/unittest/Resources/domain_view_graph_updated_entites.json
@@ -1,6 +1,10 @@
 {
     "kind": "domain",
-    "domain": "33",
+    "domain_info":
+    {
+        "domain_id": 33,
+        "domain_name": "33"
+    },
     "topics":
     {
         "5":

--- a/test/unittest/Resources/domain_view_graph_user_insert_failure.json
+++ b/test/unittest/Resources/domain_view_graph_user_insert_failure.json
@@ -1,6 +1,10 @@
 {
     "kind": "domain",
-    "domain": "33",
+    "domain_info":
+    {
+        "domain_id": 33,
+        "domain_name": "33"
+    },
     "topics":
     {
         "3":

--- a/test/unittest/Resources/empty_entities_dump.json
+++ b/test/unittest/Resources/empty_entities_dump.json
@@ -44,6 +44,7 @@
     "4": {
       "name": "120",
       "alias": "domain_0",
+      "domain_id": 120,
       "metatraffic": false,
       "alive": true,
       "status": 0,

--- a/test/unittest/Resources/empty_entities_dump_unlinked_entities.json
+++ b/test/unittest/Resources/empty_entities_dump_unlinked_entities.json
@@ -42,6 +42,7 @@
     "4": {
       "name": "120",
       "alias": "domain_0",
+      "domain_id": 120,
       "metatraffic": false,
       "alive": true,
       "status": 0,

--- a/test/unittest/Resources/old_complex_dump.json
+++ b/test/unittest/Resources/old_complex_dump.json
@@ -626,6 +626,7 @@
     "13": {
       "name": "121",
       "alias": "domain_1",
+      "domain_id": 121,
       "metatraffic": false,
       "alive": true,
       "status": 0,
@@ -639,6 +640,7 @@
     "22": {
       "name": "122",
       "alias": "domain_2",
+      "domain_id": 122,
       "metatraffic": false,
       "alive": true,
       "status": 0,
@@ -652,6 +654,7 @@
     "4": {
       "name": "120",
       "alias": "domain_0",
+      "domain_id": 120,
       "metatraffic": false,
       "alive": true,
       "status": 0,

--- a/test/unittest/Resources/simple_dump.json
+++ b/test/unittest/Resources/simple_dump.json
@@ -44,6 +44,7 @@
     "4": {
       "name": "120",
       "alias": "domain_0",
+      "domain_id": 120,
       "metatraffic": false,
       "alive": true,
       "status": 0,

--- a/test/unittest/Resources/simple_dump_no_process_participant_link.json
+++ b/test/unittest/Resources/simple_dump_no_process_participant_link.json
@@ -42,6 +42,7 @@
     "4": {
       "name": "120",
       "alias": "domain_0",
+      "domain_id": 120,
       "participants": [
         "6"
       ],

--- a/test/unittest/Resources/simple_dump_no_process_participant_link_erased_domain.json
+++ b/test/unittest/Resources/simple_dump_no_process_participant_link_erased_domain.json
@@ -49,6 +49,7 @@
         "4": {
           "name": "120",
           "alias": "domain_0",
+          "domain_id": 120,
           "participants": [],
           "metatraffic": false,
           "alive": true,

--- a/test/unittest/StatisticsBackend/IsMetatrafficTests.cpp
+++ b/test/unittest/StatisticsBackend/IsMetatrafficTests.cpp
@@ -31,8 +31,8 @@ constexpr const char* DATA_TYPE_DEFAULT = "data_type";
 #define HOST_DEFAULT_NAME(x) "host_" + std::to_string(x)
 #define USER_DEFAULT_NAME(x) "user_" + std::to_string(x)
 #define PROCESS_DEFAULT_NAME(x) "process_" + std::to_string(x)
-#define DOMAIN_DEFAULT_NAME(x) "12" + std::to_string(x)
-#define ALIAS_DEFAULT_NAME(x) "domain_" + std::to_string(x)
+#define DOMAIN_DEFAULT_NAME(x) "domain_name_" + std::to_string(x)
+#define ALIAS_DEFAULT_NAME(x) "domain_alias_" + std::to_string(x)
 #define NON_METATRAFFIC_TOPIC_NAMES {"topic_0", "rt/chatter", "Square"}
 #define METATRAFFIC_TOPIC_NAMES {"ros_discovery_info", "rt/rosout", "_fastdds_statistics_network_latency"}
 #define PARTICIPANT_DEFAULT_NAME(x) "participant_" + std::to_string(x)
@@ -47,7 +47,7 @@ TEST(is_metatraffic_tests, non_metatraffic_topic)
     // reset database
     details::StatisticsBackendData::get_instance()->database_.reset(new Database);
 
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(0)));
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(0)), 0);
     domain->alias = ALIAS_DEFAULT_NAME(0);
     details::StatisticsBackendData::get_instance()->database_->insert(domain);
 
@@ -67,7 +67,7 @@ TEST(is_metatraffic_tests, metatraffic_topic)
     // reset database
     details::StatisticsBackendData::get_instance()->database_.reset(new Database);
 
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(0)));
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(0)), 0);
     domain->alias = ALIAS_DEFAULT_NAME(0);
     details::StatisticsBackendData::get_instance()->database_->insert(domain);
 
@@ -87,7 +87,7 @@ TEST(is_metatraffic_tests, non_metatraffic_endpoint)
     // reset database
     details::StatisticsBackendData::get_instance()->database_.reset(new Database);
 
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(0)));
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(0)), 0);
     domain->alias = ALIAS_DEFAULT_NAME(0);
     details::StatisticsBackendData::get_instance()->database_->insert(domain);
 
@@ -118,7 +118,7 @@ TEST(is_metatraffic_tests, metatraffic_endpoint)
     // reset database
     details::StatisticsBackendData::get_instance()->database_.reset(new Database);
 
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(0)));
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(0)), 0);
     domain->alias = ALIAS_DEFAULT_NAME(0);
     details::StatisticsBackendData::get_instance()->database_->insert(domain);
 
@@ -162,7 +162,7 @@ TEST(is_metatraffic_tests, other_entity_kinds)
     details::StatisticsBackendData::get_instance()->database_->insert(process);
     ASSERT_EQ(StatisticsBackend::is_metatraffic(process->id), process->metatraffic);
     ASSERT_FALSE(StatisticsBackend::is_metatraffic(process->id));
-    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(0)));
+    std::shared_ptr<Domain> domain = std::make_shared<Domain>(std::string(DOMAIN_DEFAULT_NAME(0)), 0);
     domain->alias = ALIAS_DEFAULT_NAME(0);
     details::StatisticsBackendData::get_instance()->database_->insert(domain);
     ASSERT_EQ(StatisticsBackend::is_metatraffic(domain->id), domain->metatraffic);

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -182,6 +182,14 @@ TEST_F(statistics_backend_tests, get_info)
                 info.erase(LOCATOR_CONTAINER_TAG);
                 break;
             }
+            case EntityKind::DOMAIN:
+            {
+                std::shared_ptr<const Domain> domain =
+                        std::dynamic_pointer_cast<const Domain>(entity);
+                EXPECT_EQ(domain->domain_id, info[DOMAIN_ID_TAG]);
+                info.erase(DOMAIN_ID_TAG);
+                break;
+            }
             case EntityKind::DATAWRITER:
             case EntityKind::DATAREADER:
             {
@@ -555,7 +563,7 @@ TEST_F(statistics_backend_tests, get_domain_view_graph_invalid_domain)
     StatisticsBackendTest::set_database(db);
 
     // Get database graph from invalid domain
-    StatisticsBackendTest::regenerate_domain_graph(EntityId());
+    EXPECT_FALSE(StatisticsBackendTest::regenerate_domain_graph(EntityId()));
 
     // Load reference graph
     EXPECT_THROW(StatisticsBackend::get_domain_view_graph(EntityId()), BadParameter);

--- a/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
+++ b/test/unittest/StatisticsBackend/StatisticsBackendTests.cpp
@@ -491,7 +491,7 @@ TEST_F(statistics_backend_tests, set_alias)
 {
     StatisticsBackendTest::set_database(db);
     auto domains = db->get_entities_by_name(EntityKind::DOMAIN, "domain2");
-    db->init_domain_view_graph("domain2", domains[0].second);
+    db->init_domain_view_graph("domain2", 2, domains[0].second);
     StatisticsBackendTest::regenerate_domain_graph(domains[0].second);
 
     for (auto entity : entities)
@@ -541,7 +541,7 @@ TEST_F(statistics_backend_tests, get_domain_view_graph)
     StatisticsBackendTest::set_database(db);
 
     // Get database graph
-    db->init_domain_view_graph("domain2", EntityId(7));
+    db->init_domain_view_graph("domain2", 2, EntityId(7));
     StatisticsBackendTest::regenerate_domain_graph(EntityId(7));
     // Load reference graph
     Graph json_graph;

--- a/test/unittest/StatisticsParticipantListener/StatisticsParticipantListenerTests.cpp
+++ b/test/unittest/StatisticsParticipantListener/StatisticsParticipantListenerTests.cpp
@@ -370,7 +370,7 @@ public:
 
         // Domain entity
         domain_name_ = std::to_string(statistics_participant.domain_id_);
-        domain_ = std::make_shared<Domain>(domain_name_);
+        domain_ = std::make_shared<Domain>(domain_name_, 0);
         domain_->id = 0;
 
         // Host entity
@@ -2635,7 +2635,7 @@ TEST_F(statistics_participant_listener_tests, new_reader_several_topics)
 
     // Precondition: Another domain with ID 100 exists
     std::string another_domain_name = "another_domain";
-    std::shared_ptr<Domain> another_domain = std::make_shared<Domain>(another_domain_name);
+    std::shared_ptr<Domain> another_domain = std::make_shared<Domain>(another_domain_name, 0);
     EXPECT_CALL(database,
             get_entities_by_name(EntityKind::DOMAIN, another_domain_name)).Times(AnyNumber())
             .WillRepeatedly(Return(std::vector<std::pair<EntityId, EntityId>>(1,

--- a/test/unittest/TestUtils/DatabaseUtils.hpp
+++ b/test/unittest/TestUtils/DatabaseUtils.hpp
@@ -194,11 +194,11 @@ public:
         db.insert(process2);
         entities[6] = process2;
 
-        auto domain1 = std::make_shared<Domain>("domain1");
+        auto domain1 = std::make_shared<Domain>("domain1", 1);
         db.insert(domain1);
         entities[7] = domain1;
 
-        auto domain2 = std::make_shared<Domain>("domain2");
+        auto domain2 = std::make_shared<Domain>("domain2", 2);
         db.insert(domain2);
         entities[8] = domain2;
 


### PR DESCRIPTION
# Main Changes

Fast DDS Monitor checks that the domain name is the same as the domain ID in order to display data in the Domain Graph view. However, this assumption may be incorrect in cases where the domain graph is initialised with a different name. For example, the domain graph used in the Discovery Server Monitor uses the discovery server locators to generate the database entity name. This PR modifies the JSON representation of the Domain Graph, displaying both the domain name and ID in a new `domain_info` field.

Should be merged after:

- https://github.com/eProsima/Fast-DDS-statistics-backend/pull/285