### PR TITLE
Add throw of exception when SHM locators are used in discovery server initialization

### DIFF
--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -471,6 +471,10 @@ EntityId StatisticsBackend::init_monitor(
         {
             throw BadParameter("Invalid locator format: " + locator_str);
         }
+        if (locator.kind == LOCATOR_KIND_SHM)
+        {
+            throw BadParameter("SHM locators are not supported: " + locator_str);
+        }
         if (locator.port > std::numeric_limits<uint32_t>::max())
         {
             throw BadParameter(std::to_string(locator.port) + " is out of range");


### PR DESCRIPTION
This PR adds an additional validation step to the `StatisticsBackend::init_monitor` function to explicitly reject SHM (shared memory) locators. Until now, the test "init_monitor_factory_fails_tests.init_monitor_unsupported_shm" was relying on fastdds failing when performing << operators on SHM locators. That now has been fixed, so the extra check is required to pass the tests here.