### PR TITLE
Fixing proxy messages overwriting discovery source

### DIFF
--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -1485,21 +1485,21 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
                 database_->update_entity_qos(entity, item.second->optional_qos);
 
                 if (item.second->entity_discovery_info.kind() == EntityKind::PARTICIPANT &&
-                    database_->get_entity(entity)->discovery_source != DiscoverySource::DISCOVERY)
+                        database_->get_entity(entity)->discovery_source != DiscoverySource::DISCOVERY)
                 {
                     database_->update_participant_discovery_info(entity,
-                        item.second->entity_discovery_info.host,
-                        item.second->entity_discovery_info.user,
-                        item.second->entity_discovery_info.process,
-                        item.second->entity_discovery_info.participant_name,
-                        item.second->entity_discovery_info.qos,
-                        to_string(item.second->entity_discovery_info.guid),
-                        item.second->entity_discovery_info.domain_id,
-                        item.second->entity_discovery_info.entity_status,
-                        item.second->entity_discovery_info.app_id,
-                        item.second->entity_discovery_info.app_metadata,
-                        item.second->entity_discovery_info.discovery_source,
-                        item.second->entity_discovery_info.original_domain_id);
+                            item.second->entity_discovery_info.host,
+                            item.second->entity_discovery_info.user,
+                            item.second->entity_discovery_info.process,
+                            item.second->entity_discovery_info.participant_name,
+                            item.second->entity_discovery_info.qos,
+                            to_string(item.second->entity_discovery_info.guid),
+                            item.second->entity_discovery_info.domain_id,
+                            item.second->entity_discovery_info.entity_status,
+                            item.second->entity_discovery_info.app_id,
+                            item.second->entity_discovery_info.app_metadata,
+                            item.second->entity_discovery_info.discovery_source,
+                            item.second->entity_discovery_info.original_domain_id);
                 }
 
                 details::StatisticsBackendData::get_instance()->on_status_reported(domain, entity, StatusKind::PROXY);

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -1484,21 +1484,22 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
                 updated_entity = database_->insert(domain, entity, sample);
                 database_->update_entity_qos(entity, item.second->optional_qos);
 
-                if (item.second->entity_discovery_info.kind() == EntityKind::PARTICIPANT)
+                if (item.second->entity_discovery_info.kind() == EntityKind::PARTICIPANT &&
+                    database_->get_entity(entity)->discovery_source != DiscoverySource::DISCOVERY)
                 {
                     database_->update_participant_discovery_info(entity,
-                            item.second->entity_discovery_info.host,
-                            item.second->entity_discovery_info.user,
-                            item.second->entity_discovery_info.process,
-                            item.second->entity_discovery_info.participant_name,
-                            item.second->entity_discovery_info.qos,
-                            to_string(item.second->entity_discovery_info.guid),
-                            item.second->entity_discovery_info.domain_id,
-                            item.second->entity_discovery_info.entity_status,
-                            item.second->entity_discovery_info.app_id,
-                            item.second->entity_discovery_info.app_metadata,
-                            item.second->entity_discovery_info.discovery_source,
-                            item.second->entity_discovery_info.original_domain_id);
+                        item.second->entity_discovery_info.host,
+                        item.second->entity_discovery_info.user,
+                        item.second->entity_discovery_info.process,
+                        item.second->entity_discovery_info.participant_name,
+                        item.second->entity_discovery_info.qos,
+                        to_string(item.second->entity_discovery_info.guid),
+                        item.second->entity_discovery_info.domain_id,
+                        item.second->entity_discovery_info.entity_status,
+                        item.second->entity_discovery_info.app_id,
+                        item.second->entity_discovery_info.app_metadata,
+                        item.second->entity_discovery_info.discovery_source,
+                        item.second->entity_discovery_info.original_domain_id);
                 }
 
                 details::StatisticsBackendData::get_instance()->on_status_reported(domain, entity, StatusKind::PROXY);

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -4780,6 +4780,10 @@ TEST_F(database_queue_tests, push_monitor_proxy_discovery_endpoint_before_partic
     std::copy(participant_id.begin(), participant_id.end(), p_guid.entityId.value);
     endpoint_data->entity_discovery_info.participant_guid = p_guid;
 
+    // Fake entity to allow triggering data
+    Entity fakeEntity;
+    fakeEntity.discovery_source = DiscoverySource::DISCOVERY;
+    EXPECT_CALL(database, get_entity(_)).WillOnce(::testing::Return(std::make_shared<Entity>(fakeEntity)));
 
     // Precondition: The endpoint does not exist
     EXPECT_CALL(database, get_entity_kind_by_guid(endpoint_guid)).Times(AnyNumber())


### PR DESCRIPTION
Discovery source of participants discovered through the usual mechanisms were overwritten by proxy packages due to a missing check that is being added in this PR