### PR TITLE
[23929] Add undiscovery of proxy entities

### DIFF
--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -4782,6 +4782,7 @@ bool update_enabled(
     }
 }
 
+
 bool Database::update_participant_discovery_info_nts(
         const EntityId& participant_id,
         const std::string& host,

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -4782,7 +4782,6 @@ bool update_enabled(
     }
 }
 
-
 bool Database::update_participant_discovery_info_nts(
         const EntityId& participant_id,
         const std::string& host,

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -1555,7 +1555,7 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
                         // Instance handle was not stored, so the proxy entity is unknown and cannot be undiscovered
                         EPROSIMA_LOG_WARNING(BACKEND_DATABASE_QUEUE,
                                 "Attempt to undiscover unknown proxy entity with handle " <<
-                                            item.second->instance_handle);
+                                item.second->instance_handle);
                         return;
                     }
 
@@ -1568,7 +1568,8 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
                     StatisticsGuid guid =
                             string_to_guid_s(proxy_entity_handles_to_guid.at(item.second->instance_handle));
                     EntityKind entity_kind = database_->get_entity_kind_by_guid(guid);
-                    auto matched_domain_entity = database_->get_entity_by_guid(entity_kind, proxy_entity_handles_to_guid.at(
+                    auto matched_domain_entity = database_->get_entity_by_guid(entity_kind,
+                                    proxy_entity_handles_to_guid.at(
                                         item.second->instance_handle));
                     domain = matched_domain_entity.first;
                     entity = matched_domain_entity.second;

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -1483,7 +1483,8 @@ void DatabaseDataQueue<eprosima::fastdds::statistics::Data>::process_sample()
 /**
  * Converts a GUID string to a GUID_s structure.
  */
-eprosima::fastdds::statistics::detail::GUID_s string_to_guid_s(const std::string& guid_str)
+eprosima::fastdds::statistics::detail::GUID_s string_to_guid_s(
+        const std::string& guid_str)
 {
     eprosima::fastdds::statistics::detail::GUID_s guid_s;
 
@@ -1546,13 +1547,15 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
             sample.src_ts = item.first;
             try
             {
-                if(item.second->entity_discovery_info.is_proxy_undiscovery)
+                if (item.second->entity_discovery_info.is_proxy_undiscovery)
                 {
-                    if(proxy_entity_handles_to_guid.find(item.second->instance_handle) == proxy_entity_handles_to_guid.end())
+                    if (proxy_entity_handles_to_guid.find(item.second->instance_handle) ==
+                            proxy_entity_handles_to_guid.end())
                     {
                         // Instance handle was not stored, so the proxy entity is unknown and cannot be undiscovered
                         EPROSIMA_LOG_WARNING(BACKEND_DATABASE_QUEUE,
-                                "Attempt to undiscover unknown proxy entity with handle " << item.second->instance_handle);
+                                "Attempt to undiscover unknown proxy entity with handle " <<
+                                            item.second->instance_handle);
                         return;
                     }
 
@@ -1562,9 +1565,11 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
                             << item.second->instance_handle
                             << " and GUID " << proxy_entity_handles_to_guid.at(item.second->instance_handle));
 
-                    StatisticsGuid guid = string_to_guid_s(proxy_entity_handles_to_guid.at(item.second->instance_handle));
+                    StatisticsGuid guid =
+                            string_to_guid_s(proxy_entity_handles_to_guid.at(item.second->instance_handle));
                     EntityKind entity_kind = database_->get_entity_kind_by_guid(guid);
-                    auto matched_domain_entity = database_->get_entity_by_guid(entity_kind, proxy_entity_handles_to_guid.at(item.second->instance_handle));
+                    auto matched_domain_entity = database_->get_entity_by_guid(entity_kind, proxy_entity_handles_to_guid.at(
+                                        item.second->instance_handle));
                     domain = matched_domain_entity.first;
                     entity = matched_domain_entity.second;
                     database_->change_entity_status(entity, false);
@@ -1580,7 +1585,8 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
                 updated_entity = database_->insert(domain, entity, sample);
                 database_->update_entity_qos(entity, item.second->optional_qos);
 
-                if (item.second->entity_discovery_info.discovery_status == details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY &&
+                if (item.second->entity_discovery_info.discovery_status ==
+                        details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY &&
                         database_->get_entity(entity)->discovery_source != DiscoverySource::DISCOVERY)
                 {
                     // If the PROXY message is a change to UNDISCOVERY, mark the entity as inactive

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -1503,9 +1503,16 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
                 updated_entity = database_->insert(domain, entity, sample);
                 database_->update_entity_qos(entity, item.second->optional_qos);
 
-                if (item.second->entity_discovery_info.kind() == EntityKind::PARTICIPANT &&
+                if (item.second->entity_discovery_info.discovery_status == details::StatisticsBackendData::DiscoveryStatus::UNDISCOVERY &&
                         database_->get_entity(entity)->discovery_source != DiscoverySource::DISCOVERY)
                 {
+                    // If the PROXY message is a change to UNDISCOVERY, mark the entity as inactive
+                    database_->change_entity_status(entity, false);
+                }
+                else if (item.second->entity_discovery_info.kind() == EntityKind::PARTICIPANT &&
+                        database_->get_entity(entity)->discovery_source != DiscoverySource::DISCOVERY)
+                {
+                    // Only update participants when the operation is
                     // NOTE: Proxy can only update unknown, proxy or inferred participants, not discovered ones
                     // as they usually contain more complete information
                     database_->update_participant_discovery_info(entity,

--- a/src/cpp/database/database_queue.cpp
+++ b/src/cpp/database/database_queue.cpp
@@ -1480,6 +1480,56 @@ void DatabaseDataQueue<eprosima::fastdds::statistics::Data>::process_sample()
     }
 }
 
+/**
+ * Converts a GUID string to a GUID_s structure.
+ */
+eprosima::fastdds::statistics::detail::GUID_s string_to_guid_s(const std::string& guid_str)
+{
+    eprosima::fastdds::statistics::detail::GUID_s guid_s;
+
+    // GUID string format is typically: "01.0f.00.00.01.00.00.00.00.00.00.00|00.00.01.c1"
+    // Split by '|' to separate guidPrefix and entityId
+    size_t separator_pos = guid_str.find('|');
+    if (separator_pos == std::string::npos)
+    {
+        throw std::invalid_argument("Invalid GUID format: missing '|' separator");
+    }
+
+    std::string prefix_str = guid_str.substr(0, separator_pos);
+    std::string entity_str = guid_str.substr(separator_pos + 1);
+
+    // Parse guidPrefix (12 bytes, format: "01.0f.00.00.01.00.00.00.00.00.00.00")
+    std::istringstream prefix_stream(prefix_str);
+    std::string byte_str;
+    int prefix_idx = 0;
+
+    while (std::getline(prefix_stream, byte_str, '.') && prefix_idx < 12)
+    {
+        guid_s.guidPrefix().value()[prefix_idx++] = static_cast<uint8_t>(std::stoi(byte_str, nullptr, 16));
+    }
+
+    if (prefix_idx != 12)
+    {
+        throw std::invalid_argument("Invalid GUID format: guidPrefix must have 12 bytes");
+    }
+
+    // Parse entityId (4 bytes, format: "00.00.01.c1")
+    std::istringstream entity_stream(entity_str);
+    int entity_idx = 0;
+
+    while (std::getline(entity_stream, byte_str, '.') && entity_idx < 4)
+    {
+        guid_s.entityId().value()[entity_idx++] = static_cast<uint8_t>(std::stoi(byte_str, nullptr, 16));
+    }
+
+    if (entity_idx != 4)
+    {
+        throw std::invalid_argument("Invalid GUID format: entityId must have 4 bytes");
+    }
+
+    return guid_s;
+}
+
 template<>
 void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
 {
@@ -1496,6 +1546,33 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
             sample.src_ts = item.first;
             try
             {
+                if(item.second->entity_discovery_info.is_proxy_undiscovery)
+                {
+                    if(proxy_entity_handles_to_guid.find(item.second->instance_handle) == proxy_entity_handles_to_guid.end())
+                    {
+                        // Instance handle was not stored, so the proxy entity is unknown and cannot be undiscovered
+                        EPROSIMA_LOG_WARNING(BACKEND_DATABASE_QUEUE,
+                                "Attempt to undiscover unknown proxy entity with handle " << item.second->instance_handle);
+                        return;
+                    }
+
+                    // Set proxy entity as inactive in the database
+                    EPROSIMA_LOG_INFO(BACKEND_DATABASE_QUEUE,
+                            "Setting proxy entity as inactive with handle "
+                            << item.second->instance_handle
+                            << " and GUID " << proxy_entity_handles_to_guid.at(item.second->instance_handle));
+
+                    StatisticsGuid guid = string_to_guid_s(proxy_entity_handles_to_guid.at(item.second->instance_handle));
+                    EntityKind entity_kind = database_->get_entity_kind_by_guid(guid);
+                    auto matched_domain_entity = database_->get_entity_by_guid(entity_kind, proxy_entity_handles_to_guid.at(item.second->instance_handle));
+                    domain = matched_domain_entity.first;
+                    entity = matched_domain_entity.second;
+                    database_->change_entity_status(entity, false);
+                    // Mark as updated so the graph is also updated below
+                    updated_entity = true;
+                    break;
+                }
+
                 auto source_guid = item.second->data.local_entity();
                 process_sample_type(domain, entity, source_guid, sample,
                         item.second->data.value().entity_proxy());
@@ -1512,7 +1589,6 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
                 else if (item.second->entity_discovery_info.kind() == EntityKind::PARTICIPANT &&
                         database_->get_entity(entity)->discovery_source != DiscoverySource::DISCOVERY)
                 {
-                    // Only update participants when the operation is
                     // NOTE: Proxy can only update unknown, proxy or inferred participants, not discovered ones
                     // as they usually contain more complete information
                     database_->update_participant_discovery_info(entity,
@@ -1554,6 +1630,11 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
                         item.second->entity_discovery_info.discovery_status =
                                 details::StatisticsBackendData::DiscoveryStatus::UPDATE;
                     }
+
+                    // Store participant proxy instance handle to guid mapping
+                    std::ostringstream oss;
+                    oss << item.second->entity_discovery_info.guid;
+                    proxy_entity_handles_to_guid[item.second->instance_handle] = oss.str();
 
                     timestamp = now();
                     details::StatisticsBackendData::get_instance()->get_entity_queue()->push(timestamp,
@@ -1598,10 +1679,18 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
                             participant_discovery_info);
                     // Mark the participant as enqueued to avoid creating more participant placeholders
                     participant_enqueued[item.second->entity_discovery_info.participant_guid] = true;
+                    // Store placeholder participant proxy instance handle to guid mapping
+                    std::ostringstream oss;
+                    oss << participant_discovery_info.guid;
+                    proxy_entity_handles_to_guid[item.second->instance_handle] = oss.str();
                     // Adding endpoint entity
                     timestamp = now();
                     details::StatisticsBackendData::get_instance()->get_entity_queue()->push(timestamp,
                             item.second->entity_discovery_info);
+                    // Store endpoint proxy instance handle to guid mapping
+                    oss.clear();
+                    oss << item.second->entity_discovery_info.guid;
+                    proxy_entity_handles_to_guid[item.second->instance_handle] = oss.str();
                 }
                 else
                 {
@@ -1610,6 +1699,10 @@ void DatabaseDataQueue<ExtendedMonitorServiceStatusData>::process_sample()
                     timestamp = now();
                     details::StatisticsBackendData::get_instance()->get_entity_queue()->push(timestamp,
                             item.second->entity_discovery_info);
+                    // Store endpoint proxy instance handle to guid mapping
+                    std::ostringstream oss;
+                    oss << item.second->entity_discovery_info.guid;
+                    proxy_entity_handles_to_guid[item.second->instance_handle] = oss.str();
                 }
             }
             break;

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -27,11 +27,12 @@
 #include <queue>
 #include <thread>
 
+#include <fastdds/dds/common/InstanceHandle.hpp>
+#include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/common/Guid.hpp>
 #include <fastdds/rtps/common/Locator.hpp>
 #include <fastdds/rtps/common/SequenceNumber.hpp>
 #include <fastdds/rtps/common/RemoteLocators.hpp>
-#include <fastdds/dds/log/Log.hpp>
 #include <fastdds_statistics_backend/types/JSONTags.h>
 
 #include <database/database.hpp>
@@ -393,6 +394,9 @@ struct EntityDiscoveryInfo
     // useful when discovery_source is PROXY
     DomainId original_domain_id;
 
+    // Information to handle undiscovery of proxy entities
+    bool is_proxy_undiscovery = false;
+
     EntityDiscoveryInfo()
         : EntityDiscoveryInfo(EntityKind::INVALID)
     {
@@ -425,6 +429,11 @@ struct ExtendedMonitorServiceStatusData
 
     // Deserialized entity optional QoS information received through Monitor Service's proxy samples
     database::Qos optional_qos;
+
+    // Instance handle of the sample. This is the instance corresponding to a "PROXY" status type
+    // and the entity's GUID
+    fastdds::dds::InstanceHandle_t instance_handle;
+
 };
 
 class DatabaseEntityQueue : public DatabaseQueue<EntityDiscoveryInfo>
@@ -663,6 +672,9 @@ protected:
 
     // Structure to keep if the discovery of a participant has already been enqueued
     std::map<eprosima::fastdds::rtps::GUID_t, bool> participant_enqueued;
+
+    // Structure to map InstanceHandles to GUID strings for proxy entities
+    std::map<eprosima::fastdds::rtps::InstanceHandle_t, std::string> proxy_entity_handles_to_guid;
 };
 
 template<>

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -605,6 +605,38 @@ public:
 
 protected:
 
+    StatisticsGuid serialize_guid(
+            const std::string& guid_str) const
+    {
+        fastdds::statistics::detail::GUID_s guid_s;
+        std::istringstream iss(guid_str);
+        std::string byte_str;
+
+        // Parse the guidPrefix part
+        uint8_t guid_prefix_size = static_cast<uint8_t>(fastdds::rtps::GuidPrefix_t::size);
+        for (uint8_t i = 0; i < guid_prefix_size; ++i)
+        {
+            if (i == (guid_prefix_size - 1))
+            {
+                std::getline(iss, byte_str, '|');
+            }
+            else
+            {
+                std::getline(iss, byte_str, '.');
+            }
+            guid_s.guidPrefix().value()[i] = static_cast<uint8_t>(std::stoul(byte_str, nullptr, 16));
+        }
+
+        // Parse the entityId part
+        for (uint8_t i = 0; i < static_cast<uint8_t>(fastdds::rtps::EntityId_t::size); ++i)
+        {
+            std::getline(iss, byte_str, '.');
+            guid_s.entityId().value()[i] = static_cast<uint8_t>(std::stoul(byte_str, nullptr, 16));
+        }
+
+        return guid_s;
+    }
+
     std::string deserialize_guid(
             StatisticsGuid data) const
     {

--- a/src/cpp/database/database_queue.hpp
+++ b/src/cpp/database/database_queue.hpp
@@ -137,7 +137,7 @@ public:
                          + deadlock by absence of run() loop activity (by using both_empty() call)
                          */
                         return !consuming_ || both_empty() ||
-                        ( empty() && last_loop != current_loop_);
+                               ( empty() && last_loop != current_loop_);
                     });
             last_loop = current_loop_;
         }
@@ -398,7 +398,8 @@ struct EntityDiscoveryInfo
     bool is_proxy_undiscovery = false;
 
     EntityDiscoveryInfo()
-        : EntityDiscoveryInfo(EntityKind::INVALID)
+        : EntityDiscoveryInfo(
+                EntityKind::INVALID)
     {
     }
 

--- a/src/cpp/subscriber/StatisticsReaderListener.cpp
+++ b/src/cpp/subscriber/StatisticsReaderListener.cpp
@@ -70,7 +70,7 @@ bool StatisticsReaderListener::get_available_data(
     if (reader->take_next_sample(&inner_data, &info) == RETCODE_OK)
     {
         if (!info.valid_data && info.instance_state != NOT_ALIVE_NO_WRITERS_INSTANCE_STATE &&
-            info.instance_state != NOT_ALIVE_DISPOSED_INSTANCE_STATE)
+                info.instance_state != NOT_ALIVE_DISPOSED_INSTANCE_STATE)
         {
             // It is important return true in NOT_ALIVE_NO_WRITERS_INSTANCE_STATE samples even if
             // they are marked as invalid data, as they are used internally by DDS to signal that
@@ -237,7 +237,7 @@ void StatisticsReaderListener::on_data_available(
                 }
             }
             else if (info.instance_state == NOT_ALIVE_DISPOSED_INSTANCE_STATE ||
-                     info.instance_state == NOT_ALIVE_NO_WRITERS_INSTANCE_STATE)
+                    info.instance_state == NOT_ALIVE_NO_WRITERS_INSTANCE_STATE)
             {
                 // Proxy entities will be undiscovered if they are proxy and either a NOT_ALIVE_DISPOSED_INSTANCE_STATE state
                 // or a NOT_ALIVE_NO_WRITERS_INSTANCE_STATE state is received.

--- a/src/cpp/subscriber/StatisticsReaderListener.cpp
+++ b/src/cpp/subscriber/StatisticsReaderListener.cpp
@@ -221,19 +221,19 @@ void StatisticsReaderListener::on_data_available(
         {
             if (info.instance_state == ALIVE_INSTANCE_STATE)
             {
-                    database::Qos qos;
-                    auto participant = eprosima::fastdds::statistics::dds::DomainParticipant::narrow(
-                        reader->get_subscriber()->get_participant());
+                database::Qos qos;
+                auto participant = eprosima::fastdds::statistics::dds::DomainParticipant::narrow(
+                    reader->get_subscriber()->get_participant());
 
-                    if (!deserialize_proxy_data(
-                                const_cast<eprosima::fastdds::statistics::dds::DomainParticipant*>(participant),
-                                inner_data,
-                                *monitor_service_status_data))
-                    {
-                        EPROSIMA_LOG_ERROR(STATISTICSREADERLISTENER,
-                                "Failed to get optional QoS from proxy sample.");
-                        return;
-                    }
+                if (!deserialize_proxy_data(
+                            const_cast<eprosima::fastdds::statistics::dds::DomainParticipant*>(participant),
+                            inner_data,
+                            *monitor_service_status_data))
+                {
+                    EPROSIMA_LOG_ERROR(STATISTICSREADERLISTENER,
+                            "Failed to get optional QoS from proxy sample.");
+                    return;
+                }
             }
             else if (info.instance_state == NOT_ALIVE_NO_WRITERS_INSTANCE_STATE)
             {

--- a/src/cpp/subscriber/StatisticsReaderListener.cpp
+++ b/src/cpp/subscriber/StatisticsReaderListener.cpp
@@ -69,7 +69,8 @@ bool StatisticsReaderListener::get_available_data(
 {
     if (reader->take_next_sample(&inner_data, &info) == RETCODE_OK)
     {
-        if (!info.valid_data && info.instance_state != NOT_ALIVE_NO_WRITERS_INSTANCE_STATE)
+        if (!info.valid_data && info.instance_state != NOT_ALIVE_NO_WRITERS_INSTANCE_STATE &&
+            info.instance_state != NOT_ALIVE_DISPOSED_INSTANCE_STATE)
         {
             // It is important return true in NOT_ALIVE_NO_WRITERS_INSTANCE_STATE samples even if
             // they are marked as invalid data, as they are used internally by DDS to signal that
@@ -235,10 +236,11 @@ void StatisticsReaderListener::on_data_available(
                     return;
                 }
             }
-            else if (info.instance_state == NOT_ALIVE_NO_WRITERS_INSTANCE_STATE)
+            else if (info.instance_state == NOT_ALIVE_DISPOSED_INSTANCE_STATE ||
+                     info.instance_state == NOT_ALIVE_NO_WRITERS_INSTANCE_STATE)
             {
-                // Proxy entities will be undiscovered if they are proxy and a NOT_ALIVE_NO_WRITERS_INSTANCE_STATE state
-                // is received.
+                // Proxy entities will be undiscovered if they are proxy and either a NOT_ALIVE_DISPOSED_INSTANCE_STATE state
+                // or a NOT_ALIVE_NO_WRITERS_INSTANCE_STATE state is received.
                 monitor_service_status_data->entity_discovery_info.is_proxy_undiscovery = true;
             }
 

--- a/src/cpp/subscriber/StatisticsReaderListener.hpp
+++ b/src/cpp/subscriber/StatisticsReaderListener.hpp
@@ -22,6 +22,7 @@
 
 #include "fastdds/dds/subscriber/DataReaderListener.hpp"
 #include "fastdds/dds/core/status/StatusMask.hpp"
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/statistics/dds/domain/DomainParticipant.hpp>
 
 #include <fastdds_statistics_backend/topic_types/monitorservice_types.hpp>
@@ -80,6 +81,7 @@ protected:
     bool get_available_data(
             eprosima::fastdds::dds::DataReader* reader,
             T& inner_data,
+            eprosima::fastdds::dds::SampleInfo& info,
             std::chrono::system_clock::time_point& timestamp);
 
     /**

--- a/test/unittest/DatabaseQueue/CMakeLists.txt
+++ b/test/unittest/DatabaseQueue/CMakeLists.txt
@@ -124,7 +124,7 @@ if(GTEST_FOUND AND GMOCK_FOUND)
         push_monitor_sample_lost_no_entity
         push_monitor_extended_incompatible_qos
         push_monitor_extended_incompatible_qos_no_entity
-        push_monitor_statuses_size
+        push_proxy_undiscovery_ok
         )
 
     foreach(test_name ${DATABASEQUEUE_TEST_LIST})

--- a/test/unittest/DatabaseQueue/CMakeLists.txt
+++ b/test/unittest/DatabaseQueue/CMakeLists.txt
@@ -124,6 +124,7 @@ if(GTEST_FOUND AND GMOCK_FOUND)
         push_monitor_sample_lost_no_entity
         push_monitor_extended_incompatible_qos
         push_monitor_extended_incompatible_qos_no_entity
+        push_monitor_statuses_size
         push_proxy_undiscovery_ok
         push_proxy_undiscovery_unknown_entity
         push_proxy_undiscovery_ok_separate_flush

--- a/test/unittest/DatabaseQueue/CMakeLists.txt
+++ b/test/unittest/DatabaseQueue/CMakeLists.txt
@@ -125,6 +125,10 @@ if(GTEST_FOUND AND GMOCK_FOUND)
         push_monitor_extended_incompatible_qos
         push_monitor_extended_incompatible_qos_no_entity
         push_proxy_undiscovery_ok
+        push_proxy_undiscovery_unknown_entity
+        push_proxy_undiscovery_ok_separate_flush
+        push_proxy_undiscovery_with_explicit_participant_discovery
+        push_proxy_undiscovery_with_implicit_participant_discovery
         )
 
     foreach(test_name ${DATABASEQUEUE_TEST_LIST})

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -5886,7 +5886,8 @@ TEST_F(database_queue_tests, push_proxy_undiscovery_ok)
     proxy_discovery_data->data.status_kind(kind);
     proxy_discovery_data->data.value(value);
     proxy_discovery_data->entity_discovery_info = EntityDiscoveryInfo(EntityKind::PARTICIPANT);
-    proxy_discovery_data->entity_discovery_info.discovery_status = details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
+    proxy_discovery_data->entity_discovery_info.discovery_status =
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
     proxy_discovery_data->entity_discovery_info.domain_id = 1;
     proxy_discovery_data->entity_discovery_info.guid = guid_;
     proxy_discovery_data->entity_discovery_info.participant_guid = guid_;
@@ -5911,9 +5912,9 @@ TEST_F(database_queue_tests, push_proxy_undiscovery_ok)
     EXPECT_CALL(database, get_entity_kind_by_guid(guid)).Times(2);
     // Called twice, once per message. Force exception on first to simulate non-existing entity
     EXPECT_CALL(database, get_entity_by_guid(_, guid_str))
-    .Times(2)
-    .WillOnce(Throw(eprosima::statistics_backend::Exception("Entity not found")))
-    .WillOnce(Return(std::make_pair(EntityId(0), EntityId(1))));
+            .Times(2)
+            .WillOnce(Throw(eprosima::statistics_backend::Exception("Entity not found")))
+            .WillOnce(Return(std::make_pair(EntityId(0), EntityId(1))));
     // Called once, on undiscovery
     EXPECT_CALL(database, change_entity_status(EntityId(1), false)).Times(1);
     // Called once, on undiscovery

--- a/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
+++ b/test/unittest/DatabaseQueue/DatabaseQueueTests.cpp
@@ -5855,7 +5855,52 @@ TEST_F(database_queue_tests, push_monitor_statuses_size)
     monitor_data_queue.flush();
 }
 
-TEST_F(database_queue_tests, push_proxy_undiscovery_ok)
+/**
+ * Test the correct behaviour when a PROXY message for undiscovery is
+ * referred to an unknown entity.
+ */
+TEST_F(database_queue_tests, push_proxy_undiscovery_unknown_entity)
+{
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
+
+    // Build the reader GUID
+    std::array<uint8_t, 12> prefix = {1, 15, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    std::array<uint8_t, 4> suffix = {0, 0, 0, 0};
+    std::string guid_str = "01.0f.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.0";
+    DatabaseDataQueueWrapper::StatisticsGuidPrefix guid_prefix;
+    guid_prefix.value(prefix);
+    DatabaseDataQueueWrapper::StatisticsEntityId entity_id;
+    entity_id.value(suffix);
+    DatabaseDataQueueWrapper::StatisticsGuid guid;
+    guid.guidPrefix(guid_prefix);
+    guid.entityId(entity_id);
+
+    GUID_t guid_;
+    std::copy(prefix.begin(), prefix.end(), guid_.guidPrefix.value);
+    std::copy(suffix.begin(), suffix.end(), guid_.entityId.value);
+    InstanceHandle_t handle(guid_);
+
+    // Insertion of undiscovery message
+    std::shared_ptr<ExtendedMonitorServiceStatusData> proxy_undiscovery_data = std::make_shared<ExtendedMonitorServiceStatusData>();
+    eprosima::fastdds::statistics::StatusKind::StatusKind kind = eprosima::fastdds::statistics::StatusKind::PROXY;
+    proxy_undiscovery_data->data.status_kind(kind);
+    proxy_undiscovery_data->entity_discovery_info.is_proxy_undiscovery = true;
+    proxy_undiscovery_data->instance_handle = handle;
+
+    // Expectations-> database insert called to add the proxy participant
+    // Called once, on undiscovery
+    EXPECT_CALL(database, change_entity_status(_, _)).Times(0);
+    // Called once, on undiscovery
+    EXPECT_CALL(database, update_graph_on_updated_entity(_, _)).Times(0);
+    monitor_data_queue.push(timestamp, proxy_undiscovery_data);
+    monitor_data_queue.flush();
+}
+
+/**
+ * Test the correct processing of a PROXY undiscovery message even when the PROXY undiscovery
+ * arrives immediately after the PROXY discovery
+ */
+TEST_F(database_queue_tests, push_proxy_undiscovery_one_flush)
 {
     std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
 
@@ -5906,6 +5951,77 @@ TEST_F(database_queue_tests, push_proxy_undiscovery_ok)
     proxy_undiscovery_data->entity_discovery_info.is_proxy_undiscovery = true;
     proxy_undiscovery_data->instance_handle = handle;
 
+    // Expectations-> database insert called to add the proxy participant
+    // Called twice, once per message
+    EXPECT_CALL(database, get_entity_kind_by_guid(guid)).Times(2);
+    // Called twice, once per message. Force exception on first to simulate non-existing entity
+    EXPECT_CALL(database, get_entity_by_guid(_, guid_str))
+            .Times(2)
+            .WillOnce(Throw(eprosima::statistics_backend::Exception("Entity not found")))
+            .WillOnce(Return(std::make_pair(EntityId(0), EntityId(1))));
+    // Called once, on undiscovery
+    EXPECT_CALL(database, change_entity_status(EntityId(1), false)).Times(1);
+    // Called once, on undiscovery
+    EXPECT_CALL(database, update_graph_on_updated_entity(EntityId(0), EntityId(1))).Times(1);
+    monitor_data_queue.push(timestamp, proxy_discovery_data);
+    monitor_data_queue.push(timestamp, proxy_undiscovery_data);
+    monitor_data_queue.flush();
+}
+
+/**
+ * Test the correct processing of a PROXY undiscovery message when the PROXY undiscovery
+ * arrives when the PROXY discovery has already been processed
+ */
+TEST_F(database_queue_tests, push_proxy_undiscovery_ok_separate_flush)
+{
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
+
+    // Build the reader GUID
+    std::array<uint8_t, 12> prefix = {1, 15, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    std::array<uint8_t, 4> suffix = {0, 0, 0, 0};
+    std::string guid_str = "01.0f.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.0";
+    DatabaseDataQueueWrapper::StatisticsGuidPrefix guid_prefix;
+    guid_prefix.value(prefix);
+    DatabaseDataQueueWrapper::StatisticsEntityId entity_id;
+    entity_id.value(suffix);
+    DatabaseDataQueueWrapper::StatisticsGuid guid;
+    guid.guidPrefix(guid_prefix);
+    guid.entityId(entity_id);
+
+    GUID_t guid_;
+    std::copy(prefix.begin(), prefix.end(), guid_.guidPrefix.value);
+    std::copy(suffix.begin(), suffix.end(), guid_.entityId.value);
+    InstanceHandle_t handle(guid_);
+
+    // PRECONDITION: Insert a PROXY participant in the database
+    std::shared_ptr<ExtendedMonitorServiceStatusData> proxy_discovery_data = std::make_shared<ExtendedMonitorServiceStatusData>();
+    eprosima::fastdds::statistics::StatusKind::StatusKind kind = eprosima::fastdds::statistics::StatusKind::PROXY;
+    MonitorServiceData value;
+    std::vector<uint8_t> proxy = {0x50, 0x52, 0x4f, 0x58, 0x59};
+    value.entity_proxy(proxy);
+    proxy_discovery_data->data.local_entity(guid);
+    proxy_discovery_data->data.status_kind(kind);
+    proxy_discovery_data->data.value(value);
+    proxy_discovery_data->entity_discovery_info = EntityDiscoveryInfo(EntityKind::PARTICIPANT);
+    proxy_discovery_data->entity_discovery_info.discovery_status =
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
+    proxy_discovery_data->entity_discovery_info.domain_id = 1;
+    proxy_discovery_data->entity_discovery_info.guid = guid_;
+    proxy_discovery_data->entity_discovery_info.participant_guid = guid_;
+    proxy_discovery_data->entity_discovery_info.participant_name = "Proxy Participant";
+    proxy_discovery_data->entity_discovery_info.app_id = AppId::UNKNOWN;
+    proxy_discovery_data->entity_discovery_info.host = "Unknown";
+    proxy_discovery_data->entity_discovery_info.user = "Unknown";
+    proxy_discovery_data->entity_discovery_info.process = "Unknown";
+    proxy_discovery_data->entity_discovery_info.entity_status = StatusLevel::OK_STATUS;
+    proxy_discovery_data->entity_discovery_info.discovery_source = DiscoverySource::PROXY;
+    proxy_discovery_data->entity_discovery_info.original_domain_id = 0;
+    proxy_discovery_data->instance_handle = handle;
+    // Insertion of undiscovery message
+    std::shared_ptr<ExtendedMonitorServiceStatusData> proxy_undiscovery_data = std::make_shared<ExtendedMonitorServiceStatusData>();
+    proxy_undiscovery_data->data.status_kind(kind);
+    proxy_undiscovery_data->entity_discovery_info.is_proxy_undiscovery = true;
+    proxy_undiscovery_data->instance_handle = handle;
 
     // Expectations-> database insert called to add the proxy participant
     // Called twice, once per message
@@ -5920,6 +6036,206 @@ TEST_F(database_queue_tests, push_proxy_undiscovery_ok)
     // Called once, on undiscovery
     EXPECT_CALL(database, update_graph_on_updated_entity(EntityId(0), EntityId(1))).Times(1);
     monitor_data_queue.push(timestamp, proxy_discovery_data);
+    monitor_data_queue.flush();
+    monitor_data_queue.push(timestamp, proxy_undiscovery_data);
+    monitor_data_queue.flush();
+}
+
+/**
+ * Test the correct processing of a PROXY undiscovery message when the PROXY message of
+ * the endpopint arrives after the message of its participant, thus, no implicit participants
+ * are created
+ */
+TEST_F(database_queue_tests, push_proxy_undiscovery_with_explicit_participant_discovery)
+{
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
+
+    // Build the reader GUID
+    std::array<uint8_t, 12> prefix = {1, 15, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    std::array<uint8_t, 4> suffix = {0, 1, 0, 0};
+    std::string reader_guid_str = "01.0f.03.04.05.06.07.08.09.0a.0b.0c|0.1.0.0";
+    DatabaseDataQueueWrapper::StatisticsGuidPrefix guid_prefix;
+    guid_prefix.value(prefix);
+    DatabaseDataQueueWrapper::StatisticsEntityId entity_id;
+    entity_id.value(suffix);
+    DatabaseDataQueueWrapper::StatisticsGuid guid;
+    guid.guidPrefix(guid_prefix);
+    guid.entityId(entity_id);
+    GUID_t guid_;
+    std::copy(prefix.begin(), prefix.end(), guid_.guidPrefix.value);
+    std::copy(suffix.begin(), suffix.end(), guid_.entityId.value);
+    InstanceHandle_t handle(guid_);
+    // Build the participant GUID
+    std::array<uint8_t, 4> participant_suffix = {0, 0, 0, 0};
+    std::string participant_guid_str = "01.0f.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.0";
+    DatabaseDataQueueWrapper::StatisticsEntityId participant_entity_id;
+    participant_entity_id.value(participant_suffix);
+    DatabaseDataQueueWrapper::StatisticsGuid participant_guid;
+    participant_guid.guidPrefix(guid_prefix);
+    participant_guid.entityId(participant_entity_id);
+    GUID_t participant_guid_;
+    std::copy(prefix.begin(), prefix.end(), participant_guid_.guidPrefix.value);
+    std::copy(participant_suffix.begin(), participant_suffix.end(), participant_guid_.entityId.value);
+    InstanceHandle_t participant_handle(participant_guid_);
+
+    // PRECONDITION: Insert a PROXY participant in the database
+    std::shared_ptr<ExtendedMonitorServiceStatusData> participant_proxy_discovery_data = std::make_shared<ExtendedMonitorServiceStatusData>();
+    eprosima::fastdds::statistics::StatusKind::StatusKind kind = eprosima::fastdds::statistics::StatusKind::PROXY;
+    MonitorServiceData participant_value;
+    std::vector<uint8_t> participant_proxy = {0x50, 0x52, 0x4f, 0x58, 0x59};
+    participant_value.entity_proxy(participant_proxy);
+    participant_proxy_discovery_data->data.local_entity(participant_guid);
+    participant_proxy_discovery_data->data.status_kind(kind);
+    participant_proxy_discovery_data->data.value(participant_value);
+    participant_proxy_discovery_data->entity_discovery_info = EntityDiscoveryInfo(EntityKind::PARTICIPANT);
+    participant_proxy_discovery_data->entity_discovery_info.discovery_status =
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
+    participant_proxy_discovery_data->entity_discovery_info.domain_id = 1;
+    participant_proxy_discovery_data->entity_discovery_info.guid = participant_guid_;
+    participant_proxy_discovery_data->entity_discovery_info.participant_guid = participant_guid_;
+    participant_proxy_discovery_data->entity_discovery_info.participant_name = "Proxy Participant";
+    participant_proxy_discovery_data->entity_discovery_info.app_id = AppId::UNKNOWN;
+    participant_proxy_discovery_data->entity_discovery_info.host = "Unknown";
+    participant_proxy_discovery_data->entity_discovery_info.user = "Unknown";
+    participant_proxy_discovery_data->entity_discovery_info.process = "Unknown";
+    participant_proxy_discovery_data->entity_discovery_info.entity_status = StatusLevel::OK_STATUS;
+    participant_proxy_discovery_data->entity_discovery_info.discovery_source = DiscoverySource::PROXY;
+    participant_proxy_discovery_data->entity_discovery_info.original_domain_id = 0;
+    participant_proxy_discovery_data->instance_handle = participant_handle;
+    // Insert a PROXY endpoint in the database
+    std::shared_ptr<ExtendedMonitorServiceStatusData> proxy_discovery_data = std::make_shared<ExtendedMonitorServiceStatusData>();
+    MonitorServiceData value;
+    std::vector<uint8_t> proxy = {0x50, 0x52, 0x4f, 0x58, 0x60};
+    value.entity_proxy(proxy);
+    proxy_discovery_data->data.local_entity(guid);
+    proxy_discovery_data->data.status_kind(kind);
+    proxy_discovery_data->data.value(value);
+    proxy_discovery_data->entity_discovery_info = EntityDiscoveryInfo(EntityKind::DATAREADER);
+    proxy_discovery_data->entity_discovery_info.discovery_status =
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
+    proxy_discovery_data->entity_discovery_info.domain_id = 1;
+    proxy_discovery_data->entity_discovery_info.guid = guid_;
+    proxy_discovery_data->entity_discovery_info.participant_guid = participant_guid_;
+    proxy_discovery_data->entity_discovery_info.participant_name = "Proxy Endpoint";
+    proxy_discovery_data->entity_discovery_info.app_id = AppId::UNKNOWN;
+    proxy_discovery_data->entity_discovery_info.host = "Unknown";
+    proxy_discovery_data->entity_discovery_info.user = "Unknown";
+    proxy_discovery_data->entity_discovery_info.process = "Unknown";
+    proxy_discovery_data->entity_discovery_info.entity_status = StatusLevel::OK_STATUS;
+    proxy_discovery_data->entity_discovery_info.discovery_source = DiscoverySource::PROXY;
+    proxy_discovery_data->entity_discovery_info.original_domain_id = 0;
+    proxy_discovery_data->instance_handle = handle;
+    // Undiscovery message
+    std::shared_ptr<ExtendedMonitorServiceStatusData> proxy_undiscovery_data = std::make_shared<ExtendedMonitorServiceStatusData>();
+    proxy_undiscovery_data->data.status_kind(kind);
+    proxy_undiscovery_data->entity_discovery_info.is_proxy_undiscovery = true;
+    proxy_undiscovery_data->instance_handle = handle;
+
+    // Expectations-> database insert called to add the proxy participant
+    EXPECT_CALL(database, get_entity_kind_by_guid(participant_guid)).Times(1);
+    EXPECT_CALL(database, get_entity_kind_by_guid(guid)).Times(2);
+    // Called twice, once per message. Force exception on first to simulate non-existing entity
+    EXPECT_CALL(database, get_entity_by_guid(_, participant_guid_str))
+            .Times(1)
+            .WillOnce(Throw(eprosima::statistics_backend::Exception("Entity not found")));
+
+    EXPECT_CALL(database, get_entity_by_guid(_, reader_guid_str))
+            .Times(2)
+            .WillOnce(Throw(eprosima::statistics_backend::Exception("Entity not found")))
+            .WillOnce(Return(std::make_pair(EntityId(0), EntityId(2))));
+
+    // Called once, on undiscovery
+    EXPECT_CALL(database, change_entity_status(EntityId(2), false)).Times(1);
+    // Called once, on undiscovery
+    EXPECT_CALL(database, update_graph_on_updated_entity(EntityId(0), EntityId(2))).Times(1);
+    monitor_data_queue.push(timestamp, participant_proxy_discovery_data);
+    monitor_data_queue.push(timestamp, proxy_discovery_data);
+    monitor_data_queue.flush();
+    monitor_data_queue.push(timestamp, proxy_undiscovery_data);
+    monitor_data_queue.flush();
+}
+
+/**
+ * Test the correct processing of a PROXY undiscovery message when the PROXY message of
+ * the endpopint arrives before the message of its participant, thus, an implicit participant
+ * is created
+ */
+TEST_F(database_queue_tests, push_proxy_undiscovery_with_implicit_participant_discovery)
+{
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
+
+    // Build the reader GUID
+    std::array<uint8_t, 12> prefix = {1, 15, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    std::array<uint8_t, 4> suffix = {0, 1, 0, 0};
+    std::string reader_guid_str = "01.0f.03.04.05.06.07.08.09.0a.0b.0c|0.1.0.0";
+    DatabaseDataQueueWrapper::StatisticsGuidPrefix guid_prefix;
+    guid_prefix.value(prefix);
+    DatabaseDataQueueWrapper::StatisticsEntityId entity_id;
+    entity_id.value(suffix);
+    DatabaseDataQueueWrapper::StatisticsGuid guid;
+    guid.guidPrefix(guid_prefix);
+    guid.entityId(entity_id);
+    GUID_t guid_;
+    std::copy(prefix.begin(), prefix.end(), guid_.guidPrefix.value);
+    std::copy(suffix.begin(), suffix.end(), guid_.entityId.value);
+    InstanceHandle_t handle(guid_);
+    // Build the participant GUID
+    std::array<uint8_t, 4> participant_suffix = {0, 0, 0, 0};
+    std::string participant_guid_str = "01.0f.03.04.05.06.07.08.09.0a.0b.0c|0.0.0.0";
+    DatabaseDataQueueWrapper::StatisticsEntityId participant_entity_id;
+    participant_entity_id.value(participant_suffix);
+    DatabaseDataQueueWrapper::StatisticsGuid participant_guid;
+    participant_guid.guidPrefix(guid_prefix);
+    participant_guid.entityId(participant_entity_id);
+    GUID_t participant_guid_;
+    std::copy(prefix.begin(), prefix.end(), participant_guid_.guidPrefix.value);
+    std::copy(participant_suffix.begin(), participant_suffix.end(), participant_guid_.entityId.value);
+    InstanceHandle_t participant_handle(participant_guid_);
+
+    // Insert a PROXY endpoint in the database
+    std::shared_ptr<ExtendedMonitorServiceStatusData> proxy_discovery_data = std::make_shared<ExtendedMonitorServiceStatusData>();
+    eprosima::fastdds::statistics::StatusKind::StatusKind kind = eprosima::fastdds::statistics::StatusKind::PROXY;
+    MonitorServiceData value;
+    std::vector<uint8_t> proxy = {0x50, 0x52, 0x4f, 0x58, 0x60};
+    value.entity_proxy(proxy);
+    proxy_discovery_data->data.local_entity(guid);
+    proxy_discovery_data->data.status_kind(kind);
+    proxy_discovery_data->data.value(value);
+    proxy_discovery_data->entity_discovery_info = EntityDiscoveryInfo(EntityKind::DATAREADER);
+    proxy_discovery_data->entity_discovery_info.discovery_status =
+            details::StatisticsBackendData::DiscoveryStatus::DISCOVERY;
+    proxy_discovery_data->entity_discovery_info.domain_id = 1;
+    proxy_discovery_data->entity_discovery_info.guid = guid_;
+    proxy_discovery_data->entity_discovery_info.participant_guid = participant_guid_;
+    proxy_discovery_data->entity_discovery_info.participant_name = "Proxy Endpoint";
+    proxy_discovery_data->entity_discovery_info.app_id = AppId::UNKNOWN;
+    proxy_discovery_data->entity_discovery_info.host = "Unknown";
+    proxy_discovery_data->entity_discovery_info.user = "Unknown";
+    proxy_discovery_data->entity_discovery_info.process = "Unknown";
+    proxy_discovery_data->entity_discovery_info.entity_status = StatusLevel::OK_STATUS;
+    proxy_discovery_data->entity_discovery_info.discovery_source = DiscoverySource::PROXY;
+    proxy_discovery_data->entity_discovery_info.original_domain_id = 0;
+    proxy_discovery_data->instance_handle = handle;
+    // Undiscovery message
+    std::shared_ptr<ExtendedMonitorServiceStatusData> proxy_undiscovery_data = std::make_shared<ExtendedMonitorServiceStatusData>();
+    proxy_undiscovery_data->data.status_kind(kind);
+    proxy_undiscovery_data->entity_discovery_info.is_proxy_undiscovery = true;
+    proxy_undiscovery_data->instance_handle = handle;
+
+    // Expectations-> database insert called to add the proxy participant
+    // Called twice, once per message. Force exception on first to simulate non-existing entity
+    EXPECT_CALL(database, get_entity_kind_by_guid(guid)).Times(2);
+    EXPECT_CALL(database, get_entity_by_guid(_, reader_guid_str))
+            .Times(2)
+            .WillOnce(Throw(eprosima::statistics_backend::Exception("Entity not found")))
+            .WillOnce(Return(std::make_pair(EntityId(0), EntityId(2))));
+
+    // Called once, on undiscovery
+    EXPECT_CALL(database, change_entity_status(EntityId(2), false)).Times(1);
+    // Called once, on undiscovery
+    EXPECT_CALL(database, update_graph_on_updated_entity(EntityId(0), EntityId(2))).Times(1);
+    monitor_data_queue.push(timestamp, proxy_discovery_data);
+    monitor_data_queue.flush();
     monitor_data_queue.push(timestamp, proxy_undiscovery_data);
     monitor_data_queue.flush();
 }


### PR DESCRIPTION
This PR allows the statistics backend to undiscover PROXY entities when forwarded dispose/unregister messages or NOT_ALIVE_NO_WRITERS status are received. 