### PR TITLE
[24171] Fix failure of Spy mode when statistics are enabled on XML

### DIFF
--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -190,7 +190,8 @@ EntityId create_and_register_monitor(
         DomainListener* domain_listener,
         const CallbackMask& callback_mask,
         const DataKindMask& data_mask,
-        const DomainParticipantQos& participant_qos,
+        const DomainParticipantQos& monitor_participant_qos,
+        const DomainParticipantQos& spy_participant_qos,
         const DomainId domain_id = 0)
 {
     // NOTE: This method is quite awful to read because of the error handle of every entity
@@ -228,7 +229,7 @@ EntityId create_and_register_monitor(
 
     monitor->spy_participant = DomainParticipantFactory::get_instance()->create_participant(
         domain_id,
-        participant_qos,
+        spy_participant_qos,
         nullptr,
         StatusMask::none());
 
@@ -264,7 +265,7 @@ EntityId create_and_register_monitor(
     participant_mask ^= StatusMask::data_on_readers();
     monitor->participant = DomainParticipantFactory::get_instance()->create_participant(
         domain_id,
-        participant_qos,
+        monitor_participant_qos,
         monitor->participant_listener,
         participant_mask);
 
@@ -403,6 +404,22 @@ void StatisticsBackend::set_domain_listener(
     monitor->second->data_mask = data_mask;
 }
 
+void remove_statistics_from_qos(
+        DomainParticipantQos& qos)
+{
+    auto& props = qos.properties().properties();
+    props.erase(
+        std::remove_if(props.begin(), props.end(),
+        [](const eprosima::fastdds::rtps::Property& prop)
+        {
+            return prop.name() == "fastdds.statistics";
+        }),
+        props.end()
+        );
+
+    return;
+}
+
 EntityId StatisticsBackend::init_monitor(
         DomainId domain_id,
         DomainListener* domain_listener,
@@ -424,30 +441,42 @@ EntityId StatisticsBackend::init_monitor(
     domain_name << domain_id;
 
     /* Set DomainParticipantQoS */
+    /* QoS for the monitor participant*/
     /* Since configuring the default Qos from an XML is a posibility, we need to load the XML profiles just in case */
     DomainParticipantFactory::get_instance()->load_profiles();
-    DomainParticipantQos participant_qos = DomainParticipantFactory::get_instance()->get_default_participant_qos();
+    DomainParticipantQos monitor_participant_qos =
+            DomainParticipantFactory::get_instance()->get_default_participant_qos();
     /* Previous string conversion is needed for string_255 */
     std::string participant_name = "monitor_domain_" + std::to_string(domain_id);
-    participant_qos.name(participant_name);
+    monitor_participant_qos.name(participant_name);
 
-    participant_qos.properties().properties().emplace_back(
+    monitor_participant_qos.properties().properties().emplace_back(
         "fastdds.application.id",
         app_id,
         "true");
-    participant_qos.properties().properties().emplace_back(
+    monitor_participant_qos.properties().properties().emplace_back(
         "fastdds.application.metadata",
         app_metadata,
         "true");
 
-    ReturnCode_t retcode = participant_qos.wire_protocol().easy_mode(easy_mode_ip);
+    ReturnCode_t retcode = monitor_participant_qos.wire_protocol().easy_mode(easy_mode_ip);
     if (RETCODE_OK != retcode)
     {
         throw Error("Error setting easy mode IP: " + std::to_string(retcode));
     }
+    /* Remove statistics from monitor participant QoS */
+    remove_statistics_from_qos(monitor_participant_qos);
 
-    return create_and_register_monitor(domain_name.str(), domain_listener, callback_mask, data_mask, participant_qos,
-                   domain_id);
+    /* QoS for the spy participant*/
+    DomainParticipantQos spy_participant_qos = monitor_participant_qos;
+    /* Overwrite partipant name to differentiate here*/
+    std::string spy_participant_name = "monitor_spy_domain_" + std::to_string(domain_id);
+    spy_participant_qos.name(spy_participant_name);
+    /* Remove statistics from spy participant QoS */
+    remove_statistics_from_qos(spy_participant_qos);
+
+    return create_and_register_monitor(domain_name.str(), domain_listener, callback_mask, data_mask,
+                   monitor_participant_qos, spy_participant_qos, domain_id);
 }
 
 void StatisticsBackend::stop_monitor(
@@ -474,24 +503,25 @@ EntityId StatisticsBackend::init_monitor(
     /* Set DomainParticipantQoS */
     /* Since configuring the default Qos from an XML is a posibility, we need to load the XML profiles just in case */
     DomainParticipantFactory::get_instance()->load_profiles();
-    DomainParticipantQos participant_qos = DomainParticipantFactory::get_instance()->get_default_participant_qos();
+    DomainParticipantQos monitor_participant_qos =
+            DomainParticipantFactory::get_instance()->get_default_participant_qos();
     /* Avoid using SHM transport by default */
     std::shared_ptr<eprosima::fastdds::rtps::UDPv4TransportDescriptor> udp_transport =
             std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
-    participant_qos.transport().user_transports.push_back(udp_transport);
-    participant_qos.transport().use_builtin_transports = false;
+    monitor_participant_qos.transport().user_transports.push_back(udp_transport);
+    monitor_participant_qos.transport().use_builtin_transports = false;
 
-    participant_qos.properties().properties().emplace_back(
+    monitor_participant_qos.properties().properties().emplace_back(
         "fastdds.application.id",
         app_id,
         "true");
-    participant_qos.properties().properties().emplace_back(
+    monitor_participant_qos.properties().properties().emplace_back(
         "fastdds.application.metadata",
         app_metadata,
         "true");
 
     // Set monitor as SUPER CLIENT
-    participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
+    monitor_participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
             eprosima::fastdds::rtps::DiscoveryProtocol::SUPER_CLIENT;
 
     // Add locators
@@ -520,15 +550,15 @@ EntityId StatisticsBackend::init_monitor(
         // Check unicast/multicast address
         if (eprosima::fastdds::rtps::IPLocator::isMulticast(locator))
         {
-            participant_qos.wire_protocol().builtin.metatrafficMulticastLocatorList.push_back(locator);
+            monitor_participant_qos.wire_protocol().builtin.metatrafficMulticastLocatorList.push_back(locator);
         }
         else
         {
-            participant_qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(locator);
+            monitor_participant_qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(locator);
         }
 
         // Add remote SERVER to Monitor's list of SERVERs
-        participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(locator);
+        monitor_participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(locator);
 
         if (!set_locator)
         {
@@ -537,8 +567,18 @@ EntityId StatisticsBackend::init_monitor(
         }
     }
 
+    /* Remove statistics from monitor participant QoS */
+    remove_statistics_from_qos(monitor_participant_qos);
+
+    /* QoS for the spy participant*/
+    DomainParticipantQos spy_participant_qos = monitor_participant_qos;
+    /* Overwrite partipant name to differentiate here*/
+    std::string spy_participant_name = "monitor_spy_domain_" + locator_str;
+    spy_participant_qos.name(spy_participant_name);
+    remove_statistics_from_qos(spy_participant_qos);
+
     return create_and_register_monitor(participant_name, domain_listener, callback_mask, data_mask,
-                   participant_qos);
+                   monitor_participant_qos, spy_participant_qos);
 }
 
 EntityId StatisticsBackend::init_monitor_with_profile(
@@ -576,9 +616,16 @@ EntityId StatisticsBackend::init_monitor_with_profile(
         "fastdds.application.metadata",
         app_metadata,
         "true");
+    remove_statistics_from_qos(profile_extended_qos);
+
+    // Spy participant QoS
+    DomainParticipantQos spy_participant_qos = profile_extended_qos;
+    /* Overwrite partipant name to differentiate here*/
+    std::string participant_name = "monitor_spy_domain_" + std::to_string(profile_extended_qos.domainId());
+    spy_participant_qos.name(participant_name);
 
     return create_and_register_monitor(
-        domain_name.str(), domain_listener, callback_mask, data_mask, profile_extended_qos,
+        domain_name.str(), domain_listener, callback_mask, data_mask, profile_extended_qos, spy_participant_qos,
         profile_extended_qos.domainId());
 }
 

--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -663,8 +663,12 @@ void StatisticsBackendData::start_topic_spy(
         std::string type_name = topic_type->get_name().to_string();
         fastdds::dds::TypeSupport type_support =
                 fastdds::dds::TypeSupport(new fastdds::dds::DynamicPubSubType(topic_type));
-        if (fastdds::dds::RETCODE_OK != type_support.register_type(monitor->spy_participant, type_name))
+        if (fastdds::dds::RETCODE_BAD_PARAMETER == type_support.register_type(monitor->spy_participant, type_name))
         {
+            // With Security, the type seems to have been already registered by the participant, so this
+            // function returns RETCODE_PRECONDITION_NOT_MET. Thats the reason to check only for BAD_PARAMETER,
+            // which means the type cannot be registered and the spy cannot be started. In other cases, the
+            // type is already registered but may not be an error.
             throw Error("Error registering type for topic '" + topic_name + "'");
         }
 

--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -679,9 +679,12 @@ void StatisticsBackendData::start_topic_spy(
         &monitor->user_data_context);
     monitor->spy_listeners[topic_name] = listener;
 
+    // NOTE: Spy datareader uses the QoS of the first discovered writer in that topic
+    // This could lead to issues when there are multiple writers with different QoS
+    fastdds::dds::DataReaderQos reader_qos = monitor->user_data_context.get_spy_reader_qos(topic_name);
     fastdds::dds::DataReader* reader = monitor->spy_subscriber->create_datareader(
         topic,
-        fastdds::dds::DATAREADER_QOS_DEFAULT,
+        reader_qos,
         listener);
     if (!reader)
     {

--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -663,12 +663,8 @@ void StatisticsBackendData::start_topic_spy(
         std::string type_name = topic_type->get_name().to_string();
         fastdds::dds::TypeSupport type_support =
                 fastdds::dds::TypeSupport(new fastdds::dds::DynamicPubSubType(topic_type));
-        if (fastdds::dds::RETCODE_BAD_PARAMETER == type_support.register_type(monitor->spy_participant, type_name))
+        if (fastdds::dds::RETCODE_OK != type_support.register_type(monitor->spy_participant, type_name))
         {
-            // With Security, the type seems to have been already registered by the participant, so this
-            // function returns RETCODE_PRECONDITION_NOT_MET. Thats the reason to check only for BAD_PARAMETER,
-            // which means the type cannot be registered and the spy cannot be started. In other cases, the
-            // type is already registered but may not be an error.
             throw Error("Error registering type for topic '" + topic_name + "'");
         }
 

--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -535,21 +535,7 @@ void StatisticsBackendData::stop_monitor(
 
     if (monitor->spy_participant)
     {
-        if (monitor->spy_subscriber)
-        {
-            for (auto& reader : monitor->spy_readers)
-            {
-                monitor->spy_subscriber->delete_datareader(reader.second);
-            }
-
-            monitor->spy_participant->delete_subscriber(monitor->spy_subscriber);
-        }
-
-        for (auto& topic : monitor->spy_topics)
-        {
-            monitor->spy_participant->delete_topic(topic.second);
-        }
-
+        monitor->spy_participant->delete_contained_entities();
         fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(monitor->spy_participant);
     }
 
@@ -669,11 +655,17 @@ void StatisticsBackendData::start_topic_spy(
         }
 
         fastdds::dds::TopicQos topic_qos;
-        topic = monitor->spy_participant->create_topic(topic_name, type_name, topic_qos);
+        topic = monitor->spy_participant->find_topic(topic_name, fastdds::dds::Duration_t(1));
         if (!topic)
         {
-            throw Error("Error creating topic '" + topic_name + "'");
+            // Only create if not found
+            topic = monitor->spy_participant->create_topic(topic_name, type_name, topic_qos);
+            if (!topic)
+            {
+                throw Error("Error creating topic '" + topic_name + "'");
+            }
         }
+
         monitor->spy_topics[topic_name] = topic;
     }
     else
@@ -724,8 +716,11 @@ void StatisticsBackendData::stop_topic_spy(
         return;
     }
 
-    monitor->spy_subscriber->delete_datareader(monitor->spy_readers[topic_name]);
+    // Remove datareader from subscriber
+    monitor->spy_subscriber->delete_contained_entities();
+    monitor->spy_participant->delete_topic(monitor->spy_topics.at(topic_name));
     monitor->spy_readers.erase(topic_name);
+    monitor->spy_topics.erase(topic_name);
     delete monitor->spy_listeners[topic_name];
     monitor->spy_listeners.erase(topic_name);
 }

--- a/src/cpp/subscriber/StatisticsParticipantListener.cpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.cpp
@@ -222,6 +222,9 @@ void StatisticsParticipantListener::update_user_data_context(
 
         // Add the topic to the discovered topics if not already present
         ctx_->register_user_data_topic(info.topic_name.to_string(), remote_type);
+
+        // Store compatible reader QoS for this topic
+        ctx_->register_qos_for_spy_reader(info);
     }
 }
 

--- a/src/cpp/subscriber/UserDataContext.cpp
+++ b/src/cpp/subscriber/UserDataContext.cpp
@@ -105,6 +105,61 @@ fastdds::dds::DynamicType::_ref_type UserDataContext::get_type_from_topic_name_n
     return nullptr;
 }
 
+void UserDataContext::register_qos_for_spy_reader(
+        const fastdds::dds::PublicationBuiltinTopicData& info)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    register_qos_for_spy_reader_nts(info);
+}
+
+fastdds::dds::DataReaderQos UserDataContext::get_spy_reader_qos(
+        const std::string& topic_name)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = spy_reader_qos_per_topic_.find(topic_name);
+    if (it != spy_reader_qos_per_topic_.end())
+    {
+        return it->second;
+    }
+
+    // If not found, default to DATAREADER_QOS_DEFAULT.
+    return fastdds::dds::DATAREADER_QOS_DEFAULT;
+}
+
+void UserDataContext::register_qos_for_spy_reader_nts(
+        const fastdds::dds::PublicationBuiltinTopicData& info)
+{
+    std::string topic_name = info.topic_name.to_string();
+
+    if (topic_name.empty())
+    {
+        return;
+    }
+
+    // Only store QoS for the first discovered writer on each topic
+    if (spy_reader_qos_per_topic_.count(topic_name) > 0)
+    {
+        return;
+    }
+
+    // Copy only QoS that may affect matching
+    fastdds::dds::DataReaderQos reader_qos;
+    reader_qos.reliability(info.reliability);
+    reader_qos.durability(info.durability);
+    reader_qos.deadline(info.deadline);
+    reader_qos.latency_budget(info.latency_budget);
+    reader_qos.liveliness(info.liveliness);
+    reader_qos.ownership(info.ownership);
+    reader_qos.destination_order(info.destination_order);
+    if (info.history.has_value())
+    {
+        reader_qos.history(info.history.value());
+    }
+
+    spy_reader_qos_per_topic_[topic_name] = reader_qos;
+}
+
 } // namespace subscriber
 } // namespace statistics_backend
 } // namespace eprosima

--- a/src/cpp/subscriber/UserDataContext.hpp
+++ b/src/cpp/subscriber/UserDataContext.hpp
@@ -24,6 +24,8 @@
 #include <mutex>
 #include <string>
 
+#include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
+#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/xtypes/dynamic_types/DynamicType.hpp>
 
 namespace eprosima {
@@ -48,6 +50,7 @@ public:
     void register_user_data_topic(
             const std::string& topic_name,
             fastdds::dds::DynamicType::_ref_type type);
+
     /**
      * Get the dynamic type associated with a topic name.
      * @param topic_name Topic name.
@@ -55,6 +58,23 @@ public:
      */
     fastdds::dds::DynamicType::_ref_type get_type_from_topic_name(
             const std::string& topic_name);
+
+    /**
+     * Get a DataReaderQos compatible with the first discovered writer for the given topic.
+     * @param topic_name Topic name.
+     * @return DataReaderQos derived from the writer's QoS or DATAREADER_QOS_DEFAULT if no
+     * writer has been discovered for that topic.
+     */
+    fastdds::dds::DataReaderQos get_spy_reader_qos(
+            const std::string& topic_name);
+
+    /**
+     * Store a DataReaderQos compatible with the given writer's QoS for the topic.
+     * Only stores the QoS for the first discovered writer on the topic.
+     * @param info Publication builtin topic data from the discovered writer.
+     */
+    void register_qos_for_spy_reader(
+            const fastdds::dds::PublicationBuiltinTopicData& info);
 
 protected:
 
@@ -75,12 +95,22 @@ protected:
     fastdds::dds::DynamicType::_ref_type get_type_from_topic_name_nts(
             const std::string& topic_name);
 
+    /**
+     * Store a DataReaderQos compatible with the given writer's QoS for the topic.
+     * Only stores the QoS for the first discovered writer on the topic. Non thread-safe version.
+     * @param info Publication builtin topic data from the discovered writer.
+     */
+    void register_qos_for_spy_reader_nts(
+            const fastdds::dds::PublicationBuiltinTopicData& info);
+
     // Mutex to protect access to the maps
     std::mutex mutex_;
     // Map of type name to dynamic type
     std::map<std::string, fastdds::dds::DynamicType::_ref_type> discovered_user_data_types_;
     // Map of topic name to type name
     std::map<std::string, std::string> discovered_topics_;
+    // Map of topic name to DataReaderQos compatible with the first discovered writer on that topic
+    std::map<std::string, fastdds::dds::DataReaderQos> spy_reader_qos_per_topic_;
 };
 
 } // namespace subscriber

--- a/test/mock/dds/DomainParticipant/fastdds/dds/domain/DomainParticipant.hpp
+++ b/test/mock/dds/DomainParticipant/fastdds/dds/domain/DomainParticipant.hpp
@@ -125,6 +125,12 @@ public:
             Topic * topic
         ));
 
+    MOCK_METHOD0(
+        delete_contained_entities,
+        void
+        (
+        ));
+
     MOCK_METHOD3(
         create_publisher,
         Publisher *

--- a/test/mock/dds/DomainParticipant/fastdds/dds/domain/DomainParticipant.hpp
+++ b/test/mock/dds/DomainParticipant/fastdds/dds/domain/DomainParticipant.hpp
@@ -118,6 +118,14 @@ public:
             const TopicQos& qos
         ));
 
+    MOCK_METHOD2(
+        find_topic,
+        Topic *
+        (
+            const std::string& topic_name,
+            const fastdds::dds::Duration_t& timeout
+        ));
+
     MOCK_METHOD1(
         delete_topic,
         void

--- a/test/mock/dds/Subscriber/fastdds/dds/subscriber/Subscriber.hpp
+++ b/test/mock/dds/Subscriber/fastdds/dds/subscriber/Subscriber.hpp
@@ -83,6 +83,10 @@ public:
     MOCK_CONST_METHOD0(
         get_participant,
         DomainParticipant * ());
+
+    MOCK_METHOD0(
+        delete_contained_entities,
+        ReturnCode_t ());
 };
 
 


### PR DESCRIPTION
Launching the Spy mode with the statistics enabled in a XML failed because there was a type registered both in dynamic and static modes. 

2 solutions have been implemented:

1) Statistics writers have been disable in both the monitor and the spy participant.
2) When starting a new spy datareader, now we check for topic presence before creating the topic directly  