### PR TITLE
[24171] Fix failure of Spy mode when statistics are enabled on XML

### DIFF
--- a/src/cpp/StatisticsBackend.cpp
+++ b/src/cpp/StatisticsBackend.cpp
@@ -190,7 +190,8 @@ EntityId create_and_register_monitor(
         DomainListener* domain_listener,
         const CallbackMask& callback_mask,
         const DataKindMask& data_mask,
-        const DomainParticipantQos& participant_qos,
+        const DomainParticipantQos& monitor_participant_qos,
+        const DomainParticipantQos& spy_participant_qos,
         const DomainId domain_id = 0)
 {
     // NOTE: This method is quite awful to read because of the error handle of every entity
@@ -228,7 +229,7 @@ EntityId create_and_register_monitor(
 
     monitor->spy_participant = DomainParticipantFactory::get_instance()->create_participant(
         domain_id,
-        participant_qos,
+        spy_participant_qos,
         nullptr,
         StatusMask::none());
 
@@ -264,7 +265,7 @@ EntityId create_and_register_monitor(
     participant_mask ^= StatusMask::data_on_readers();
     monitor->participant = DomainParticipantFactory::get_instance()->create_participant(
         domain_id,
-        participant_qos,
+        monitor_participant_qos,
         monitor->participant_listener,
         participant_mask);
 
@@ -403,6 +404,22 @@ void StatisticsBackend::set_domain_listener(
     monitor->second->data_mask = data_mask;
 }
 
+void remove_statistics_from_qos(
+        DomainParticipantQos& qos)
+{
+    auto& props = qos.properties().properties();
+    props.erase(
+        std::remove_if(props.begin(), props.end(),
+        [](const eprosima::fastdds::rtps::Property& prop)
+        {
+            return prop.name() == "fastdds.statistics";
+        }),
+        props.end()
+        );
+
+    return;
+}
+
 EntityId StatisticsBackend::init_monitor(
         DomainId domain_id,
         DomainListener* domain_listener,
@@ -424,30 +441,42 @@ EntityId StatisticsBackend::init_monitor(
     domain_name << domain_id;
 
     /* Set DomainParticipantQoS */
+    /* QoS for the monitor participant*/
     /* Since configuring the default Qos from an XML is a posibility, we need to load the XML profiles just in case */
     DomainParticipantFactory::get_instance()->load_profiles();
-    DomainParticipantQos participant_qos = DomainParticipantFactory::get_instance()->get_default_participant_qos();
+    DomainParticipantQos monitor_participant_qos =
+            DomainParticipantFactory::get_instance()->get_default_participant_qos();
     /* Previous string conversion is needed for string_255 */
     std::string participant_name = "monitor_domain_" + std::to_string(domain_id);
-    participant_qos.name(participant_name);
+    monitor_participant_qos.name(participant_name);
 
-    participant_qos.properties().properties().emplace_back(
+    monitor_participant_qos.properties().properties().emplace_back(
         "fastdds.application.id",
         app_id,
         "true");
-    participant_qos.properties().properties().emplace_back(
+    monitor_participant_qos.properties().properties().emplace_back(
         "fastdds.application.metadata",
         app_metadata,
         "true");
 
-    ReturnCode_t retcode = participant_qos.wire_protocol().easy_mode(easy_mode_ip);
+    ReturnCode_t retcode = monitor_participant_qos.wire_protocol().easy_mode(easy_mode_ip);
     if (RETCODE_OK != retcode)
     {
         throw Error("Error setting easy mode IP: " + std::to_string(retcode));
     }
+    /* Remove statistics from monitor participant QoS */
+    remove_statistics_from_qos(monitor_participant_qos);
 
-    return create_and_register_monitor(domain_name.str(), domain_listener, callback_mask, data_mask, participant_qos,
-                   domain_id);
+    /* QoS for the spy participant*/
+    DomainParticipantQos spy_participant_qos = monitor_participant_qos;
+    /* Overwrite partipant name to differentiate here*/
+    std::string spy_participant_name = "monitor_spy_domain_" + std::to_string(domain_id);
+    spy_participant_qos.name(spy_participant_name);
+    /* Remove statistics from spy participant QoS */
+    remove_statistics_from_qos(spy_participant_qos);
+
+    return create_and_register_monitor(domain_name.str(), domain_listener, callback_mask, data_mask,
+                   monitor_participant_qos, spy_participant_qos, domain_id);
 }
 
 void StatisticsBackend::stop_monitor(
@@ -474,24 +503,25 @@ EntityId StatisticsBackend::init_monitor(
     /* Set DomainParticipantQoS */
     /* Since configuring the default Qos from an XML is a posibility, we need to load the XML profiles just in case */
     DomainParticipantFactory::get_instance()->load_profiles();
-    DomainParticipantQos participant_qos = DomainParticipantFactory::get_instance()->get_default_participant_qos();
+    DomainParticipantQos monitor_participant_qos =
+            DomainParticipantFactory::get_instance()->get_default_participant_qos();
     /* Avoid using SHM transport by default */
     std::shared_ptr<eprosima::fastdds::rtps::UDPv4TransportDescriptor> udp_transport =
             std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
-    participant_qos.transport().user_transports.push_back(udp_transport);
-    participant_qos.transport().use_builtin_transports = false;
+    monitor_participant_qos.transport().user_transports.push_back(udp_transport);
+    monitor_participant_qos.transport().use_builtin_transports = false;
 
-    participant_qos.properties().properties().emplace_back(
+    monitor_participant_qos.properties().properties().emplace_back(
         "fastdds.application.id",
         app_id,
         "true");
-    participant_qos.properties().properties().emplace_back(
+    monitor_participant_qos.properties().properties().emplace_back(
         "fastdds.application.metadata",
         app_metadata,
         "true");
 
     // Set monitor as SUPER CLIENT
-    participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
+    monitor_participant_qos.wire_protocol().builtin.discovery_config.discoveryProtocol =
             eprosima::fastdds::rtps::DiscoveryProtocol::SUPER_CLIENT;
 
     // Add locators
@@ -520,15 +550,15 @@ EntityId StatisticsBackend::init_monitor(
         // Check unicast/multicast address
         if (eprosima::fastdds::rtps::IPLocator::isMulticast(locator))
         {
-            participant_qos.wire_protocol().builtin.metatrafficMulticastLocatorList.push_back(locator);
+            monitor_participant_qos.wire_protocol().builtin.metatrafficMulticastLocatorList.push_back(locator);
         }
         else
         {
-            participant_qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(locator);
+            monitor_participant_qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(locator);
         }
 
         // Add remote SERVER to Monitor's list of SERVERs
-        participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(locator);
+        monitor_participant_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(locator);
 
         if (!set_locator)
         {
@@ -537,8 +567,18 @@ EntityId StatisticsBackend::init_monitor(
         }
     }
 
+    /* Remove statistics from monitor participant QoS */
+    remove_statistics_from_qos(monitor_participant_qos);
+
+    /* QoS for the spy participant*/
+    DomainParticipantQos spy_participant_qos = monitor_participant_qos;
+    /* Overwrite partipant name to differentiate here*/
+    std::string spy_participant_name = "monitor_spy_domain_" + locator_str;
+    spy_participant_qos.name(spy_participant_name);
+    remove_statistics_from_qos(spy_participant_qos);
+
     return create_and_register_monitor(participant_name, domain_listener, callback_mask, data_mask,
-                   participant_qos);
+                   monitor_participant_qos, spy_participant_qos);
 }
 
 EntityId StatisticsBackend::init_monitor_with_profile(
@@ -576,9 +616,16 @@ EntityId StatisticsBackend::init_monitor_with_profile(
         "fastdds.application.metadata",
         app_metadata,
         "true");
+    remove_statistics_from_qos(profile_extended_qos);
+
+    // Spy participant QoS
+    DomainParticipantQos spy_participant_qos = profile_extended_qos;
+    /* Overwrite partipant name to differentiate here*/
+    std::string participant_name = "monitor_spy_domain_" + std::to_string(profile_extended_qos.domainId());
+    spy_participant_qos.name(participant_name);
 
     return create_and_register_monitor(
-        domain_name.str(), domain_listener, callback_mask, data_mask, profile_extended_qos,
+        domain_name.str(), domain_listener, callback_mask, data_mask, profile_extended_qos, spy_participant_qos,
         profile_extended_qos.domainId());
 }
 

--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -535,21 +535,7 @@ void StatisticsBackendData::stop_monitor(
 
     if (monitor->spy_participant)
     {
-        if (monitor->spy_subscriber)
-        {
-            for (auto& reader : monitor->spy_readers)
-            {
-                monitor->spy_subscriber->delete_datareader(reader.second);
-            }
-
-            monitor->spy_participant->delete_subscriber(monitor->spy_subscriber);
-        }
-
-        for (auto& topic : monitor->spy_topics)
-        {
-            monitor->spy_participant->delete_topic(topic.second);
-        }
-
+        monitor->spy_participant->delete_contained_entities();
         fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(monitor->spy_participant);
     }
 
@@ -627,6 +613,45 @@ void StatisticsBackendData::stop_alert_watcher()
     }
 }
 
+void StatisticsBackendData::find_or_create_spy_topic_and_type_nts(
+        Monitor& monitor,
+        const std::string& topic_name,
+        const fastdds::dds::TypeSupport& type)
+{
+    // Find if the topic has been already created and if the associated type is correct
+    fastdds::dds::TopicDescription* topic_desc = monitor.spy_participant->lookup_topicdescription(topic_name);
+    if (nullptr != topic_desc)
+    {
+        if (topic_desc->get_type_name() != type->get_name())
+        {
+            throw Error(topic_name + " is not using expected type " + type->get_name() +
+                          " and is using instead type " + topic_desc->get_type_name());
+        }
+
+        try
+        {
+            monitor.spy_topics[topic_name] = dynamic_cast<fastdds::dds::Topic*>(topic_desc);
+        }
+        catch (const std::bad_cast& e)
+        {
+            throw Error(topic_name + " is already used but is not a simple Topic: " + e.what());
+        }
+
+    }
+    else
+    {
+        if (fastdds::dds::RETCODE_PRECONDITION_NOT_MET == monitor.spy_participant->register_type(type,
+                type->get_name()))
+        {
+            // Name already in use
+            throw Error(std::string("Type name ") + type->get_name() + " is already in use");
+        }
+        fastdds::dds::TopicQos topic_qos;
+        monitor.spy_topics[topic_name] =
+                monitor.spy_participant->create_topic(topic_name, type->get_name(), topic_qos);
+    }
+}
+
 void StatisticsBackendData::start_topic_spy(
         EntityId monitor_id,
         const std::string& topic_name,
@@ -663,18 +688,9 @@ void StatisticsBackendData::start_topic_spy(
         std::string type_name = topic_type->get_name().to_string();
         fastdds::dds::TypeSupport type_support =
                 fastdds::dds::TypeSupport(new fastdds::dds::DynamicPubSubType(topic_type));
-        if (fastdds::dds::RETCODE_OK != type_support.register_type(monitor->spy_participant, type_name))
-        {
-            throw Error("Error registering type for topic '" + topic_name + "'");
-        }
 
-        fastdds::dds::TopicQos topic_qos;
-        topic = monitor->spy_participant->create_topic(topic_name, type_name, topic_qos);
-        if (!topic)
-        {
-            throw Error("Error creating topic '" + topic_name + "'");
-        }
-        monitor->spy_topics[topic_name] = topic;
+        find_or_create_spy_topic_and_type_nts(*monitor, topic_name, type_support);
+        topic = monitor->spy_topics.at(topic_name);
     }
     else
     {
@@ -695,6 +711,7 @@ void StatisticsBackendData::start_topic_spy(
     {
         throw Error("Error creating user data reader in topic '" + topic_name + "'");
     }
+
     monitor->spy_readers[topic_name] = reader;
 }
 
@@ -724,8 +741,11 @@ void StatisticsBackendData::stop_topic_spy(
         return;
     }
 
-    monitor->spy_subscriber->delete_datareader(monitor->spy_readers[topic_name]);
+    // Remove only this topic's datareader (not all readers as other spy topics may be active)
+    monitor->spy_subscriber->delete_datareader(monitor->spy_readers.at(topic_name));
+    monitor->spy_participant->delete_topic(monitor->spy_topics.at(topic_name));
     monitor->spy_readers.erase(topic_name);
+    monitor->spy_topics.erase(topic_name);
     delete monitor->spy_listeners[topic_name];
     monitor->spy_listeners.erase(topic_name);
 }

--- a/src/cpp/StatisticsBackendData.hpp
+++ b/src/cpp/StatisticsBackendData.hpp
@@ -45,7 +45,7 @@ namespace database {
 
 struct ExtendedMonitorServiceStatusData;
 class DatabaseEntityQueue;
-template <typename T>
+template<typename T>
 class DatabaseDataQueue;
 
 } // namespace database
@@ -319,6 +319,7 @@ public:
      * @brief Method executed by the alert watcher thread
      */
     void alert_watcher();
+
     /**
      * @brief Starts a topic spy on a given topic.
      *
@@ -404,6 +405,19 @@ protected:
     void prepare_entity_discovery_status(
             DiscoveryStatus discovery_status,
             DomainListener::Status& status);
+
+    /**
+     * @brief Finds or creates a topic with the specified name and type in the monitor_spy
+     * participant.
+     * @param monitor Reference to the monitor to which the topic belongs
+     * @param topic_name The name of the topic to find or create
+     * @param type The type of the topic to find or create
+     * @throws BadParameter if no monitor with the specified ID exists
+     */
+    void find_or_create_spy_topic_and_type_nts(
+            Monitor& monitor,
+            const std::string& topic_name,
+            const fastdds::dds::TypeSupport& type);
 
     /**
      * @brief Reference to the instance of the Singleton.

--- a/src/cpp/subscriber/StatisticsReaderListener.hpp
+++ b/src/cpp/subscriber/StatisticsReaderListener.hpp
@@ -34,7 +34,7 @@ namespace statistics_backend {
 
 namespace database {
 
-template <typename T>
+template<typename T>
 class DatabaseDataQueue;
 class Database;
 class DatabaseEntityQueue;

--- a/test/mock/dds/DomainParticipant/fastdds/dds/domain/DomainParticipant.hpp
+++ b/test/mock/dds/DomainParticipant/fastdds/dds/domain/DomainParticipant.hpp
@@ -118,11 +118,25 @@ public:
             const TopicQos& qos
         ));
 
+    MOCK_METHOD2(
+        find_topic,
+        Topic *
+        (
+            const std::string& topic_name,
+            const fastdds::dds::Duration_t& timeout
+        ));
+
     MOCK_METHOD1(
         delete_topic,
         void
         (
             Topic * topic
+        ));
+
+    MOCK_METHOD0(
+        delete_contained_entities,
+        void
+        (
         ));
 
     MOCK_METHOD3(

--- a/test/mock/dds/Subscriber/fastdds/dds/subscriber/Subscriber.hpp
+++ b/test/mock/dds/Subscriber/fastdds/dds/subscriber/Subscriber.hpp
@@ -83,6 +83,10 @@ public:
     MOCK_CONST_METHOD0(
         get_participant,
         DomainParticipant * ());
+
+    MOCK_METHOD0(
+        delete_contained_entities,
+        ReturnCode_t ());
 };
 
 


### PR DESCRIPTION
Launching the Spy mode with the statistics enabled in a XML failed because there was a type registered both in dynamic and static modes.

2 solutions have been implemented:

Statistics writers have been disabled in both the monitor and the spy participant.
When starting a new spy datareader, now we check for topic presence before creating the topic directly