### PR TITLE
[24157] Fix Spy DataReader created with incompatible QoS 

### DIFF
--- a/src/cpp/StatisticsBackendData.cpp
+++ b/src/cpp/StatisticsBackendData.cpp
@@ -703,9 +703,12 @@ void StatisticsBackendData::start_topic_spy(
         &monitor->user_data_context);
     monitor->spy_listeners[topic_name] = listener;
 
+    // NOTE: Spy datareader uses the QoS of the first discovered writer in that topic
+    // This could lead to issues when there are multiple writers with different QoS
+    fastdds::dds::DataReaderQos reader_qos = monitor->user_data_context.get_spy_reader_qos(topic_name);
     fastdds::dds::DataReader* reader = monitor->spy_subscriber->create_datareader(
         topic,
-        fastdds::dds::DATAREADER_QOS_DEFAULT,
+        reader_qos,
         listener);
     if (!reader)
     {

--- a/src/cpp/subscriber/StatisticsParticipantListener.cpp
+++ b/src/cpp/subscriber/StatisticsParticipantListener.cpp
@@ -222,6 +222,9 @@ void StatisticsParticipantListener::update_user_data_context(
 
         // Add the topic to the discovered topics if not already present
         ctx_->register_user_data_topic(info.topic_name.to_string(), remote_type);
+
+        // Store compatible reader QoS for this topic
+        ctx_->register_qos_for_spy_reader(info);
     }
 }
 

--- a/src/cpp/subscriber/UserDataContext.cpp
+++ b/src/cpp/subscriber/UserDataContext.cpp
@@ -105,6 +105,61 @@ fastdds::dds::DynamicType::_ref_type UserDataContext::get_type_from_topic_name_n
     return nullptr;
 }
 
+void UserDataContext::register_qos_for_spy_reader(
+        const fastdds::dds::PublicationBuiltinTopicData& info)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    register_qos_for_spy_reader_nts(info);
+}
+
+fastdds::dds::DataReaderQos UserDataContext::get_spy_reader_qos(
+        const std::string& topic_name)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = spy_reader_qos_per_topic_.find(topic_name);
+    if (it != spy_reader_qos_per_topic_.end())
+    {
+        return it->second;
+    }
+
+    // If not found, default to DATAREADER_QOS_DEFAULT.
+    return fastdds::dds::DATAREADER_QOS_DEFAULT;
+}
+
+void UserDataContext::register_qos_for_spy_reader_nts(
+        const fastdds::dds::PublicationBuiltinTopicData& info)
+{
+    std::string topic_name = info.topic_name.to_string();
+
+    if (topic_name.empty())
+    {
+        return;
+    }
+
+    // Only store QoS for the first discovered writer on each topic
+    if (spy_reader_qos_per_topic_.count(topic_name) > 0)
+    {
+        return;
+    }
+
+    // Copy only QoS that may affect matching
+    fastdds::dds::DataReaderQos reader_qos;
+    reader_qos.reliability(info.reliability);
+    reader_qos.durability(info.durability);
+    reader_qos.deadline(info.deadline);
+    reader_qos.latency_budget(info.latency_budget);
+    reader_qos.liveliness(info.liveliness);
+    reader_qos.ownership(info.ownership);
+    reader_qos.destination_order(info.destination_order);
+    if (info.history.has_value())
+    {
+        reader_qos.history(info.history.value());
+    }
+
+    spy_reader_qos_per_topic_[topic_name] = reader_qos;
+}
+
 } // namespace subscriber
 } // namespace statistics_backend
 } // namespace eprosima

--- a/src/cpp/subscriber/UserDataContext.hpp
+++ b/src/cpp/subscriber/UserDataContext.hpp
@@ -24,6 +24,8 @@
 #include <mutex>
 #include <string>
 
+#include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
+#include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/xtypes/dynamic_types/DynamicType.hpp>
 
 namespace eprosima {
@@ -48,6 +50,7 @@ public:
     void register_user_data_topic(
             const std::string& topic_name,
             fastdds::dds::DynamicType::_ref_type type);
+
     /**
      * Get the dynamic type associated with a topic name.
      * @param topic_name Topic name.
@@ -55,6 +58,23 @@ public:
      */
     fastdds::dds::DynamicType::_ref_type get_type_from_topic_name(
             const std::string& topic_name);
+
+    /**
+     * Get a DataReaderQos compatible with the first discovered writer for the given topic.
+     * @param topic_name Topic name.
+     * @return DataReaderQos derived from the writer's QoS or DATAREADER_QOS_DEFAULT if no
+     * writer has been discovered for that topic.
+     */
+    fastdds::dds::DataReaderQos get_spy_reader_qos(
+            const std::string& topic_name);
+
+    /**
+     * Store a DataReaderQos compatible with the given writer's QoS for the topic.
+     * Only stores the QoS for the first discovered writer on the topic.
+     * @param info Publication builtin topic data from the discovered writer.
+     */
+    void register_qos_for_spy_reader(
+            const fastdds::dds::PublicationBuiltinTopicData& info);
 
 protected:
 
@@ -75,12 +95,22 @@ protected:
     fastdds::dds::DynamicType::_ref_type get_type_from_topic_name_nts(
             const std::string& topic_name);
 
+    /**
+     * Store a DataReaderQos compatible with the given writer's QoS for the topic.
+     * Only stores the QoS for the first discovered writer on the topic. Non thread-safe version.
+     * @param info Publication builtin topic data from the discovered writer.
+     */
+    void register_qos_for_spy_reader_nts(
+            const fastdds::dds::PublicationBuiltinTopicData& info);
+
     // Mutex to protect access to the maps
     std::mutex mutex_;
     // Map of type name to dynamic type
     std::map<std::string, fastdds::dds::DynamicType::_ref_type> discovered_user_data_types_;
     // Map of topic name to type name
     std::map<std::string, std::string> discovered_topics_;
+    // Map of topic name to DataReaderQos compatible with the first discovered writer on that topic
+    std::map<std::string, fastdds::dds::DataReaderQos> spy_reader_qos_per_topic_;
 };
 
 } // namespace subscriber


### PR DESCRIPTION
Datareaders used to spy topics were created with default QoS, now they use a set of QoS compatible with the first discovered writer, replicating the approach of Fast DDS Spy.

This PR depends on https://github.com/eProsima/Fast-DDS-statistics-backend/pull/307 and must be merged after it