### PR TITLE
[#24342] Hotfix/undiscovery endpoints

### DIFF
--- a/src/cpp/subscriber/StatisticsReaderListener.cpp
+++ b/src/cpp/subscriber/StatisticsReaderListener.cpp
@@ -222,18 +222,20 @@ void StatisticsReaderListener::on_data_available(
         {
             if (info.instance_state == ALIVE_INSTANCE_STATE)
             {
-                database::Qos qos;
-                auto participant = eprosima::fastdds::statistics::dds::DomainParticipant::narrow(
-                    reader->get_subscriber()->get_participant());
-
-                if (!deserialize_proxy_data(
-                            const_cast<eprosima::fastdds::statistics::dds::DomainParticipant*>(participant),
-                            inner_data,
-                            *monitor_service_status_data))
+                // Empty PROXY payloads in alive samples are entity disposals.
+                if (!inner_data.value().entity_proxy().empty())
                 {
-                    EPROSIMA_LOG_ERROR(STATISTICSREADERLISTENER,
-                            "Failed to get optional QoS from proxy sample.");
-                    return;
+                    auto participant = eprosima::fastdds::statistics::dds::DomainParticipant::narrow(
+                        reader->get_subscriber()->get_participant());
+
+                    if (!deserialize_proxy_data(
+                                const_cast<eprosima::fastdds::statistics::dds::DomainParticipant*>(participant),
+                                inner_data,
+                                *monitor_service_status_data))
+                    {
+                        EPROSIMA_LOG_ERROR(STATISTICSREADERLISTENER,
+                                "Failed to get optional QoS from proxy sample.");
+                    }
                 }
             }
             else if (info.instance_state == NOT_ALIVE_DISPOSED_INSTANCE_STATE ||


### PR DESCRIPTION
## Description
This PR fixes endpoint removal.

When a `publisher/subscriber` endpoint was deleted, the backend could receive an ALIVE PROXY sample with an empty payload and still try to deserialize optional QoS, producing errors.

`
2026-04-09 09:41:20.737 [STATISTICSREADERLISTENER Error] Failed to get publication data for proxy sample. -> Function deserialize_proxy_data
`

### Fast-DDS-Monitor-Pro [[#24342] Handle endpoint undiscovery messages](https://github.com/eProsima/Fast-DDS-monitor/pull/294)
Also, discovery logs did not explicitly show undiscovery events.

