### PR TITLE
[#24367] Fix Windows deadlock in check_alerts_timeouts()

### DIFF
--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -1239,31 +1239,32 @@ void Database::trigger_alerts_of_kind_nts(
 
 void Database::check_alerts_timeouts()
 {
-    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
-    for (auto& domain_it : domains_)
+    std::vector<std::pair<EntityId, AlertInfo>> timed_out;
     {
-        EntityId domainId = domain_it.first;
-        auto alerts_in_domain = alerts_.find(domainId);
-        if (alerts_in_domain != alerts_.end())
+        std::lock_guard<std::shared_timed_mutex> lock(mutex_);
+        for (auto& domain_it : domains_)
         {
-            for (auto& alert_it : alerts_in_domain->second)
+            EntityId domainId = domain_it.first;
+            auto alerts_in_domain = alerts_.find(domainId);
+            if (alerts_in_domain != alerts_.end())
             {
-                std::shared_ptr<AlertInfo> alert_info = alert_it.second;
-                if (alert_info->check_timeout())
+                for (auto& alert_it : alerts_in_domain->second)
                 {
-                    // Notify the alert has been triggered
-                    // TODO (eProsima) Workaround to avoid deadlock if callback implementation requires taking the database
-                    // mutex (e.g. by calling get_info). A refactor for not calling on_domain_view_graph_update from within
-                    // this function would be required.
-                    execute_without_lock([&]()
-                            {
-                                details::StatisticsBackendData::get_instance()->on_alert_timeout(
-                                    domainId,
-                                    *alert_info);
-                            });
+                    std::shared_ptr<AlertInfo> alert_info = alert_it.second;
+                    if (alert_info->check_timeout())
+                    {
+                        timed_out.emplace_back(domainId, *alert_info);
+                    }
                 }
             }
         }
+    }
+
+    for (auto& entry : timed_out)
+    {
+        details::StatisticsBackendData::get_instance()->on_alert_timeout(
+            entry.first,
+            entry.second);
     }
 }
 

--- a/src/cpp/database/database.cpp
+++ b/src/cpp/database/database.cpp
@@ -554,7 +554,7 @@ EntityId Database::insert_new_endpoint(
     return entity_id;
 }
 
-template <typename T>
+template<typename T>
 std::shared_ptr<DDSEndpoint> Database::create_endpoint_nts(
         const std::string& endpoint_guid,
         const std::string& name,
@@ -3532,7 +3532,7 @@ std::vector<const StatisticsSample*> Database::select(
     return samples;
 }
 
-template <>
+template<>
 void Database::get_status_data(
         const EntityId& entity_id,
         ProxySample& status_data)
@@ -3578,7 +3578,7 @@ void Database::get_status_data(
     }
 }
 
-template <>
+template<>
 void Database::get_status_data(
         const EntityId& entity_id,
         ConnectionListSample& status_data)
@@ -3624,7 +3624,7 @@ void Database::get_status_data(
     }
 }
 
-template <>
+template<>
 void Database::get_status_data(
         const EntityId& entity_id,
         IncompatibleQosSample& status_data)
@@ -3660,7 +3660,7 @@ void Database::get_status_data(
     }
 }
 
-template <>
+template<>
 void Database::get_status_data(
         const EntityId& entity_id,
         InconsistentTopicSample& status_data)
@@ -3696,7 +3696,7 @@ void Database::get_status_data(
     }
 }
 
-template <>
+template<>
 void Database::get_status_data(
         const EntityId& entity_id,
         LivelinessLostSample& status_data)
@@ -3719,7 +3719,7 @@ void Database::get_status_data(
     }
 }
 
-template <>
+template<>
 void Database::get_status_data(
         const EntityId& entity_id,
         LivelinessChangedSample& status_data)
@@ -3742,7 +3742,7 @@ void Database::get_status_data(
     }
 }
 
-template <>
+template<>
 void Database::get_status_data(
         const EntityId& entity_id,
         DeadlineMissedSample& status_data)
@@ -3778,7 +3778,7 @@ void Database::get_status_data(
     }
 }
 
-template <>
+template<>
 void Database::get_status_data(
         const EntityId& entity_id,
         SampleLostSample& status_data)
@@ -3801,7 +3801,7 @@ void Database::get_status_data(
     }
 }
 
-template <>
+template<>
 void Database::get_status_data(
         const EntityId& entity_id,
         ExtendedIncompatibleQosSample& status_data)
@@ -4651,7 +4651,7 @@ Graph Database::get_entity_subgraph_nts(
     return entity_graph_updated;
 }
 
-template <>
+template<>
 bool Database::update_entity_status_nts(
         std::shared_ptr<DataReader>& entity)
 {
@@ -4681,7 +4681,7 @@ bool Database::update_entity_status_nts(
     return entity_status_logic_nts(entity_error, entity_warning, entity->status);
 }
 
-template <>
+template<>
 bool Database::update_entity_status_nts(
         std::shared_ptr<DataWriter>& entity)
 {
@@ -5128,7 +5128,7 @@ void map_to_vector(
 }
 
 // Auxiliar function to convert a map of maps to a vector
-template <typename T>
+template<typename T>
 void map_of_maps_to_vector(
         const std::map<EntityId, std::map<EntityId, std::shared_ptr<T>>>& map,
         std::vector<std::shared_ptr<const Entity>>& vec)


### PR DESCRIPTION
## Description

`check_alerts_timeouts()` held a `std::shared_lock` and called  `execute_without_lock()`, which always calls `mutex_.unlock()` → `ReleaseSRWLockExclusive()` on Windows. Releasing an exclusive lock when only a shared lock is held corrupts the SRWLOCK and deadlocks the process on the next acquisition — causing the application to freeze on Windows every time an alert timeout fired.

Replaced the `execute_without_lock()` workaround with a **collect then callback** pattern. **Timed-out** alerts are copied into a local vector under an **exclusive** lock . When the lock is released the stored domains in the vector, with the `alertInfo` are executed.

## Root cause

`std::shared_timed_mutex` on Windows is implemented over an SRWLOCK:

| `std::` operation | Win32 call |
|---|---|
| `lock()` | `AcquireSRWLockExclusive` |
| `unlock()` | `ReleaseSRWLockExclusive` |
| `lock_shared()` | `AcquireSRWLockShared` |
| `unlock_shared()` | `ReleaseSRWLockShared` |

`execute_without_lock()` calls `mutex_.unlock()` regardless of whether the caller holds a shared or exclusive lock. When called from a shared-lock context this invokes `ReleaseSRWLockExclusive` without a matching acquire, silently corrupting the lock's internal state.

## Test

1. Start a monitor
2. Create a `NO_DATA_ALERT`, 
3. Verify the application does **not** freeze on Windows when the timeout fires.
4. Test the same points but without this PR. Expected behaviour -> the monitor freezes when the timeout fires.